### PR TITLE
Only loop through hosts if they exists, fixes #30

### DIFF
--- a/app/scripts/start.js
+++ b/app/scripts/start.js
@@ -196,10 +196,13 @@
             localStorage.setItem(key, JSON.stringify(hosts));
         }
 
-        for (var i = 0; i < hosts.length; i++) {
-            list.appendChild(createItem(hosts[i], (i + 1)));
+        if(hosts) {
+            for (var i = 0; i < hosts.length; i++) {
+                list.appendChild(createItem(hosts[i], (i + 1)));
+            }
         }
     }
+
     renderServers();
     loadPreviousHost();
 


### PR DESCRIPTION
If you first load up the application without ever running it before an error would occur in the console about getting the length of a null variable. This checks to verify that the hosts array isn't null before looping through them. Fixes #30 