### PR TITLE
add missing vinyl-map requirement

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -50,7 +50,7 @@ function initWindow() {
     var win = new BrowserWindow({
         'title': APP_NAME,
         // Standard icon looks somehow very thin in the taskbar
-        'icon': path.resolve(path.join(__dirname, 'icons', 'tray', 'icon-tray.png')),
+        'icon': path.resolve(path.join(__dirname, 'icons', 'icon.png')),
         'node-integration': false,
         'accept-first-mouse': true,
         'show': false,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "gulp-util": "^3.0.6",
     "q": "^1.4.1",
     "tree-kill": "^0.1.1",
-    "yargs": "^3.15.0"
+    "yargs": "^3.15.0",
+    "vinyl-map": "^1.0.1"
   },
   "optionalDependencies": {
     "appdmg": "^0.3.2",


### PR DESCRIPTION
Got an error and was unable to start on Ubuntu 14.04.3 LTS.

* Installed vinyl-map and it worked.
* Removed vinyl-map and started getting these errors in terminal although it launched.
* Went away as expected when module was reinstalled.

```
Error: Cannot find module 'vinyl-map'
  at Function.Module._resolveFilename (module.js:338:15)
  at Function.Module._load (module.js:280:25)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Object.<anonymous> (/home/pauls/Rocket.Chat.Electron/tasks/build.js:9:11)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Object.<anonymous> (/home/pauls/Rocket.Chat.Electron/gulpfile.js:3:1)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Liftoff.handleArguments (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/bin/gulp.js:116:3)
  at Liftoff.<anonymous> (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:192:16)
  at module.exports (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/node_modules/flagged-respawn/index.js:17:3)
  at Liftoff.<anonymous> (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:185:9)
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:159:9
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/v8flags/index.js:99:14
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/v8flags/index.js:38:7
  at process._tickCallback (node.js:419:13)
  at Function.Module.runMain (module.js:499:11)
  at startup (node.js:119:16)
  at node.js:906:3

[DEPRECATION NOTICE] Esperanto is no longer under active development. To convert an ES6 module to another format, consider using Babel (https://babeljs.io)

Error: Cannot find module 'vinyl-map'
  at Function.Module._resolveFilename (module.js:338:15)
  at Function.Module._load (module.js:280:25)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Object.<anonymous> (/home/pauls/Rocket.Chat.Electron/tasks/build.js:9:11)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Object.<anonymous> (/home/pauls/Rocket.Chat.Electron/gulpfile.js:3:1)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Liftoff.handleArguments (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/bin/gulp.js:116:3)
  at Liftoff.<anonymous> (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:192:16)
  at module.exports (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/node_modules/flagged-respawn/index.js:17:3)
  at Liftoff.<anonymous> (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:185:9)
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:159:9
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/v8flags/index.js:99:14
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/v8flags/index.js:38:7
  at process._tickCallback (node.js:419:13)
  at Function.Module.runMain (module.js:499:11)
  at startup (node.js:119:16)
  at node.js:906:3

[DEPRECATION NOTICE] Esperanto is no longer under active development. To convert an ES6 module to another format, consider using Babel (https://babeljs.io)

Error: Cannot find module 'vinyl-map'
  at Function.Module._resolveFilename (module.js:338:15)
  at Function.Module._load (module.js:280:25)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Object.<anonymous> (/home/pauls/Rocket.Chat.Electron/tasks/build.js:9:11)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Object.<anonymous> (/home/pauls/Rocket.Chat.Electron/gulpfile.js:3:1)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Liftoff.handleArguments (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/bin/gulp.js:116:3)
  at Liftoff.<anonymous> (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:192:16)
  at module.exports (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/node_modules/flagged-respawn/index.js:17:3)
  at Liftoff.<anonymous> (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:185:9)
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:159:9
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/v8flags/index.js:99:14
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/v8flags/index.js:38:7
  at process._tickCallback (node.js:419:13)
  at Function.Module.runMain (module.js:499:11)
  at startup (node.js:119:16)
  at node.js:906:3

[DEPRECATION NOTICE] Esperanto is no longer under active development. To convert an ES6 module to another format, consider using Babel (https://babeljs.io)

Error: Cannot find module 'vinyl-map'
  at Function.Module._resolveFilename (module.js:338:15)
  at Function.Module._load (module.js:280:25)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Object.<anonymous> (/home/pauls/Rocket.Chat.Electron/tasks/build.js:9:11)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Object.<anonymous> (/home/pauls/Rocket.Chat.Electron/gulpfile.js:3:1)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Liftoff.handleArguments (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/bin/gulp.js:116:3)
  at Liftoff.<anonymous> (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:192:16)
  at module.exports (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/node_modules/flagged-respawn/index.js:17:3)
  at Liftoff.<anonymous> (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:185:9)
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:159:9
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/v8flags/index.js:99:14
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/v8flags/index.js:38:7
  at process._tickCallback (node.js:419:13)
  at Function.Module.runMain (module.js:499:11)
  at startup (node.js:119:16)
  at node.js:906:3

[DEPRECATION NOTICE] Esperanto is no longer under active development. To convert an ES6 module to another format, consider using Babel (https://babeljs.io)

Error: Cannot find module 'vinyl-map'
  at Function.Module._resolveFilename (module.js:338:15)
  at Function.Module._load (module.js:280:25)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Object.<anonymous> (/home/pauls/Rocket.Chat.Electron/tasks/build.js:9:11)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Object.<anonymous> (/home/pauls/Rocket.Chat.Electron/gulpfile.js:3:1)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Liftoff.handleArguments (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/bin/gulp.js:116:3)
  at Liftoff.<anonymous> (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:192:16)
  at module.exports (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/node_modules/flagged-respawn/index.js:17:3)
  at Liftoff.<anonymous> (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:185:9)
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:159:9
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/v8flags/index.js:99:14
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/v8flags/index.js:38:7
  at process._tickCallback (node.js:419:13)
  at Function.Module.runMain (module.js:499:11)
  at startup (node.js:119:16)
  at node.js:906:3

[DEPRECATION NOTICE] Esperanto is no longer under active development. To convert an ES6 module to another format, consider using Babel (https://babeljs.io)

Error: Cannot find module 'vinyl-map'
  at Function.Module._resolveFilename (module.js:338:15)
  at Function.Module._load (module.js:280:25)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Object.<anonymous> (/home/pauls/Rocket.Chat.Electron/tasks/build.js:9:11)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Object.<anonymous> (/home/pauls/Rocket.Chat.Electron/gulpfile.js:3:1)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Liftoff.handleArguments (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/bin/gulp.js:116:3)
  at Liftoff.<anonymous> (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:192:16)
  at module.exports (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/node_modules/flagged-respawn/index.js:17:3)
  at Liftoff.<anonymous> (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:185:9)
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:159:9
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/v8flags/index.js:99:14
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/v8flags/index.js:38:7
  at process._tickCallback (node.js:419:13)
  at Function.Module.runMain (module.js:499:11)
  at startup (node.js:119:16)
  at node.js:906:3

[DEPRECATION NOTICE] Esperanto is no longer under active development. To convert an ES6 module to another format, consider using Babel (https://babeljs.io)

Error: Cannot find module 'vinyl-map'
  at Function.Module._resolveFilename (module.js:338:15)
  at Function.Module._load (module.js:280:25)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Object.<anonymous> (/home/pauls/Rocket.Chat.Electron/tasks/build.js:9:11)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Object.<anonymous> (/home/pauls/Rocket.Chat.Electron/gulpfile.js:3:1)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Liftoff.handleArguments (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/bin/gulp.js:116:3)
  at Liftoff.<anonymous> (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:192:16)
  at module.exports (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/node_modules/flagged-respawn/index.js:17:3)
  at Liftoff.<anonymous> (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:185:9)
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:159:9
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/v8flags/index.js:99:14
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/v8flags/index.js:38:7
  at process._tickCallback (node.js:419:13)
  at Function.Module.runMain (module.js:499:11)
  at startup (node.js:119:16)
  at node.js:906:3

[DEPRECATION NOTICE] Esperanto is no longer under active development. To convert an ES6 module to another format, consider using Babel (https://babeljs.io)

Error: Cannot find module 'vinyl-map'
  at Function.Module._resolveFilename (module.js:338:15)
  at Function.Module._load (module.js:280:25)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Object.<anonymous> (/home/pauls/Rocket.Chat.Electron/tasks/build.js:9:11)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Object.<anonymous> (/home/pauls/Rocket.Chat.Electron/gulpfile.js:3:1)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Liftoff.handleArguments (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/bin/gulp.js:116:3)
  at Liftoff.<anonymous> (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:192:16)
  at module.exports (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/node_modules/flagged-respawn/index.js:17:3)
  at Liftoff.<anonymous> (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:185:9)
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:159:9
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/v8flags/index.js:99:14
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/v8flags/index.js:38:7
  at process._tickCallback (node.js:419:13)
  at Function.Module.runMain (module.js:499:11)
  at startup (node.js:119:16)
  at node.js:906:3

[DEPRECATION NOTICE] Esperanto is no longer under active development. To convert an ES6 module to another format, consider using Babel (https://babeljs.io)

Error: Cannot find module 'vinyl-map'
  at Function.Module._resolveFilename (module.js:338:15)
  at Function.Module._load (module.js:280:25)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Object.<anonymous> (/home/pauls/Rocket.Chat.Electron/tasks/build.js:9:11)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Object.<anonymous> (/home/pauls/Rocket.Chat.Electron/gulpfile.js:3:1)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Liftoff.handleArguments (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/bin/gulp.js:116:3)
  at Liftoff.<anonymous> (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:192:16)
  at module.exports (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/node_modules/flagged-respawn/index.js:17:3)
  at Liftoff.<anonymous> (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:185:9)
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:159:9
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/v8flags/index.js:99:14
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/v8flags/index.js:38:7
  at process._tickCallback (node.js:419:13)
  at Function.Module.runMain (module.js:499:11)
  at startup (node.js:119:16)
  at node.js:906:3

[DEPRECATION NOTICE] Esperanto is no longer under active development. To convert an ES6 module to another format, consider using Babel (https://babeljs.io)

Error: Cannot find module 'vinyl-map'
  at Function.Module._resolveFilename (module.js:338:15)
  at Function.Module._load (module.js:280:25)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Object.<anonymous> (/home/pauls/Rocket.Chat.Electron/tasks/build.js:9:11)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Object.<anonymous> (/home/pauls/Rocket.Chat.Electron/gulpfile.js:3:1)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Liftoff.handleArguments (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/bin/gulp.js:116:3)
  at Liftoff.<anonymous> (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:192:16)
  at module.exports (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/node_modules/flagged-respawn/index.js:17:3)
  at Liftoff.<anonymous> (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:185:9)
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:159:9
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/v8flags/index.js:99:14
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/v8flags/index.js:38:7
  at process._tickCallback (node.js:419:13)
  at Function.Module.runMain (module.js:499:11)
  at startup (node.js:119:16)
  at node.js:906:3

[DEPRECATION NOTICE] Esperanto is no longer under active development. To convert an ES6 module to another format, consider using Babel (https://babeljs.io)

Error: Cannot find module 'vinyl-map'
  at Function.Module._resolveFilename (module.js:338:15)
  at Function.Module._load (module.js:280:25)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Object.<anonymous> (/home/pauls/Rocket.Chat.Electron/tasks/build.js:9:11)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Object.<anonymous> (/home/pauls/Rocket.Chat.Electron/gulpfile.js:3:1)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Liftoff.handleArguments (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/bin/gulp.js:116:3)
  at Liftoff.<anonymous> (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:192:16)
  at module.exports (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/node_modules/flagged-respawn/index.js:17:3)
  at Liftoff.<anonymous> (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:185:9)
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:159:9
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/v8flags/index.js:99:14
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/v8flags/index.js:38:7
  at process._tickCallback (node.js:419:13)
  at Function.Module.runMain (module.js:499:11)
  at startup (node.js:119:16)
  at node.js:906:3

[DEPRECATION NOTICE] Esperanto is no longer under active development. To convert an ES6 module to another format, consider using Babel (https://babeljs.io)

Error: Cannot find module 'vinyl-map'
  at Function.Module._resolveFilename (module.js:338:15)
  at Function.Module._load (module.js:280:25)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Object.<anonymous> (/home/pauls/Rocket.Chat.Electron/tasks/build.js:9:11)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Object.<anonymous> (/home/pauls/Rocket.Chat.Electron/gulpfile.js:3:1)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Liftoff.handleArguments (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/bin/gulp.js:116:3)
  at Liftoff.<anonymous> (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:192:16)
  at module.exports (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/node_modules/flagged-respawn/index.js:17:3)
  at Liftoff.<anonymous> (/home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:185:9)
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/liftoff/index.js:159:9
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/v8flags/index.js:99:14
  at /home/pauls/Rocket.Chat.Electron/node_modules/gulp/node_modules/v8flags/index.js:38:7
  at process._tickCallback (node.js:419:13)
  at Function.Module.runMain (module.js:499:11)
  at startup (node.js:119:16)
  at node.js:906:3
```