### PR TITLE
[FIX] cve 2018 1000136

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rocketchat",
   "productName": "Rocket.Chat+",
   "description": "Rocket.Chat Native Cross-Platform Desktop Application via Electron.",
-  "version": "2.10.5",
+  "version": "2.10.6",
   "author": "Rocket.Chat Support <support@rocket.chat>",
   "copyright": "© 2018, Rocket.Chat",
   "homepage": "https://rocket.chat",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   "devDependencies": {
     "chai": "^4.1.2",
     "conventional-changelog-cli": "^1.3.9",
-    "electron": "^1.8.2",
+    "electron": "^1.8.4",
     "electron-builder": "^19.56.0",
     "electron-mocha": "^5.0.0",
     "eslint": "^4.17.0",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: rocketchat-desktop
-version: 2.10.5
+version: 2.10.6
 summary: Rocket.Chat+
 description: Rocket.Chat Native Cross-Platform Desktop Application via Electron.
 confinement: strict

--- a/yarn.lock
+++ b/yarn.lock
@@ -1504,9 +1504,9 @@ electron-window@^0.8.0:
   dependencies:
     is-electron-renderer "^2.0.0"
 
-electron@^1.8.2:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.8.2.tgz#a817cd733c2972b3c7cc4f777caf6e424b88014d"
+electron@^1.8.4:
+  version "1.8.7"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.8.7.tgz#373c1dc4589d7ab4acd49aff8db4a1c0a6c3bcc1"
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^3.0.1"


### PR DESCRIPTION
@RocketChat/desktopapp 
Closes #720 

It's just bumping the electron dependency to the current patch release which includes fixes to address the remote code execution vulnerability.