### PR TITLE
FIX: Remove developer debug window during screen share

### DIFF
--- a/src/public/jitsi-preload.js
+++ b/src/public/jitsi-preload.js
@@ -4,7 +4,6 @@ const electron = require('electron');
 const { remote } = require('electron');
 const selfBrowserWindow = remote.getCurrentWindow();
 
-selfBrowserWindow.webContents.openDevTools({ mode: 'detach' });
 selfBrowserWindow.webContents.once('dom-ready', () => {
     window.JitsiMeetElectron = {
         /**


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/desktopapp 

Right now when you try to share your screen it opens a developer window.

