### PR TITLE
Hide sidebar by default until adding new server

### DIFF
--- a/src/scripts/sidebar.js
+++ b/src/scripts/sidebar.js
@@ -39,8 +39,8 @@ class SideBar extends EventEmitter {
             this.setActive(hostUrl);
         });
 
-        servers.on('active-cleared', (hostUrl) => {
-            this.deactiveAll(hostUrl);
+        servers.on('active-cleared', () => {
+            this.deactiveAll(true);
         });
 
         servers.on('title-setted', (hostUrl, title) => {
@@ -161,17 +161,21 @@ class SideBar extends EventEmitter {
             return;
         }
 
-        this.deactiveAll();
+        this.deactiveAll(false);
         var item = this.getByUrl(hostUrl);
         if (item) {
             item.classList.add('active');
         }
     }
 
-    deactiveAll () {
+    deactiveAll (showSidebar) {
         var item;
         while (!(item = this.getActive()) === false) {
             item.classList.remove('active');
+        }
+
+        if (showSidebar && this.isHidden()) {
+            this.show();
         }
     }
 
@@ -242,7 +246,7 @@ class SideBar extends EventEmitter {
     }
 
     isHidden () {
-        return localStorage.getItem('sidebar-closed') === 'true';
+        return localStorage.getItem('sidebar-closed') !== 'false';
     }
 }
 


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #304 

<!-- INSTRUCTION: Tell us more about your PR -->
Not sure if this change is wanted, but it didn't take long, so I don't mind either way.

By default it will now hide the server list until you attempt add a new server, then it will be shown until you close it again.

There are 3 ways you can add a server now the sidebar is hidden:
- ⌘N
- Select `Window->Add new server`
- Select `View->Toggle server list` then add server with `+` in server list