### PR TITLE
Fix various quirks with the windows installer

### DIFF
--- a/build/win/installer.nsh
+++ b/build/win/installer.nsh
@@ -1,0 +1,4 @@
+!macro customInstall
+    ; Required as electron-builder does not provide a way to specify it as of version 11.2.4
+    WriteRegStr SHCTX "${UNINSTALL_REGISTRY_KEY}" "DisplayIcon" '"$INSTDIR\resources\build\icon.ico"'
+!macroend

--- a/package.json
+++ b/package.json
@@ -20,15 +20,20 @@
       "package.json"
     ],
     "extraResources": [
-      "dictionaries/**/*"
+      "dictionaries/**/*",
+      "build/icon.ico"
     ],
     "mac": {
       "helperBundleId": "chat.rocket.electron.helper",
       "category": "public.app-category.productivity",
       "target": ["dmg", "pkg", "zip"]
     },
-    "win": {
-      "target": ["nsis"]
+    "nsis": {
+      "include": "build/win/installer.nsh",
+      "oneClick": false,
+      "perMachine": true,
+      "allowElevation": true,
+      "allowToChangeInstallationDirectory": true
     },
     "linux": {
       "target": ["deb", "rpm"]


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

The default settings for electron-builder's win target aren't great. They create a setup exe that is one-click and automatically installs Rocket.Chat+ into the current users AppData folder with no way to change it. This isn't terribly user friendly and is probably a no-no in some Enterprise environments that use Rocket.Chat. Additionally the created uninstallation entry doesn't have an icon with the default settings. I've changed the build config to do the following:
* Now not one-click, forced to All Users instead like the old installer
* Now shows an icon in Programs and Features instead of being blank
* Now allows changing installation directory