### PR TITLE
Fix minimised start on Windows

### DIFF
--- a/src/background.custom.js
+++ b/src/background.custom.js
@@ -114,13 +114,17 @@ export function afterMainWindow (mainWindow) {
 
     app.on('activate', function () {
         mainWindow.show();
+        mainWindowState.saveState(mainWindow);
     });
 
     mainWindow.webContents.on('will-navigate', function (event) {
         event.preventDefault();
     });
 
-    ipcMain.on('focus', () => mainWindow.show());
+    ipcMain.on('focus', () => {
+        mainWindow.show();
+        mainWindowState.saveState(mainWindow);
+    });
 
     ipcMain.on('getSystemIdleTime', (event) => {
         event.returnValue = idle.getIdleTime();


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #499 #300

<!-- INSTRUCTION: Tell us more about your PR -->
The app remembers its previous state, so if you close it minimised then it will open minimised etc. There were a couple of places missing where it saves the state when you restore the window, so after you hide it once, it always open hidden.