### PR TITLE
Enable host selection

### DIFF
--- a/app/app.html
+++ b/app/app.html
@@ -11,7 +11,7 @@
     <script src="vendor/require.js"></script>
     <script type="text/javascript">
         // Uncomment the script below to clear the storage
-        localStorage.clear();
+        //localStorage.clear();
     </script>
     <script type="text/javascript">
         requirejs(['scripts/start'], function (app) {});

--- a/app/app.html
+++ b/app/app.html
@@ -11,7 +11,7 @@
     <script src="vendor/require.js"></script>
     <script type="text/javascript">
         // Uncomment the script below to clear the storage
-        // localStorage.clear();
+        localStorage.clear();
     </script>
     <script type="text/javascript">
         requirejs(['scripts/start'], function (app) {});
@@ -31,9 +31,19 @@
                 </header>
                 <div class="fields">
                     <div class="input-text active">
-                        <input type="text" name="host" placeholder="https://demo.rocket.chat" dir="auto" required>
+                        <input type="text" name="host" placeholder="https://demo.rocket.chat" dir="auto">
                     </div>
                 </div>
+
+                <div id="invalidUrl" style="display:none;" class="alert alert-danger">
+                    Not a valid instance url
+                </div>
+
+                <div id="defaultInstance" style="display: none;" class="alert alert-danger">
+                    <span>No url was provided.</span>
+                    <button class="button primary" id="connectDefaultInstance">Connect to Demo?</button>
+                </div>
+
                 <div class="submit">
                     <input type="submit" data-loading-text="Connecting..." class="button primary login" value="Connect"></input>
                 </div>

--- a/app/main.js
+++ b/app/main.js
@@ -11,8 +11,8 @@ var tray = require('./tray');
 
 // global variable
 var APP_NAME = 'Rocket.Chat';
-var INDEX = 'https://demo.rocket.chat';
-// var INDEX = 'file://' + path.join( __dirname, 'app.html' );
+//var INDEX = 'https://demo.rocket.chat';
+var INDEX = 'file://' + path.join( __dirname, 'app.html' );
 
 let flagQuitApp = false;
 let mainWindow;

--- a/app/main.js
+++ b/app/main.js
@@ -136,6 +136,7 @@ function appReady() {
             appWindow.loadUrl(url);
         }
     });
+
 }
 
 function onQuitApp() {

--- a/app/scripts/start.js
+++ b/app/scripts/start.js
@@ -1,6 +1,7 @@
 (function() {
     var key = 'rocket.chat.host',
-        header = 'X-Rocket-Chat-Version'.toLowerCase();
+        rocketHeader = 'X-Rocket-Chat-Version'.toLowerCase(),
+        defaultInstance = 'https://demo.rocket.chat/';
 
     //init loader
     var loader = document.querySelector('.loader');
@@ -43,6 +44,7 @@
 
     var form = document.querySelector('form');
     form.addEventListener('submit', function(ev) {
+        console.log('trying to connect')
         ev.preventDefault();
         ev.stopPropagation();
         var input = form.querySelector('[name="host"]');
@@ -50,19 +52,30 @@
         var val = button.value;
         button.value = button.getAttribute('data-loading-text');
         var url = input.value;
-        console.debug('checking', url);
-        input.classList.remove('wrong');
-        urlExists(url, 5000).then(function() {
-            console.debug('url found!');
-            localStorage.setItem(key, url);
-            document.body.classList.add('connecting');
-            // redirect to host
-            redirect(url);
-        }, function(status) {
+
+        if (url.length === 0) {
             button.value = val;
-            console.debug('url wrong');
-            input.classList.add('wrong');
-        });
+            
+            form.querySelector('#defaultInstance').style.display = 'block';
+            form.querySelector('#connectDefaultInstance').onclick = connectDefaultInstance;
+        } else {
+
+            console.debug('checking', url);
+            input.classList.remove('wrong');
+            urlExists(url, 5000).then(function() {
+                console.debug('url found!');
+                localStorage.setItem(key, url);
+                document.body.classList.add('connecting');
+                // redirect to host
+                //redirect(url);
+            }, function(status) {
+                button.value = val;
+                form.querySelector('#invalidUrl').style.display = 'block';
+                console.debug('url wrong');
+                input.classList.add('wrong');
+            });
+        }
+
         return false;
     });
 
@@ -76,7 +89,7 @@
                     if (!resolved) {
                         resolved = true;
                         var headers = this.getAllResponseHeaders().toLowerCase();
-                        if (headers.indexOf(header) !== -1) {
+                        if (headers.indexOf(rocketHeader) !== -1) {
                             resolve();
                         } else {
                             reject(this.status);
@@ -97,7 +110,17 @@
     }
 
     function redirect(url) {
-        window.open(url, '_blank');
+        window.location = url;
+    }
+
+    function connectDefaultInstance() {
+        document.body.classList.add('connecting');
+
+        form.querySelector('#defaultInstance').style.display = 'none';
+        localStorage.setItem(key, defaultInstance);
+
+        redirect(defaultInstance);
+
     }
 
 })();

--- a/app/scripts/start.js
+++ b/app/scripts/start.js
@@ -55,7 +55,6 @@
 
         if (url.length === 0) {
             button.value = val;
-            
             form.querySelector('#defaultInstance').style.display = 'block';
             form.querySelector('#connectDefaultInstance').onclick = connectDefaultInstance;
         } else {


### PR DESCRIPTION
This enables the ability to select the host.

Shows error if the host is not a valid rocket.chat instance.

If they don't enter anything it'll prompt them to connect to the demo instance.  Like so:
![Screenshot](http://i.imgur.com/6rY9ofG.png)

I'd like to enable a menu option to take them back to the screen to enter a new url.