### PR TITLE
[FIX] Support On-Premise Jitsi screen sharing

### DIFF
--- a/src/public/preload.js
+++ b/src/public/preload.js
@@ -13,7 +13,8 @@ window.i18n = i18n;
 const defaultWindowOpen = window.open;
 
 function customWindowOpen (url, frameName, features) {
-    if (url.indexOf('meet.jit.si') !== -1) {
+    const jitsiDomain = RocketChat.settings.get('Jitsi_Domain');
+    if (url.indexOf(jitsiDomain) !== -1) {
         features = ((features) ? (features + ",") : "") +
             "nodeIntegration=true,preload=" + path.join(__dirname, 'jitsi-preload.js');
         return defaultWindowOpen(url, frameName, features);

--- a/src/public/preload.js
+++ b/src/public/preload.js
@@ -14,7 +14,7 @@ const defaultWindowOpen = window.open;
 
 function customWindowOpen (url, frameName, features) {
     const jitsiDomain = RocketChat.settings.get('Jitsi_Domain');
-    if (url.indexOf(jitsiDomain) !== -1) {
+    if (jitsiDomain && url.indexOf(jitsiDomain) !== -1) {
         features = ((features) ? (features + ",") : "") +
             "nodeIntegration=true,preload=" + path.join(__dirname, 'jitsi-preload.js');
         return defaultWindowOpen(url, frameName, features);


### PR DESCRIPTION
The current code that enables Jitsi screen sharing works only with the public Jitsi servers.

This fix uses the preferences field to decide if the js file should be loaded. The default value of the field is the same as the existing string used, so should work fine for public server out of the box.

@RocketChat/desktopapp 


