### PR TITLE
[FIX] for #794 macOS dock badge not clearing anymore

### DIFF
--- a/src/scripts/start.js
+++ b/src/scripts/start.js
@@ -11,8 +11,12 @@ import './menus';
 sidebar.on('badge-setted', function () {
     const badge = sidebar.getGlobalBadge();
 
-    if (process.platform === 'darwin' && badge.showAlert) {
-        remote.app.dock.setBadge(badge.count.toString());
+    if (process.platform === 'darwin') {
+        if (badge.count > 0) {
+            remote.app.dock.setBadge(badge.count.toString());
+        } else {
+            remote.app.dock.setBadge(badge.title);
+        }
     }
 
     if (process.platform === 'win32') {


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/desktopapp 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #794

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Adapted the code to always update the badge with either the number of unread highlights (priority) or the existing old notification title (for the "dot" notification in case there are no highlights but activity).
