### PR TITLE
Don't open dev tools on about, and show message when no updates

### DIFF
--- a/src/background/autoUpdate.js
+++ b/src/background/autoUpdate.js
@@ -36,9 +36,17 @@ function updateDownloaded () {
     });
 }
 
+function updateNotAvailable () {
+    if (checkForUpdatesEvent) {
+        checkForUpdatesEvent.sender.send('update-result', false);
+        checkForUpdatesEvent = null;
+    }
+}
+
 function updateAvailable ({version}) {
     if (checkForUpdatesEvent) {
         checkForUpdatesEvent.sender.send('update-result', true);
+        checkForUpdatesEvent = null;
     } else if (updateFile.skip === version) {
         console.log(`Skipping version: ${version}`);
         return;
@@ -98,6 +106,7 @@ function updateAvailable ({version}) {
 
 function checkForUpdates () {
     autoUpdater.on('update-available', updateAvailable);
+    autoUpdater.on('update-not-available', updateNotAvailable);
 
     autoUpdater.on('download-progress', ({percent}) => {
         console.log(`Update progress: ${percent}`);

--- a/src/public/about.html
+++ b/src/public/about.html
@@ -87,7 +87,7 @@
 				document.querySelector('.update-spin').setAttribute('style', 'display:none');
 				document.querySelector('.update').removeAttribute('disabled');
 				if (!updateAvailable) {
-					alert('No updates are available');
+					alert('No updates are available.');
 				}
 			});
 

--- a/src/scripts/menus/app.js
+++ b/src/scripts/menus/app.js
@@ -19,7 +19,6 @@ const appTemplate = [
             });
             win.loadURL('file://' + __dirname + '/about.html');
             win.setMenuBarVisibility(false);
-            win.openDevTools();
             win.show();
         }
     },


### PR DESCRIPTION
Remove dev code to open dev tools, and show a response when user click check for updates, and there are none