### PR TITLE
Enhancements to OSX Notifications

### DIFF
--- a/src/background.custom.js
+++ b/src/background.custom.js
@@ -8,13 +8,7 @@ import windowStateKeeper from './background/windowState';
 import certificate from './background/certificate';
 import idle from '@paulcbetts/system-idle-time';
 import { checkForUpdates } from './background/autoUpdate';
-import jetpack from 'fs-jetpack';
 
-const appDataDir = jetpack.cwd(app.getAppPath());
-const packageJson = appDataDir.read('./package.json', 'json');
-if (packageJson && packageJson.build && packageJson.build.appId) {
-    global.BUNDLE_ID = packageJson.build.appId;
-}
 
 process.env.GOOGLE_API_KEY = 'AIzaSyADqUh_c1Qhji3Cp1NE43YrcpuPkmhXD-c';
 

--- a/src/public/lib/Notification.js
+++ b/src/public/lib/Notification.js
@@ -1,10 +1,10 @@
-const { ipcRenderer, remote } = require('electron');
+const { ipcRenderer } = require('electron');
 
 if (process.platform === 'darwin') {
     const NodeNotification = require('node-mac-notifier');
-    window.Notification = class extends NodeNotification {
+    window.Notification = class Notification extends NodeNotification {
         constructor (title, options) {
-            options.bundleId = remote.getGlobal('BUNDLE_ID');
+            options.bundleId = `chat.rocket`;
             super(title, options);
         }
 

--- a/src/public/lib/Notification.js
+++ b/src/public/lib/Notification.js
@@ -6,6 +6,10 @@ if (process.platform === 'darwin') {
         constructor (title, options) {
             options.bundleId = `chat.rocket`;
             super(title, options);
+            this.addEventListener('click', (/*notification*/) => {
+                ipcRenderer.send('focus');
+                ipcRenderer.sendToHost('focus');
+            });
         }
 
         static requestPermission () {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

FIX #193

`BundleId` is undefined in packaged version which caused wrong App Icon to show up. Also, clicking on the notification now focus back to the App main window.