### PR TITLE
Fix to put tray object in mainWindow allowing for tray icon alerts to work

### DIFF
--- a/src/scripts/tray.js
+++ b/src/scripts/tray.js
@@ -27,6 +27,8 @@ const _iconTrayAlert = path.join(__dirname, 'images', icons[process.platform].di
 
 function createAppTray () {
     const _tray = new Tray(_iconTray);
+    mainWindow.tray = _tray;
+    
     const contextMenuShow = Menu.buildFromTemplate([{
         label: 'Show',
         click () {

--- a/src/scripts/tray.js
+++ b/src/scripts/tray.js
@@ -28,7 +28,7 @@ const _iconTrayAlert = path.join(__dirname, 'images', icons[process.platform].di
 function createAppTray () {
     const _tray = new Tray(_iconTray);
     mainWindow.tray = _tray;
-    
+
     const contextMenuShow = Menu.buildFromTemplate([{
         label: 'Show',
         click () {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #353 

<!-- INSTRUCTION: Tell us more about your PR -->
tray.js was missing the assignment of the _tray object into the mainWindow.  This caused the code to never modify the tray when showTrayAlert() was called.