### PR TITLE
[FIX] Add camera plug in snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,6 +17,7 @@ apps:
       - gsettings
       - pulseaudio
       - opengl
+      - camera
 parts:
   app:
     plugin: dump


### PR DESCRIPTION
The snap package does not have access to the camera.
Camera is added in the plugs list. The app still needs to be manually connected
after install tough, because the camera interface is not an
`auto-connect` one.
(see https://docs.snapcraft.io/reference/interfaces).

<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/desktopapp 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #601

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
