### PR TITLE
[FIX] Fix for leaking jitsi url to webview

### DIFF
--- a/src/scripts/webview.js
+++ b/src/scripts/webview.js
@@ -68,7 +68,9 @@ class WebView extends EventEmitter {
         webviewObj.setAttribute('disablewebsecurity', 'on');
 
         webviewObj.addEventListener('did-navigate-in-page', (lastPath) => {
-            this.saveLastPath(host.url, lastPath.url);
+            if ((lastPath.url).includes(host.url)) {
+                this.saveLastPath(host.url, lastPath.url);
+            }
         });
 
         webviewObj.addEventListener('console-message', function (e) {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

Jitsi meeting url was being saved to the webview, overwriting the server url and making the electron app unusable, only fix was removing the server and adding again (or changing url via DevTools).

This fix should solve that and other possible leaks due to iframe url being saved to the webview. 