### PR TITLE
electron-update fix spellcheck

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -13,7 +13,8 @@
     "ffi": "^2.1.0",
     "electron-notification-shim": "^1.1.0",
     "electron-toaster": "^2.0.2",
-    "fs-jetpack": "^0.7.0"
+    "fs-jetpack": "^0.7.0",
+    "spellchecker": "3.3.1"
   },
   "packageNameTemplate": "{{name}}-v{{version}}-{{platform}}-{{arch}}",
   "codeSignIdentity": {

--- a/app/scripts/preload.js
+++ b/app/scripts/preload.js
@@ -206,6 +206,10 @@ try {
 			'es_ES',
 			'pt_BR'
 		];
+	} else {
+		for (var i = 0; i < availableDictionaries.length; i++) {
+			availableDictionaries[i] = availableDictionaries[i].replace('-', '_');
+		}
 	}
 
 	availableDictionaries = availableDictionaries.sort(function(a, b) {

--- a/app/scripts/preload.js
+++ b/app/scripts/preload.js
@@ -71,13 +71,13 @@ var supportExternalLinks = function(e) {
 document.addEventListener('click', supportExternalLinks, false);
 
 
-// const {webFrame} = require('electron');
+const {webFrame} = require('electron');
 const {remote} = require('electron');
 
-// var webContents = remote.getCurrentWebContents();
+var webContents = remote.getCurrentWebContents();
 var menu = new remote.Menu();
 
-// var path = remote.require('path');
+var path = remote.require('path');
 
 // // set the initial context menu so that a context menu exists even before spellcheck is called
 var getTemplate = function() {
@@ -112,11 +112,11 @@ var getTemplate = function() {
 	];
 };
 
-// let languagesMenu;
-// let checker;
+let languagesMenu;
+let checker;
 const enabledDictionaries = [];
-// let availableDictionaries = [];
-// let dictionariesPath;
+let availableDictionaries = [];
+let dictionariesPath;
 
 if (localStorage.getItem('spellcheckerDictionaries')) {
 	let spellcheckerDictionaries = JSON.parse(localStorage.getItem('spellcheckerDictionaries'));
@@ -125,218 +125,218 @@ if (localStorage.getItem('spellcheckerDictionaries')) {
 	}
 }
 
-// const saveEnabledDictionaries = function() {
-// 	localStorage.setItem('spellcheckerDictionaries', JSON.stringify(enabledDictionaries));
-// };
+const saveEnabledDictionaries = function() {
+	localStorage.setItem('spellcheckerDictionaries', JSON.stringify(enabledDictionaries));
+};
 
-// const isCorrect = function(text) {
-// 	if (!checker) {
-// 		return true;
-// 	}
+const isCorrect = function(text) {
+	if (!checker) {
+		return true;
+	}
 
-// 	let isCorrect = false;
-// 	enabledDictionaries.forEach(function(enabledDictionary) {
-// 		if (availableDictionaries.indexOf(enabledDictionary) === -1) {
-// 			return;
-// 		}
+	let isCorrect = false;
+	enabledDictionaries.forEach(function(enabledDictionary) {
+		if (availableDictionaries.indexOf(enabledDictionary) === -1) {
+			return;
+		}
 
-// 		checker.setDictionary(enabledDictionary, dictionariesPath);
-// 		if (!checker.isMisspelled(text)) {
-// 			isCorrect = true;
-// 		}
-// 	});
+		checker.setDictionary(enabledDictionary, dictionariesPath);
+		if (!checker.isMisspelled(text)) {
+			isCorrect = true;
+		}
+	});
 
-// 	return isCorrect;
-// };
+	return isCorrect;
+};
 
-// const getCorrections = function(text) {
-// 	// Create an array of arrays of corrections
-// 	// One array of corrections per language
-// 	let allCorrections = [];
-// 	enabledDictionaries.forEach(function(enabledDictionary) {
-// 		if (availableDictionaries.indexOf(enabledDictionary) === -1) {
-// 			return;
-// 		}
+const getCorrections = function(text) {
+	// Create an array of arrays of corrections
+	// One array of corrections per language
+	let allCorrections = [];
+	enabledDictionaries.forEach(function(enabledDictionary) {
+		if (availableDictionaries.indexOf(enabledDictionary) === -1) {
+			return;
+		}
 
-// 		checker.setDictionary(enabledDictionary, dictionariesPath);
-// 		const languageCorrections = checker.getCorrectionsForMisspelling(text);
-// 		if (languageCorrections.length > 0) {
-// 			allCorrections.push(languageCorrections);
-// 		}
-// 	});
+		checker.setDictionary(enabledDictionary, dictionariesPath);
+		const languageCorrections = checker.getCorrectionsForMisspelling(text);
+		if (languageCorrections.length > 0) {
+			allCorrections.push(languageCorrections);
+		}
+	});
 
-// 	// Get the size of biggest array
-// 	let length = 0;
-// 	allCorrections.forEach(function(items) {
-// 		length = Math.max(length, items.length);
-// 	});
+	// Get the size of biggest array
+	let length = 0;
+	allCorrections.forEach(function(items) {
+		length = Math.max(length, items.length);
+	});
 
-// 	// Merge all arrays until the size of the biggest array
-// 	// To get the best suggestions of each language first
-// 	// Ex: [[1,2,3], [a,b]] => [1,a,2,b,3]
-// 	const corrections = [];
-// 	for (let i = 0; i < length; i++) {
-// 		for (var j = 0; j < allCorrections.length; j++) {
-// 			if (allCorrections[j][i]) {
-// 				corrections.push(allCorrections[j][i]);
-// 			}
-// 		}
-// 	}
+	// Merge all arrays until the size of the biggest array
+	// To get the best suggestions of each language first
+	// Ex: [[1,2,3], [a,b]] => [1,a,2,b,3]
+	const corrections = [];
+	for (let i = 0; i < length; i++) {
+		for (var j = 0; j < allCorrections.length; j++) {
+			if (allCorrections[j][i]) {
+				corrections.push(allCorrections[j][i]);
+			}
+		}
+	}
 
-// 	// Remove duplicateds
-// 	corrections.forEach(function(item, index) {
-// 		const dupIndex = corrections.indexOf(item, index+1);
-// 		if (dupIndex > -1) {
-// 			corrections.splice(dupIndex, 1);
-// 		}
-// 	});
+	// Remove duplicateds
+	corrections.forEach(function(item, index) {
+		const dupIndex = corrections.indexOf(item, index+1);
+		if (dupIndex > -1) {
+			corrections.splice(dupIndex, 1);
+		}
+	});
 
-// 	return corrections;
-// };
+	return corrections;
+};
 
-// try {
-// 	checker = require('spellchecker');
+try {
+	checker = require('spellchecker');
 
-// 	availableDictionaries = checker.getAvailableDictionaries();
+	availableDictionaries = checker.getAvailableDictionaries();
 
-// 	if (availableDictionaries.length === 0) {
-// 		dictionariesPath = path.join(remote.app.getAppPath(), '../dictionaries');
-// 		availableDictionaries = [
-// 			'en_US',
-// 			'es_ES',
-// 			'pt_BR'
-// 		];
-// 	}
+	if (availableDictionaries.length === 0) {
+		dictionariesPath = path.join(remote.app.getAppPath(), '../dictionaries');
+		availableDictionaries = [
+			'en_US',
+			'es_ES',
+			'pt_BR'
+		];
+	}
 
-// 	availableDictionaries = availableDictionaries.sort(function(a, b) {
-// 		if (a > b) {
-// 			return 1;
-// 		}
-// 		if (a < b) {
-// 			return -1;
-// 		}
-// 		return 0;
-// 	});
+	availableDictionaries = availableDictionaries.sort(function(a, b) {
+		if (a > b) {
+			return 1;
+		}
+		if (a < b) {
+			return -1;
+		}
+		return 0;
+	});
 
-// 	for (var i = enabledDictionaries.length - 1; i >= 0; i--) {
-// 		if (availableDictionaries.indexOf(enabledDictionaries[i]) === -1) {
-// 			enabledDictionaries.splice(i, 1);
-// 		}
-// 	}
+	for (var i = enabledDictionaries.length - 1; i >= 0; i--) {
+		if (availableDictionaries.indexOf(enabledDictionaries[i]) === -1) {
+			enabledDictionaries.splice(i, 1);
+		}
+	}
 
-// 	if (enabledDictionaries.length === 0) {
-// 		if (localStorage.getItem('userLanguage')) {
-// 			let userLanguage = localStorage.getItem('userLanguage').replace('-', '_');
-// 			if (availableDictionaries.indexOf(userLanguage) > -1) {
-// 				enabledDictionaries.push(userLanguage);
-// 			}
-// 			if (userLanguage.indexOf('_') > -1) {
-// 				userLanguage = userLanguage.split('_')[0];
-// 				if (availableDictionaries.indexOf(userLanguage) > -1) {
-// 					enabledDictionaries.push(userLanguage);
-// 				}
-// 			}
-// 		}
+	if (enabledDictionaries.length === 0) {
+		if (localStorage.getItem('userLanguage')) {
+			let userLanguage = localStorage.getItem('userLanguage').replace('-', '_');
+			if (availableDictionaries.indexOf(userLanguage) > -1) {
+				enabledDictionaries.push(userLanguage);
+			}
+			if (userLanguage.indexOf('_') > -1) {
+				userLanguage = userLanguage.split('_')[0];
+				if (availableDictionaries.indexOf(userLanguage) > -1) {
+					enabledDictionaries.push(userLanguage);
+				}
+			}
+		}
 
-// 		let navigatorLanguage = navigator.language.replace('-', '_');
-// 		if (availableDictionaries.indexOf(navigatorLanguage) > -1) {
-// 			enabledDictionaries.push(navigatorLanguage);
-// 		}
-// 		if (navigatorLanguage.indexOf('_') > -1) {
-// 			navigatorLanguage = navigatorLanguage.split('_')[0];
-// 			if (availableDictionaries.indexOf(navigatorLanguage) > -1) {
-// 				enabledDictionaries.push(navigatorLanguage);
-// 			}
-// 		}
-// 	}
+		let navigatorLanguage = navigator.language.replace('-', '_');
+		if (availableDictionaries.indexOf(navigatorLanguage) > -1) {
+			enabledDictionaries.push(navigatorLanguage);
+		}
+		if (navigatorLanguage.indexOf('_') > -1) {
+			navigatorLanguage = navigatorLanguage.split('_')[0];
+			if (availableDictionaries.indexOf(navigatorLanguage) > -1) {
+				enabledDictionaries.push(navigatorLanguage);
+			}
+		}
+	}
 
-// 	if (enabledDictionaries.length === 0) {
-// 		let defaultLanguage = 'en_US';
-// 		if (availableDictionaries.indexOf(defaultLanguage) > -1) {
-// 			enabledDictionaries.push(defaultLanguage);
-// 		}
-// 		defaultLanguage = defaultLanguage.split('_')[0];
-// 		if (availableDictionaries.indexOf(defaultLanguage) > -1) {
-// 			enabledDictionaries.push(defaultLanguage);
-// 		}
-// 	}
+	if (enabledDictionaries.length === 0) {
+		let defaultLanguage = 'en_US';
+		if (availableDictionaries.indexOf(defaultLanguage) > -1) {
+			enabledDictionaries.push(defaultLanguage);
+		}
+		defaultLanguage = defaultLanguage.split('_')[0];
+		if (availableDictionaries.indexOf(defaultLanguage) > -1) {
+			enabledDictionaries.push(defaultLanguage);
+		}
+	}
 
-// 	languagesMenu = {
-// 		label: 'Spelling languages',
-// 		submenu: []
-// 	};
+	languagesMenu = {
+		label: 'Spelling languages',
+		submenu: []
+	};
 
-// 	availableDictionaries.forEach((dictionary) => {
-// 		const menu = {
-// 			label: dictionary,
-// 			type: 'checkbox',
-// 			checked: enabledDictionaries.indexOf(dictionary) > -1,
-// 			click: function(menuItem) {
-// 				menu.checked = menuItem.checked;
-// 				if (menuItem.checked) {
-// 					enabledDictionaries.push(dictionary);
-// 				} else {
-// 					enabledDictionaries.splice(enabledDictionaries.indexOf(dictionary), 1);
-// 				}
-// 				saveEnabledDictionaries();
-// 			}
-// 		};
-// 		languagesMenu.submenu.push(menu);
-// 	});
+	availableDictionaries.forEach((dictionary) => {
+		const menu = {
+			label: dictionary,
+			type: 'checkbox',
+			checked: enabledDictionaries.indexOf(dictionary) > -1,
+			click: function(menuItem) {
+				menu.checked = menuItem.checked;
+				if (menuItem.checked) {
+					enabledDictionaries.push(dictionary);
+				} else {
+					enabledDictionaries.splice(enabledDictionaries.indexOf(dictionary), 1);
+				}
+				saveEnabledDictionaries();
+			}
+		};
+		languagesMenu.submenu.push(menu);
+	});
 
-// 	webFrame.setSpellCheckProvider('', false, {
-// 		spellCheck: function(text) {
-// 			return isCorrect(text);
-// 		}
-// 	});
-// } catch(e) {
-// 	console.log('Spellchecker module unavailable');
-// }
+	webFrame.setSpellCheckProvider('', false, {
+		spellCheck: function(text) {
+			return isCorrect(text);
+		}
+	});
+} catch(e) {
+	console.log('Spellchecker module unavailable \n' + e.message);
+}
 
 window.addEventListener('contextmenu', function(event){
 	event.preventDefault();
 
 	const template = getTemplate();
 
-// 	if (languagesMenu) {
-// 		template.unshift({ type: 'separator' });
-// 		template.unshift(languagesMenu);
-// 	}
+	if (languagesMenu) {
+		template.unshift({ type: 'separator' });
+		template.unshift(languagesMenu);
+	}
 
 	setTimeout(function() {
-// 		if (['TEXTAREA', 'INPUT'].indexOf(event.target.nodeName) > -1) {
-// 			const text = window.getSelection().toString().trim();
-// 			if (text !== '' && !isCorrect(text)) {
-// 				const options = getCorrections(text);
-// 				const maxItems = Math.min(options.length, 6);
+		if (['TEXTAREA', 'INPUT'].indexOf(event.target.nodeName) > -1) {
+			const text = window.getSelection().toString().trim();
+			if (text !== '' && !isCorrect(text)) {
+				const options = getCorrections(text);
+				const maxItems = Math.min(options.length, 6);
 
-// 				if (maxItems > 0) {
-// 					const suggestions = [];
-// 					const onClick = function(menuItem) {
-// 						webContents.replaceMisspelling(menuItem.label);
-// 					};
+				if (maxItems > 0) {
+					const suggestions = [];
+					const onClick = function(menuItem) {
+						webContents.replaceMisspelling(menuItem.label);
+					};
 
-// 					for (let i = 0; i < options.length; i++) {
-// 						const item = options[i];
-// 						suggestions.push({ label: item, click: onClick });
-// 					}
+					for (let i = 0; i < options.length; i++) {
+						const item = options[i];
+						suggestions.push({ label: item, click: onClick });
+					}
 
-// 					template.unshift({ type: 'separator' });
+					template.unshift({ type: 'separator' });
 
-// 					if (suggestions.length > maxItems) {
-// 						const morSuggestions = {
-// 							label: 'More spelling suggestions',
-// 							submenu: suggestions.slice(maxItems)
-// 						};
-// 						template.unshift(morSuggestions);
-// 					}
+					if (suggestions.length > maxItems) {
+						const morSuggestions = {
+							label: 'More spelling suggestions',
+							submenu: suggestions.slice(maxItems)
+						};
+						template.unshift(morSuggestions);
+					}
 
-// 					template.unshift.apply(template, suggestions.slice(0, maxItems));
-// 				} else {
-// 					template.unshift({ label: 'no suggestions', click: function() { } });
-// 				}
-// 			}
-// 		}
+					template.unshift.apply(template, suggestions.slice(0, maxItems));
+				} else {
+					template.unshift({ label: 'no suggestions', click: function() { } });
+				}
+			}
+		}
 
 		menu = remote.Menu.buildFromTemplate(template);
 		menu.popup(remote.getCurrentWindow());
@@ -348,12 +348,12 @@ function getSystemIdleTime() {
 	return IPC.sendSync('getSystemIdleTime');
 }
 
-setInterval(function(){
-	try {
-		if(getSystemIdleTime() < UserPresence.awayTime) {
-			UserPresence.setOnline();
-		}
-	} catch(e) {
-		console.error(e);
-	}
-}, 1e3);
+// setInterval(function(){
+// 	try {
+// 		if(getSystemIdleTime() < UserPresence.awayTime) {
+// 			UserPresence.setOnline();
+// 		}
+// 	} catch(e) {
+// 		console.error(e);
+// 	}
+// }, 1e3);


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Tell us more about your PR -->

- Re-enable previously broken spellchecking code for electron-update
- Fix Mac OS X not having spellchecker module, and thus not working, by adding explicit spellchecker v3.3.1 dependency
- Fixed no default language being selected on Windows when spellchecker loads the available dictionaries (en-US as opposed to en_US)

Tested on so far:
- Windows 10 x64
- Mac OS X Siera (10.12)
- Ubuntu 16.04.1 LTS
- Fedora 25.1