### PR TITLE
[FIX] window-size: fix error on loading screen

### DIFF
--- a/src/background/windowState.js
+++ b/src/background/windowState.js
@@ -9,7 +9,7 @@ import _ from 'lodash';
 export default function (name, defaults) {
 
     const userDataDir = jetpack.cwd(app.getPath('userData'));
-    const stateStoreFile = 'window-state-' + name +'.json';
+    const stateStoreFile = `window-state-${name}.json`;
     let state = {
         width: defaults.width,
         height: defaults.height
@@ -41,10 +41,10 @@ export default function (name, defaults) {
     };
 
     return {
-        get x () { return state.x; },
-        get y () { return state.y; },
-        get width () { return state.width; },
-        get height () { return state.height; },
+        get x () { return Math.floor(state.x); },
+        get y () { return Math.floor(state.y); },
+        get width () { return Math.floor(state.width); },
+        get height () { return Math.floor(state.height); },
         get isMaximized () { return state.isMaximized; },
         get isMinimized () { return state.isMinimized; },
         get isHidden () { return state.isHidden; },

--- a/src/helpers/window.js
+++ b/src/helpers/window.js
@@ -31,10 +31,10 @@ export default function (name, options) {
         const position = win.getPosition();
         const size = win.getSize();
         return {
-            x: position[0],
-            y: position[1],
-            width: size[0],
-            height: size[1]
+            x: Math.floor(position[0]),
+            y: Math.floor(position[1]),
+            width: Math.floor(size[0]),
+            height: Math.floor(size[1])
         };
     };
 


### PR DESCRIPTION
the window size (height/widhth, x/y) should all be integers

if window tried to load with float numbers it was throwing errors
on the main process.

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/DesktopApp 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #540 
