### PR TITLE
Notifications on Windows XP, Vista, 7

### DIFF
--- a/app/background.js
+++ b/app/background.js
@@ -3,10 +3,12 @@
 // It doesn't have any windows which you can see on screen, but we can open
 // window from here.
 
-import { app, BrowserWindow } from 'electron';
+import { app, BrowserWindow, ipcMain } from 'electron';
 import devHelper from './vendor/electron_boilerplate/dev_helper';
 import windowStateKeeper from './vendor/electron_boilerplate/window_state';
 import certificate from './certificate';
+import Toaster from 'electron-toaster';
+const toaster = new Toaster();
 
 // Special module holding environment variables which you declared
 // in config/env_xxx.json file.
@@ -97,6 +99,20 @@ app.on('ready', function () {
 
     mainWindow.webContents.on('will-navigate', function(event) {
         event.preventDefault();
+    });
+
+    toaster.init(mainWindow);
+
+    ipcMain.on('notification-shim', (e, msg) => {
+        
+        mainWindow.webContents.executeJavaScript(`
+            require('electron').ipcRenderer.send('electron-toaster-message', {
+                title: '${msg.title}',
+                message: \`${msg.options.body}\`,
+                width: 400,
+                htmlFile: 'file://'+__dirname+'/notification.html?'
+            });
+        `);
     });
 
     certificate.initWindow(mainWindow);

--- a/app/background.js
+++ b/app/background.js
@@ -8,7 +8,6 @@ import devHelper from './vendor/electron_boilerplate/dev_helper';
 import windowStateKeeper from './vendor/electron_boilerplate/window_state';
 import certificate from './certificate';
 import Toaster from 'electron-toaster';
-import os from 'os';
 const toaster = new Toaster();
 
 // Special module holding environment variables which you declared
@@ -37,14 +36,19 @@ var mainWindowState = windowStateKeeper('main', {
     height: 600
 });
 
-// ==== Quick check to fetch Operating System and it's version ==>>
-// Add here any OS without native support for notifications to Toaster is used
+// ==== Quick check to fetch OS Name and set Toaster notifications on/off ==>>
+// Add here any OS without native support for notifications
 var useToaster = false;
 
-// Windows 7 or older
-if (os.platform() === 'win32' || os.platform() === 'win64') {
-    if (parseFloat(os.release) < 6.2) useToaster = true;
-};
+// Windows 7 / 2008 R2
+if (navigator.userAgent.indexOf("Windows NT 6.2")!=-1) useToaster = true;
+
+// Windows Vista / 2008
+if (navigator.userAgent.indexOf("Windows NT 6.0")!=-1) useToaster = true;
+
+// Windows XP / 2003
+if (navigator.userAgent.indexOf("Windows NT 5.2")!=-1) useToaster = true;
+if (navigator.userAgent.indexOf("Windows NT 5.1")!=-1) useToaster = true;
 // =========================================================================>>
 
 app.on('ready', function () {

--- a/app/background.js
+++ b/app/background.js
@@ -36,6 +36,21 @@ var mainWindowState = windowStateKeeper('main', {
     height: 600
 });
 
+// ==== Quick check to fetch OS Name and set Toaster notifications on/off ==>>
+// Add here any OS without native support for notifications
+var useToaster = false;
+
+// Windows 7 / 2008 R2
+if (navigator.userAgent.indexOf("Windows NT 6.2")!=-1) useToaster = true;
+
+// Windows Vista / 2008
+if (navigator.userAgent.indexOf("Windows NT 6.0")!=-1) useToaster = true;
+
+// Windows XP / 2003
+if (navigator.userAgent.indexOf("Windows NT 5.2")!=-1) useToaster = true;
+if (navigator.userAgent.indexOf("Windows NT 5.1")!=-1) useToaster = true;
+// =========================================================================>>
+
 app.on('ready', function () {
 
     mainWindow = new BrowserWindow({
@@ -101,19 +116,23 @@ app.on('ready', function () {
         event.preventDefault();
     });
 
-    toaster.init(mainWindow);
+	if(useToaster) {
+		
+	    toaster.init(mainWindow);
 
-    ipcMain.on('notification-shim', (e, msg) => {
+		ipcMain.on('notification-shim', (e, msg) => {
         
-        mainWindow.webContents.executeJavaScript(`
-            require('electron').ipcRenderer.send('electron-toaster-message', {
-                title: '${msg.title}',
-                message: \`${msg.options.body}\`,
-                width: 400,
-                htmlFile: 'file://'+__dirname+'/notification.html?'
-            });
-        `);
-    });
+			mainWindow.webContents.executeJavaScript(`
+				require('electron').ipcRenderer.send('electron-toaster-message', {
+					title: '${msg.title}',
+					message: \`${msg.options.body}\`,
+					width: 400,
+					htmlFile: 'file://'+__dirname+'/notification.html?'
+				});
+			`);
+		});
+	};
+
 
     certificate.initWindow(mainWindow);
 });

--- a/app/background.js
+++ b/app/background.js
@@ -8,6 +8,7 @@ import devHelper from './vendor/electron_boilerplate/dev_helper';
 import windowStateKeeper from './vendor/electron_boilerplate/window_state';
 import certificate from './certificate';
 import Toaster from 'electron-toaster';
+import os from 'os';
 const toaster = new Toaster();
 
 // Special module holding environment variables which you declared
@@ -36,19 +37,14 @@ var mainWindowState = windowStateKeeper('main', {
     height: 600
 });
 
-// ==== Quick check to fetch OS Name and set Toaster notifications on/off ==>>
-// Add here any OS without native support for notifications
+// ==== Quick check to fetch Operating System and it's version ==>>
+// Add here any OS without native support for notifications to Toaster is used
 var useToaster = false;
 
-// Windows 7 / 2008 R2
-if (navigator.userAgent.indexOf("Windows NT 6.2")!=-1) useToaster = true;
-
-// Windows Vista / 2008
-if (navigator.userAgent.indexOf("Windows NT 6.0")!=-1) useToaster = true;
-
-// Windows XP / 2003
-if (navigator.userAgent.indexOf("Windows NT 5.2")!=-1) useToaster = true;
-if (navigator.userAgent.indexOf("Windows NT 5.1")!=-1) useToaster = true;
+// Windows 7 or older
+if (os.platform() === 'win32' || os.platform() === 'win64') {
+    if (parseFloat(os.release) < 6.2) useToaster = true;
+};
 // =========================================================================>>
 
 app.on('ready', function () {

--- a/app/background.js
+++ b/app/background.js
@@ -36,19 +36,14 @@ var mainWindowState = windowStateKeeper('main', {
     height: 600
 });
 
-// ==== Quick check to fetch OS Name and set Toaster notifications on/off ==>>
-// Add here any OS without native support for notifications
+// ==== Quick check to fetch Operating System and it's version ==>>
+// Add here any OS without native support for notifications to Toaster is used
 var useToaster = false;
 
-// Windows 7 / 2008 R2
-if (navigator.userAgent.indexOf("Windows NT 6.2")!=-1) useToaster = true;
-
-// Windows Vista / 2008
-if (navigator.userAgent.indexOf("Windows NT 6.0")!=-1) useToaster = true;
-
-// Windows XP / 2003
-if (navigator.userAgent.indexOf("Windows NT 5.2")!=-1) useToaster = true;
-if (navigator.userAgent.indexOf("Windows NT 5.1")!=-1) useToaster = true;
+// Windows 7 or older
+if (os.platform() === 'win32' || os.platform() === 'win64') {
+    if (parseFloat(os.release()) < 6.2) useToaster = true;
+};
 // =========================================================================>>
 
 app.on('ready', function () {

--- a/app/notification.html
+++ b/app/notification.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html>
+<head>
+
+
+	<title>toaster</title>
+	<!-- <link rel="stylesheet" type="text/css" href="bower_components/material-design-lite/material.min.css"> -->
+	<link rel="stylesheet" type="text/css" href="bower_components/octicons/octicons/octicons.css">
+	<style type="text/css">
+		*{margin: 0;padding:0;}
+		body, html{
+			font: 13px/1.4 Helvetica,arial,nimbussansl,liberationsans,freesans,clean,sans-serif,"Segoe UI Emoji","Segoe UI Symbol";
+			width: 100%;
+			height: 100%;
+			overflow: hidden;
+		}
+
+		.ico{
+			color: white;
+			font-size: 32px;
+			padding: 11px;
+		}
+
+		#title{
+			font-weight:bold;
+			font-size: 18px;
+		}
+
+		#message{
+			font-size: 14px;
+		}
+
+		#detail{
+			font-weight:bold;
+			font-size: 12px;
+			color: red;
+		}
+
+		table{
+			width: 100%;
+		}
+
+		table td {
+		    vertical-align: top;
+		}
+
+	</style>
+</head>
+	<body>
+		<table id="content">
+			<tbody>
+				<row>
+					<td style="background-color:silver;" width="90" cellpadding="0">
+						<div style="text-align:center;">
+							<br>
+							<img src="images/icon.png" style="width: 50px" />
+						</div>
+					</td>
+					<td cellpadding="30">
+						<div style="padding:22px;">
+							<span id="title"></span><hr>
+							<span id="message"></span><br><br><br>
+							<span id="detail"></span>
+						</div>
+					</td>
+				</row>
+			</tbody>
+		</table>
+		<script>
+			function getQueryVariable(variable) {
+				var query = window.location.search.substring(1);
+				var vars = query.split("&");
+				for (var i=0;i<vars.length;i++) {
+					var pair = vars[i].split("=");
+					if (pair[0] === variable) {
+						return decodeURIComponent(pair[1]);
+					}
+				}
+			}
+
+			var autoSize = function() {
+				var heightOffset = window.outerHeight - window.innerHeight;
+				var widthOffset = window.outerWidth - window.innerWidth;
+				var result = {
+					height : document.getElementById("content").clientHeight + heightOffset,
+					width : document.getElementById("content").clientWidth + widthOffset
+				}
+
+				window.resizeTo(result.width, result.height);
+
+				return result;
+			};
+
+
+			var onKeydown = function(/*e*/) {
+				window.close();
+			};
+
+			var onLoad = function load(/*event*/){
+				autoSize();
+			    this.removeEventListener("load", load, false); //remove listener, no longer needed
+
+				this.setTimeout(function() {
+					this.close();
+				}, parseInt(getQueryVariable("timeout")));
+
+				document.addEventListener("keydown", onKeydown, false);
+				document.addEventListener("click", window.close);
+			};
+
+			document.getElementById("title").innerHTML = getQueryVariable("title");
+			document.getElementById("message").innerHTML = getQueryVariable("message");
+			document.getElementById("detail").innerHTML = getQueryVariable("detail");
+			window.addEventListener("load", onLoad, false);
+		</script>
+	</body>
+</html>
+
+

--- a/app/package.json
+++ b/app/package.json
@@ -9,6 +9,8 @@
   "copyright": "© 2016, Rocket.Chat",
   "main": "background.js",
   "dependencies": {
+    "electron-notification-shim": "^1.1.0",
+    "electron-toaster": "^2.0.1",
     "fs-jetpack": "^0.7.0"
   },
   "packageNameTemplate": "{{name}}-v{{version}}-{{platform}}-{{arch}}",

--- a/app/scripts/preload.js
+++ b/app/scripts/preload.js
@@ -3,6 +3,8 @@
 
 var IPC = require('electron').ipcRenderer;
 
+require('electron-notification-shim')();
+
 class Notification extends window.Notification {
 	get onclick() {
 		return super.onclick;

--- a/app/scripts/start.js
+++ b/app/scripts/start.js
@@ -7,6 +7,8 @@ import { webview } from './webview';
 import tray from './tray';
 import './menus';
 
+require('electron-notification-shim')();
+
 sidebar.on('badge-setted', function() {
     var badge = sidebar.getGlobalBadge();
 

--- a/app/scripts/start.js
+++ b/app/scripts/start.js
@@ -7,8 +7,6 @@ import { webview } from './webview';
 import tray from './tray';
 import './menus';
 
-require('electron-notification-shim')();
-
 sidebar.on('badge-setted', function() {
     var badge = sidebar.getGlobalBadge();
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "q": "^1.4.1",
     "rollup": "^0.25.4",
     "tree-kill": "^0.1.1",
-    "yargs": "^4.2.0"
+    "yargs": "^4.2.0",
+    "electron-toaster": "^2.0.1",
+    "electron-notification-shim": "^1.1.0"
   },
   "optionalDependencies": {
     "appdmg": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -29,5 +29,9 @@
     "type": "git",
     "url": "https://github.com/RocketChat/Rocket.Chat.Electron.git"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "electron-notification-shim": "^1.1.0",
+    "electron-toaster": "^2.0.1"
+  }
 }


### PR DESCRIPTION
@RocketChat/core
@rodrigok 
@geekgonecrazy 

This PR addresses the issue on #199 to restrict the notification for systems with no native support. Now only Windows XP, Vista and 7.

Closes #55.
