### PR TITLE
Fix for some issues (installer & client)

### DIFF
--- a/app/scripts/menus.js
+++ b/app/scripts/menus.js
@@ -56,6 +56,7 @@ if (process.platform === 'darwin') {
 					label: 'Quit',
 					accelerator: 'Command+Q',
 					click: function() {
+                        remote.app.forceQuit = true;
 						app.quit();
 					}
 				}
@@ -169,6 +170,7 @@ if (process.platform === 'darwin') {
 					label: 'Quit',
 					accelerator: 'Ctrl+Q',
 					click: function() {
+                        remote.app.forceQuit = true;
 						app.quit();
 					}
 				}

--- a/app/scripts/tray.js
+++ b/app/scripts/tray.js
@@ -44,20 +44,21 @@ function createAppTray(mainWindow) {
     }, {
         label: 'Quit',
         click: function() {
+            remote.app.forceQuit = true;
             doQuit();
         }
     }]);
     _tray.setToolTip('Rocket.Chat');
     _tray.setContextMenu(contextMenu);
 
-    if (process.platform === 'darwin') {
-        _tray.on('double-clicked', function() {
+    if (process.platform === 'darwin' || process.platform == 'win32') {
+        _tray.on('double-click', function() {
             toggleShowMainWindow();
         });
     } else {
         let dblClickDelay = 500,
             dblClickTimeoutFct = null;
-        _tray.on('clicked', function() {
+        _tray.on('click', function() {
             if (!dblClickTimeoutFct) {
                 dblClickTimeoutFct = setTimeout(function() {
                     // Single click, do nothing for now
@@ -97,7 +98,6 @@ function showTrayAlert(showAlert, title) {
             _tray.setImage(_iconTrayAlert);
             if (process.platform === 'darwin') {
                 _tray.setTitle(title);
-            //     _tray.setTitle(title);
             }
         } else {
             _tray.setImage(_iconTray);
@@ -145,9 +145,16 @@ bindOnQuit(function() {
     remote.app.quit();
 });
 
-window.addEventListener('beforeunload', function() {
-    destroy();
-});
+// Closes or hides the client
+window.onbeforeunload = function(e) {
+    if(!remote.app.forceQuit) {
+        showMainWindow(false);
+        return false;
+    }
+    else {
+        destroy();
+    }
+}
 
 export default {
     createAppTray: createAppTray,

--- a/resources/windows/installer.nsi
+++ b/resources/windows/installer.nsi
@@ -89,7 +89,7 @@ Function .onInit
     
     ; Check if the application is currently running, show message if it is
     retryInstallation:
-    FindWindow $0 "Chrome_WidgetWin_1" "Rocket.Chat"
+    FindWindow $0 "Chrome_WidgetWin_1" "${productName}"
         StrCmp $0 0 notRunning
             MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "${productName} is currently running. Please close the application to continue." /SD IDCANCEL IDRETRY retryInstallation
             Abort
@@ -121,7 +121,7 @@ FunctionEnd
 ;    Installation sections
 ;   --------------------------------
 
-Section "Rocket.Chat Client"
+Section "${productName} Client"
 
     ; Make this section a requirement
     SectionIn RO
@@ -233,7 +233,7 @@ Function un.onInit
 
     ; Check if the application is currently running, show message if it is
     retryUninstall:
-    FindWindow $0 "Chrome_WidgetWin_1" "Rocket.Chat"
+    FindWindow $0 "Chrome_WidgetWin_1" "${productName}"
         StrCmp $0 0 notRunning
             MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "${productName} is currently running. Please close the application to continue." /SD IDCANCEL IDRETRY retryUninstall
             Abort


### PR DESCRIPTION
Can you review my changes? :)

Commit (1) comment:
- Added a force quit option to the app, if this is set, the application will quit. Otherwise it'll just hide. (#89)
- Fixed bug in windows, where you had to triple-click the tray icon show the app (#77)

Commit (2) comment:
- Added check, if the application is running, because this lead to
errors
- Added option to add a shortcut to the autostart folder (#57)
- Added option to launch the app after the installation (#37)
- Added option to choose the installation directory (#41)
- Added the shortcuts as options, so you can choose, if you want a
desktop, autostart or start menu shortcut (a part of #96)
- Enabled / Added these pages: components, browse installation folder,
finish page
- Extended the comments, so it's easier to find the correct spots