### PR TITLE
Note for debian developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ npm install
 ```
 It will also download Electron runtime, and install dependencies for second `package.json` file inside `app` folder.
 
+Debian users need to make sure they have the package `libxss-dev` installed.
+
 #### Starting the app
 
 ```


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Tell us more about your PR -->

`libxss-dev` is not installed by default on Ubuntu.