### PR TITLE
[NEW] check install location for a servers.json as well

### DIFF
--- a/src/scripts/servers.js
+++ b/src/scripts/servers.js
@@ -67,8 +67,14 @@ class Servers extends EventEmitter {
         if (Object.keys(hosts).length === 0) {
             const serverFileName = 'servers.json';
             const userDataDir = jetpack.cwd(remote.app.getPath('userData'));
+            const installDataDir = jetpack.cwd(process.cwd());
             try {
-                const result = userDataDir.read(serverFileName, 'json');
+                var result = installDataDir.read(serverFileName, 'json');
+                const resultUserDataDir = userDataDir.read(serverFileName, 'json');
+                // overwrite installDataDir servers.json
+                if (resultUserDataDir) {
+                  var result = resultUserDataDir;
+                }
                 if (result) {
                     hosts = {};
                     Object.keys(result).forEach((title) => {

--- a/src/scripts/servers.js
+++ b/src/scripts/servers.js
@@ -73,7 +73,7 @@ class Servers extends EventEmitter {
                 const resultUserDataDir = userDataDir.read(serverFileName, 'json');
                 // overwrite installDataDir servers.json
                 if (resultUserDataDir) {
-                  var result = resultUserDataDir;
+                    result = resultUserDataDir;
                 }
                 if (result) {
                     hosts = {};


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #455

<!-- INSTRUCTION: Tell us more about your PR -->
Loading servers.json file from install location unless a servers.json is placed in user's local config, e.g. in %APPDATA%/Roaming on Windows. Why that? If deploying rocket.chat client with /allusers, a deployment tool in a last step could copy a preconfigured servers.json into the global installation location. If the client is started the server URL is preconfigured to the own server by the global servers.json to any user on the system unless a user overwrites it by an own one.