### PR TITLE
[FIX] Refactor keep-alive to remove excessive calls to UserPresence

### DIFF
--- a/src/public/preload.js
+++ b/src/public/preload.js
@@ -17,12 +17,13 @@ events.forEach(function (e) {
 
 const userPresenceControl = () => {
     UserPresence.stopTimer(); //stop userpresence control
-    const AWAY_TIME = 300000; // 5 min
     const INTERVAL = 10000; // 10s
     setInterval(() => {
         try {
             const idleTime = ipcRenderer.sendSync('getSystemIdleTime');
-            if (idleTime < AWAY_TIME) {
+            console.log(idleTime);
+            if (idleTime < INTERVAL) {
+                console.log('setonline');
                 UserPresence.setOnline();
             }
         } catch (e) {

--- a/src/public/preload.js
+++ b/src/public/preload.js
@@ -16,14 +16,11 @@ events.forEach(function (e) {
 });
 
 const userPresenceControl = () => {
-    UserPresence.stopTimer(); //stop userpresence control
     const INTERVAL = 10000; // 10s
     setInterval(() => {
         try {
             const idleTime = ipcRenderer.sendSync('getSystemIdleTime');
-            console.log(idleTime);
             if (idleTime < INTERVAL) {
-                console.log('setonline');
                 UserPresence.setOnline();
             }
         } catch (e) {

--- a/src/public/preload.js
+++ b/src/public/preload.js
@@ -1,4 +1,4 @@
-/* globals Meteor, Tracker, RocketChat */
+/* globals Meteor, Tracker, RocketChat, UserPresence*/
 'use strict';
 
 const { ipcRenderer, shell } = require('electron');
@@ -15,6 +15,29 @@ events.forEach(function (e) {
     });
 });
 
+const userPresenceControl = () => {
+    UserPresence.stopTimer(); //stop userpresence control
+    const AWAY_TIME = 300000; // 5 min
+    const INTERVAL = 10000; // 10s
+    let userOnline = true;
+    setInterval(() => {
+        try {
+            const idleTime = ipcRenderer.sendSync('getSystemIdleTime');
+            if (idleTime < AWAY_TIME && !userOnline) {
+                Meteor.call('UserPresence:online');
+                userOnline = true;
+            }
+            if (idleTime >= AWAY_TIME && userOnline) {
+                if (!userOnline) { return; }
+                Meteor.call('UserPresence:away');
+                userOnline = false;
+            }
+        } catch (e) {
+            console.error(`Error getting system idle time: ${e}`);
+        }
+    }, INTERVAL);
+};
+
 window.addEventListener('load', function () {
     Meteor.startup(function () {
         Tracker.autorun(function () {
@@ -24,8 +47,8 @@ window.addEventListener('load', function () {
             }
         });
     });
+    userPresenceControl();
 });
-
 window.onload = function () {
     const $ = require('./vendor/jquery-3.1.1');
     function checkExternalUrl (e) {
@@ -34,7 +57,6 @@ window.onload = function () {
         if (RegExp(`^${location.protocol}\/\/${location.host}`).test(href)) {
             return;
         }
-
         // Check href matching relative URL
         if (!/^([a-z]+:)?\/\//.test(href)) {
             return;
@@ -65,19 +87,3 @@ document.addEventListener('drop', e => e.preventDefault());
 
 const spellChecker = new SpellCheck();
 spellChecker.enable();
-
-/**
- * Keep user online if they are still using their computer
- */
-const AWAY_TIME = 300000; // 5 mins
-const INTERVAL = 10000; // 10 seconds
-setInterval(function () {
-    try {
-        const idleTime = ipcRenderer.sendSync('getSystemIdleTime');
-        if (idleTime < AWAY_TIME) {
-            Meteor.call('UserPresence:online');
-        }
-    } catch (e) {
-        console.error(`Error getting system idle time: ${e}`);
-    }
-}, INTERVAL);

--- a/src/public/preload.js
+++ b/src/public/preload.js
@@ -19,18 +19,11 @@ const userPresenceControl = () => {
     UserPresence.stopTimer(); //stop userpresence control
     const AWAY_TIME = 300000; // 5 min
     const INTERVAL = 10000; // 10s
-    let userOnline = true;
     setInterval(() => {
         try {
             const idleTime = ipcRenderer.sendSync('getSystemIdleTime');
-            if (idleTime < AWAY_TIME && !userOnline) {
-                Meteor.call('UserPresence:online');
-                userOnline = true;
-            }
-            if (idleTime >= AWAY_TIME && userOnline) {
-                if (!userOnline) { return; }
-                Meteor.call('UserPresence:away');
-                userOnline = false;
+            if (idleTime < AWAY_TIME) {
+                UserPresence.setOnline();
             }
         } catch (e) {
             console.error(`Error getting system idle time: ${e}`);


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #498

Refactor the code so instead of sending a keep alive every 10 seconds, we actually manage user presence status in the app. Every 10 seconds we still check if the user is idle or not, but only call Meteor when we change states.