### PR TITLE
Open external app

### DIFF
--- a/app/scripts/webview.js
+++ b/app/scripts/webview.js
@@ -72,6 +72,9 @@ class WebView extends EventEmitter {
 
 		// Open external app on clicked link. e.g. mailto:, tel:, etc...
 		webviewObj.addEventListener('new-window', (e) => {
+			if (/^https?:\/\//.test(e.url)) {
+				return;
+			}
 			shell.openExternal(e.url);
 		});
 

--- a/app/scripts/webview.js
+++ b/app/scripts/webview.js
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events';
 import { servers } from './servers';
 import { sidebar } from './sidebar';
+import { shell } from 'electron';
 
 class WebView extends EventEmitter {
 	constructor() {
@@ -67,6 +68,11 @@ class WebView extends EventEmitter {
 
 		webviewObj.addEventListener('dom-ready', () => {
 			this.emit('dom-ready', host.url);
+		});
+
+		// Open external app on clicked link. e.g. mailto:, tel:, etc...
+		webviewObj.addEventListener('new-window', (e) => {
+			shell.openExternal(e.url);
 		});
 
 		this.webviewParentElement.appendChild(webviewObj);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "asar": "^0.10.0",
-    "electron-prebuilt": "0.37.7",
+    "electron-prebuilt": "0.36.10",
     "fs-jetpack": "^0.7.0",
     "gulp": "^3.9.0",
     "gulp-less": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "asar": "^0.10.0",
-    "electron-prebuilt": "0.36.10",
+    "electron-prebuilt": "0.37.7",
     "fs-jetpack": "^0.7.0",
     "gulp": "^3.9.0",
     "gulp-less": "^3.0.3",


### PR DESCRIPTION
@RocketChat/core

Launch external desktop application on clicked non http url. e.g. `mailto:`, `tel:`

>Open the given external protocol URL in the desktop's default manner. (For example, mailto: URLs in the user's default mail agent.) Returns true if an application was available to open the URL, false otherwise.

See also: [shell.openExternal()](https://github.com/electron/electron/blob/master/docs/api/shell.md#shellopenexternalurl-options)