### PR TITLE
Stop redirect when dragging image/url into window

### DIFF
--- a/src/public/preload.js
+++ b/src/public/preload.js
@@ -77,6 +77,9 @@ var supportExternalLinks = function (e) {
 };
 
 document.addEventListener('click', supportExternalLinks, false);
+// Prevent redirect to url when dragging in
+document.addEventListener('dragover', e => e.preventDefault());
+document.addEventListener('drop', e => e.preventDefault());
 
 
 const {webFrame} = require('electron');


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes RocketChat/Rocket.Chat#5046
Fix issue mentioned in #308 

<!-- INSTRUCTION: Tell us more about your PR -->
Don't redirect to url/image url if image or url is dragged into window.

Tested, and this doesn't stop drag&drop image upload from working.