### PR TITLE
[FIX] Correctly use category for Linux targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,10 +54,10 @@
     },
     "linux": {
       "desktop": {
-        "Categories": "GNOME;GTK;Network;InstantMessaging",
         "StartupWMClass": "Rocket.Chat+",
         "MimeType": "x-scheme-handler/rocketchat"
       },
+      "category": "GNOME;GTK;Network;InstantMessaging",
       "target": [
         "deb",
         "rpm"


### PR DESCRIPTION
@RocketChat/desktopapp 

Closes #680

Stumbled upon this while checking out #763 (may collide with this PR) and saw that the definition for Linux targets seems to have changed in electron builder.
With this change the category is set correctly in the `*.desktop` file.
