### PR TITLE
create rpm package

### DIFF
--- a/resources/linux/RHEL/app.spec
+++ b/resources/linux/RHEL/app.spec
@@ -1,0 +1,33 @@
+Name:     {{name}}
+Version:  v{{version}}
+Release:  linux
+Summary:  {{description}}
+Group:    Applications/Communications
+Vendor:   Rocket.Chat Community
+Packager: {{author}}
+License:  MIT
+URL:      https://rocket.chat/
+AutoReq:  0
+
+%description
+{{description}}
+
+%install
+mkdir -p %{buildroot}/opt/{{name}}
+cp -r opt/{{name}}/* %{buildroot}/opt/{{name}}
+
+mkdir -p %{buildroot}/usr/bin
+cat > %{buildroot}/usr/bin/{{name}} <<EOF
+#!/bin/bash
+/opt/{{name}}/{{name}}
+EOF
+
+mkdir -p %{buildroot}/usr/share/applications
+cp -r usr/share/applications/{{name}}.desktop \
+    %{buildroot}/usr/share/applications
+
+%files
+%defattr(-,root,root,-)
+/opt/{{name}}/
+%attr(755,root,root) /usr/bin/{{name}}
+/usr/share/applications/{{name}}.desktop

--- a/tasks/release/linux.js
+++ b/tasks/release/linux.js
@@ -104,6 +104,45 @@ var packToDebFile = function () {
     return deferred.promise;
 };
 
+var packToRpmFile = function () {
+    var deferred = Q.defer();
+
+    var rpmFileName = packName + '.rpm';
+    var rpmPath = releasesDir.path(rpmFileName);
+
+    gulpUtil.log('Creating RPM package... (' + rpmFileName + ')');
+
+    // Preparing RPM Spec file
+    var spec = projectDir.read('resources/linux/RHEL/app.spec');
+    spec = utils.replace(spec, {
+        name: manifest.name,
+        description: manifest.description,
+        version: manifest.version,
+        author: manifest.author,
+    });
+    tmpDir.write('SPECS/app.spec', spec);
+
+    // Build the package...
+    childProcess.exec('fakeroot rpmbuild --quiet -D "_topdir `pwd`/tmp" -D "_builddir ' + packDir.path() + '" -bb ' + tmpDir.path('SPECS/app.spec').replace(/\s/g, '\\ '),
+        function (error, stdout, stderr) {
+            if (error || stderr) {
+                console.log('ERROR while building RPM package:');
+                console.log(error);
+                console.log(stderr);
+            } else {
+                // Copy to release directory
+                tmpDir.copy('RPMS/x86_64', releasesDir.path(), {
+                    matching: '*.rpm',
+                    overwrite: true
+                });
+                gulpUtil.log('RPM package ready!', rpmPath);
+            }
+            deferred.resolve();
+        });
+
+    return deferred.promise;
+};
+
 var cleanClutter = function () {
     return tmpDir.removeAsync('.');
 };
@@ -115,6 +154,7 @@ module.exports = function () {
         .then(finalize)
         .then(renameApp)
         .then(packToDebFile)
+        .then(packToRpmFile)
         .then(cleanClutter)
         .catch(console.error);
 };


### PR DESCRIPTION
Code test pass: http://p.fdzh.org/qjzP2mEl

Need to test rpm package:
- [x] Fedora
- [ ] RHEL/CentOS 7 (electron do not support el6/el5)
- [ ] openSUSE

Test steps(On Fedora22/23):

1.build rpm and deb

```
$ sudo dnf install dpkg rpm-build npm fakeroot
$ npm install
$ npm run release
```

2.install rpm

```
$ sudo dnf install rocketchat-v1.2.0-linux.x86_64.rpm  # Fedora 22+
$ sudo yum localinstall rocketchat-v1.2.0-linux.x86_64.rpm  # RHEL 7 / Fedora 21-
$ sudo zypper install rocketchat-v1.2.0-linux.x86_64.rpm  # openSUSE
```
