### PR TITLE
Fix issues with desktop entry on linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,10 @@
       "allowToChangeInstallationDirectory": true
     },
     "linux": {
+      "desktop": {
+        "Categories": "GNOME;GTK;Network;InstantMessaging",
+        "StartupWMClass": "Rocket.Chat+"
+      },
       "target": ["deb", "rpm"]
     }
   },


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #338

<!-- INSTRUCTION: Tell us more about your PR -->
When launched the desktop app is iconless and independent from the launcher. This line added to the rocketchat.desktop file ensures the launcher and the app remain as one on the desktop.

- [x] Test once built