### PR TITLE
Only show reload screen if main webview error

### DIFF
--- a/src/scripts/webview.js
+++ b/src/scripts/webview.js
@@ -120,6 +120,12 @@ class WebView extends EventEmitter {
             }
         });
 
+        webviewObj.addEventListener('did-get-response-details', (e) => {
+            if (e.resourceType === 'mainFrame' && e.httpResponseCode >= 500) {
+                webviewObj.loadURL('file://' + __dirname + '/loading-error.html');
+            }
+        });
+
         this.webviewParentElement.appendChild(webviewObj);
 
         webviewObj.src = host.lastPath || host.url;

--- a/src/scripts/webview.js
+++ b/src/scripts/webview.js
@@ -114,8 +114,10 @@ class WebView extends EventEmitter {
             this.emit('dom-ready', host.url);
         });
 
-        webviewObj.addEventListener('did-fail-load', () => {
-            webviewObj.loadURL('file://' + __dirname + '/loading-error.html');
+        webviewObj.addEventListener('did-fail-load', (e) => {
+            if (e.isMainFrame) {
+                webviewObj.loadURL('file://' + __dirname + '/loading-error.html');
+            }
         });
 
         this.webviewParentElement.appendChild(webviewObj);


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #385 
Closes #389 

<!-- INSTRUCTION: Tell us more about your PR -->
It seems the `did-fail-load` event fires when links such as youtube fail to load, causing the server reload screen to show. This makes it only check for errors in loading the main app.