### PR TITLE
[NEW] Adds extra validation on minimizing or restoring the window

### DIFF
--- a/src/scripts/tray.js
+++ b/src/scripts/tray.js
@@ -69,7 +69,10 @@ function createAppTray () {
     };
 
     mainWindow.on('show', onShow);
+    mainWindow.on('restore', onShow);
+
     mainWindow.on('hide', onHide);
+    mainWindow.on('minimize', onHide);
 
     _tray.setToolTip(remote.app.getName());
 
@@ -78,6 +81,7 @@ function createAppTray () {
     });
 
     _tray.on('click', () => {
+        console.log('click');
         mainWindow.show();
     });
 

--- a/src/scripts/tray.js
+++ b/src/scripts/tray.js
@@ -81,7 +81,6 @@ function createAppTray () {
     });
 
     _tray.on('click', () => {
-        console.log('click');
         mainWindow.show();
     });
 

--- a/src/scripts/tray.js
+++ b/src/scripts/tray.js
@@ -81,6 +81,10 @@ function createAppTray () {
     });
 
     _tray.on('click', () => {
+        if (mainWindow.isVisible()) {
+            return mainWindow.hide();
+        }
+
         mainWindow.show();
     });
 


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/DesktopApp 

closes #44 

When minimizing/restoring the window it doesn't fire the "open/close" events,
so if you minimize it and right-click the tray icon you will see "Hide" option (incorrect one),
clicking it won't change anything as the window is already hidden.