### PR TITLE
Option to start the client hidden

### DIFF
--- a/app/background.js
+++ b/app/background.js
@@ -25,11 +25,19 @@ app.on('ready', function () {
         x: mainWindowState.x,
         y: mainWindowState.y,
         width: mainWindowState.width,
-        height: mainWindowState.height
+        height: mainWindowState.height,
+        
+        // Opens hidden, if the state was hidden on closing
+        skipTaskbar: mainWindowState.isMinimized,
+        show: !mainWindowState.isMinimized
     });
 
     if (mainWindowState.isMaximized) {
         mainWindow.maximize();
+    }
+    
+    if (mainWindowState.isMinimized) {
+        mainWindow.minimize();
     }
 
     if (env.name === 'test') {

--- a/app/vendor/electron_boilerplate/window_state.js
+++ b/app/vendor/electron_boilerplate/window_state.js
@@ -25,6 +25,7 @@ export default function (name, defaults) {
             state.height = size[1];
         }
         state.isMaximized = win.isMaximized();
+        state.isMinimized = win.isMinimized();
         userDataDir.write(stateStoreFile, state, { atomic: true });
     };
 
@@ -34,6 +35,7 @@ export default function (name, defaults) {
         get width() { return state.width; },
         get height() { return state.height; },
         get isMaximized() { return state.isMaximized; },
+        get isMinimized() { return state.isMinimized; },
         saveState: saveState
     };
 }


### PR DESCRIPTION
If the client was closed in hidden state, it will also start hidden.

Fixes a part of issue  #96