### PR TITLE
[NEW] add osx shortcut to enter full screen

### DIFF
--- a/src/i18n/lang/de_DE.i18n.json
+++ b/src/i18n/lang/de_DE.i18n.json
@@ -65,6 +65,7 @@
     "Toggle_Menu_Bar": "MenuBar ein-/ausblenden",
     "Toggle_Server_List": "Server Liste ein-/ausblenden",
     "Toggle_Tray_Icon": "Symbole in Menüleiste ein-/ausblenden",
+    "Toggle_Full_Screen": "Vollbildmodus",
     "Undo": "Widerrufen",
     "Update_Available": "Aktualisierung verfügbar",
     "Update_Available_message": "Eine neue Version der Rocket.Chat Desktop App ist verfügbar!",

--- a/src/i18n/lang/en.i18n.json
+++ b/src/i18n/lang/en.i18n.json
@@ -69,6 +69,7 @@
     "Toggle_Menu_Bar": "Toggle Menu Bar",
     "Toggle_Server_List": "Toggle Server List",
     "Toggle_Tray_Icon": "Toggle Tray Icon",
+    "Toggle_Full_Screen": "Toogle Full Screen",
     "Undo": "Undo",
     "Update_Available": "Update Available",
     "Update_Available_message": "A new version of the Rocket.Chat Desktop App is available!",

--- a/src/scripts/menus/view.js
+++ b/src/scripts/menus/view.js
@@ -99,7 +99,15 @@ if (isMac) {
             tray.toggle();
         },
         position: 'after=toggle'
-    });
+    }, {
+        label: i18n.__('Toggle_Full_Screen'),
+        accelerator: 'Control+Command+F',
+        click: function () {
+            const mainWindow = remote.getCurrentWindow();
+            mainWindow.setFullScreen(!mainWindow.isFullScreen());
+        },
+        position: 'after=toggle'
+        });
 } else {
     viewTemplate.push({
         label: i18n.__('Toggle_Menu_Bar'),


### PR DESCRIPTION
[NEW] Add shortcut to enter full screen on osx.

Add new menu item to the view menu to enter full screen by menu an keyboard shortcut.

(Default option in all osx applications)