### PR TITLE
[FIX] osx menubar icon use to much space

### DIFF
--- a/src/scripts/tray.js
+++ b/src/scripts/tray.js
@@ -150,7 +150,12 @@ function showTrayAlert (badge, status = 'online') {
         if (remote.systemPreferences.isDarkMode()) {
             countColor = messageCountColor['white'];
         }
-        mainWindow.tray.setTitle(`${statusBullet[status]} ${countColor}${badge.title}`);
+        
+        let trayTitle = `${statusBullet[status]}`;
+        if(hasMentions) {
+            trayTitle = `${statusBullet[status]} ${countColor}${badge.title}`;
+        }
+        mainWindow.tray.setTitle(trayTitle);
         remote.app.dock.setBadge(badge.title);
     }
 

--- a/src/scripts/tray.js
+++ b/src/scripts/tray.js
@@ -150,9 +150,9 @@ function showTrayAlert (badge, status = 'online') {
         if (remote.systemPreferences.isDarkMode()) {
             countColor = messageCountColor['white'];
         }
-        
+
         let trayTitle = `${statusBullet[status]}`;
-        if(hasMentions) {
+        if (hasMentions) {
             trayTitle = `${statusBullet[status]} ${countColor}${badge.title}`;
         }
         mainWindow.tray.setTitle(trayTitle);


### PR DESCRIPTION
Fix for: OSX menubar icon use to much space

I fixed the issue [#813](https://github.com/RocketChat/Rocket.Chat.Electron/issues/813)
Now the counter will be shown only if you mentioned else, it would be removed (counter) so you have much more space.

Closes #813 