### PR TITLE
Make links open in browser window instead of WebView

### DIFF
--- a/app/background.js
+++ b/app/background.js
@@ -46,6 +46,11 @@ app.on('ready', function () {
     mainWindow.on('close', function () {
         mainWindowState.saveState(mainWindow);
     });
+
+    mainWindow.webContents.on('new-window', function(e, url) {
+        e.preventDefault();
+        require('shell').openExternal(url);
+    });
 });
 
 app.on('window-all-closed', function () {


### PR DESCRIPTION
This short change makes the clients primary browser handle opening links. I think this is a saner default, what do you all think?