### PR TITLE
[New] Add snap and tar.gz as linux targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
         "MimeType": "x-scheme-handler/rocketchat"
       },
       "target": [
+        "tar.gz",
+        "snap",
         "deb",
         "rpm"
       ]


### PR DESCRIPTION
@RocketChat/desktopapp 

Closes #762 

Add snap and tar.gz as additional linux targets in order to support systems that doesn't use neither rpm nor deb package managers. E.g. I use gentoo and it doesn't work with deb and rpm package managers. So in order to simplify rocket chat app usage I need installer either for snap or just simple tar.gz.