### PR TITLE
[WIP] [FIX] Tray icon module

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -10,13 +10,14 @@ import certificate from './background/certificate';
 import { addServer, createMainWindow, getMainWindow } from './background/mainWindow';
 import menus from './background/menus';
 import './background/screenshare';
+import tray from './background/tray';
 
 import i18n from './i18n/index.js';
 import env from './env';
 
 export { default as showAboutDialog } from './background/aboutDialog';
 export { default as remoteServers } from './background/servers';
-export { certificate, menus };
+export { certificate, menus, tray };
 
 process.env.GOOGLE_API_KEY = 'AIzaSyADqUh_c1Qhji3Cp1NE43YrcpuPkmhXD-c';
 

--- a/src/background/mainWindow.js
+++ b/src/background/mainWindow.js
@@ -33,7 +33,6 @@ const attachWindowStateHandling = (mainWindow) => {
 	});
 
 	app.on('before-quit', () => {
-		mainWindowState.saveState(mainWindow);
 		mainWindowState.saveState.flush();
 		mainWindow = null;
 	});

--- a/src/background/mainWindow.js
+++ b/src/background/mainWindow.js
@@ -11,6 +11,7 @@ import windowStateKeeper from './windowState';
 import env from '../env';
 
 let mainWindow = null;
+let hideOnClose = true;
 
 const mainWindowOptions = {
 	width: 1000,
@@ -49,11 +50,11 @@ const attachWindowStateHandling = (mainWindow) => {
 		event.preventDefault();
 		if (mainWindow.isFullScreen()) {
 			mainWindow.once('leave-full-screen', () => {
-				mainWindow.hide();
+				(process.platform === 'darwin' && hideOnClose) ? mainWindow.hide() : mainWindow.destroy();
 			});
 			mainWindow.setFullScreen(false);
 		} else {
-			mainWindow.hide();
+			(process.platform === 'darwin' && hideOnClose) ? mainWindow.hide() : mainWindow.destroy();
 		}
 		mainWindowState.saveState(mainWindow);
 	});
@@ -64,6 +65,14 @@ const attachWindowStateHandling = (mainWindow) => {
 
 	mainWindow.on('move', () => {
 		mainWindowState.saveState(mainWindow);
+	});
+
+	mainWindow.on('tray-created', () => {
+		hideOnClose = true;
+	});
+
+	mainWindow.on('tray-destroyed', () => {
+		hideOnClose = false;
 	});
 };
 

--- a/src/background/menus.js
+++ b/src/background/menus.js
@@ -307,7 +307,7 @@ class Menus extends EventEmitter {
 			...this.state,
 			...partialState,
 		};
-		this.update();
+		this.emit('update');
 	}
 
 	getItem(id) {

--- a/src/background/tray.js
+++ b/src/background/tray.js
@@ -1,9 +1,7 @@
-import { remote } from 'electron';
+import { app, systemPreferences, Menu, Tray as TrayIcon } from 'electron';
 import { EventEmitter } from 'events';
 import path from 'path';
 import i18n from '../i18n/index.js';
-
-const { Tray: TrayIcon, Menu, app, systemPreferences } = remote;
 
 const getTrayIconFileNameSuffix = ({ badge: { title, count, showAlert } }) => {
 	if (title === '•') {
@@ -26,7 +24,7 @@ const getTrayIconPath = (state) => {
 		darwin: 'osx',
 	}[process.platform];
 	const fileName = `icon-tray-${ getTrayIconFileNameSuffix(state) }.${ process.platform === 'win32' ? 'ico' : 'png' }`;
-	return path.join(__dirname, 'images', iconDir, fileName);
+	return path.join(__dirname, 'public', 'images', iconDir, fileName);
 };
 
 const getTrayIconTitle = ({ badge: { title, count, showAlert }, status, showUserStatus }) => {

--- a/src/background/tray.js
+++ b/src/background/tray.js
@@ -95,7 +95,7 @@ class Tray extends EventEmitter {
 		this.trayIcon.on('click', () => this.emit('set-main-window-visibility', !isMainWindowVisible));
 		this.trayIcon.on('right-click', (event, bounds) => this.trayIcon.popUpContextMenu(undefined, bounds));
 
-		this.emit('tray-created');
+		this.emit('created');
 	}
 
 	destroyTrayIcon() {
@@ -104,7 +104,7 @@ class Tray extends EventEmitter {
 		}
 
 		this.trayIcon.destroy();
-		this.emit('tray-destroyed');
+		this.emit('destroyed');
 		this.trayIcon = null;
 	}
 

--- a/src/scripts/events.js
+++ b/src/scripts/events.js
@@ -183,8 +183,8 @@ export default () => {
 	getCurrentWindow().on('minimize', updateWindowState);
 	getCurrentWindow().on('restore', updateWindowState);
 
-	tray.on('tray-created', () => getCurrentWindow().emit('tray-created'));
-	tray.on('tray-destroyed', () => getCurrentWindow().emit('tray-destroyed'));
+	tray.on('created', () => getCurrentWindow().emit('tray-created'));
+	tray.on('destroyed', () => getCurrentWindow().emit('tray-destroyed'));
 	tray.on('set-main-window-visibility', (visible) =>
 		(visible ? getCurrentWindow().show() : getCurrentWindow().hide()));
 	tray.on('quit', () => app.quit());

--- a/src/scripts/events.js
+++ b/src/scripts/events.js
@@ -1,11 +1,10 @@
 import { remote, ipcRenderer } from 'electron';
 import servers from './servers';
 import sidebar from './sidebar';
-import tray from './tray';
 import webview from './webview';
 
 const { app, getCurrentWindow, shell } = remote;
-const { certificate, menus, showAboutDialog } = remote.require('./background');
+const { certificate, menus, showAboutDialog, tray } = remote.require('./background');
 
 export default () => {
 	menus.on('quit', () => app.quit());

--- a/src/scripts/events.js
+++ b/src/scripts/events.js
@@ -202,6 +202,10 @@ export default () => {
 		}
 	});
 
+	webview.on('ipc-message-user-status-manually-set', (hostUrl, [status]) => {
+		tray.setState({ status });
+	});
+
 	ipcRenderer.on('render-taskbar-icon', (event, messageCount) => {
 		// Create a canvas from unread messages
 		function createOverlayIcon(messageCount) {

--- a/src/scripts/tray.js
+++ b/src/scripts/tray.js
@@ -4,9 +4,9 @@ import { remote } from 'electron';
 import path from 'path';
 import i18n from '../i18n/index.js';
 
-const { Tray, Menu } = remote;
+const { Tray, Menu, getCurrentWindow } = remote;
 
-const mainWindow = remote.getCurrentWindow();
+const mainWindow = getCurrentWindow();
 
 const icons = {
 	win32: {
@@ -130,7 +130,10 @@ function createAppTray() {
 }
 
 let state = {
-	badge: null,
+	badge: {
+		title: '',
+		count: 0,
+	},
 	status: 'online',
 };
 

--- a/src/scripts/tray.js
+++ b/src/scripts/tray.js
@@ -9,16 +9,10 @@ const { Tray, Menu, app, getCurrentWindow, systemPreferences } = remote;
 
 const mainWindow = getCurrentWindow();
 
-const icons = {
-	win32: {
-		dir: 'windows',
-	},
-	linux: {
-		dir: 'linux',
-	},
-	darwin: {
-		dir: 'osx',
-	},
+const iconsDir = {
+	win32: 'windows',
+	linux: 'linux',
+	darwin: 'osx',
 };
 
 const statusBullet = {
@@ -55,7 +49,7 @@ function getTrayImagePath(badge) {
 		iconFilename += '.png';
 	}
 
-	return path.join(__dirname, 'images', icons[process.platform].dir, iconFilename);
+	return path.join(__dirname, 'images', iconsDir[process.platform], iconFilename);
 }
 
 const createContextMenuTemplate = ({ isHidden }, events) => ([

--- a/src/scripts/tray.js
+++ b/src/scripts/tray.js
@@ -5,7 +5,7 @@ import i18n from '../i18n/index.js';
 
 const { Tray, Menu, app, getCurrentWindow, systemPreferences } = remote;
 
-const mainWindow = getCurrentWindow();
+let trayIcon = null;
 
 const getTrayIconFileNameSuffix = ({ badge: { title, count, showAlert } }) => {
 	if (title === '•') {
@@ -61,11 +61,11 @@ const createContextMenuTemplate = ({ isHidden }, events) => ([
 	},
 ]);
 
-function createAppTray() {
-	const _tray = new Tray(getTrayIconPath({ badge: { title:'', count:0, showAlert:false } }));
-	_tray.setToolTip(app.getName());
+const mainWindow = getCurrentWindow();
 
-	mainWindow.tray = _tray;
+function createAppTray() {
+	trayIcon = new Tray(getTrayIconPath({ badge: { title:'', count:0, showAlert:false } }));
+	trayIcon.setToolTip(app.getName());
 
 	const events = new EventEmitter();
 
@@ -75,7 +75,7 @@ function createAppTray() {
 		};
 		const template = createContextMenuTemplate(state, events);
 		const menu = Menu.buildFromTemplate(template);
-		_tray.setContextMenu(menu);
+		trayIcon.setContextMenu(menu);
 	};
 
 	events.on('setVisibility', (visible) => {
@@ -93,11 +93,11 @@ function createAppTray() {
 
 	updateContextMenu();
 
-	_tray.on('right-click', function(event, bounds) {
-		_tray.popUpContextMenu(undefined, bounds);
+	trayIcon.on('right-click', function(event, bounds) {
+		trayIcon.popUpContextMenu(undefined, bounds);
 	});
 
-	_tray.on('click', () => {
+	trayIcon.on('click', () => {
 		if (mainWindow.isVisible() && !mainWindow.isMinimized()) {
 			return mainWindow.hide();
 		}
@@ -110,7 +110,7 @@ function createAppTray() {
 		mainWindow.removeListener('show', updateContextMenu);
 		mainWindow.removeListener('minimize', updateContextMenu);
 		mainWindow.removeListener('restore', updateContextMenu);
-		_tray.destroy();
+		trayIcon.destroy();
 		mainWindow.emit('tray-destroyed');
 	};
 
@@ -127,7 +127,7 @@ let state = {
 };
 
 function showTrayAlert(badge, status = 'online') {
-	if (mainWindow.tray === null || mainWindow.tray === undefined) {
+	if (trayIcon === null || trayIcon === undefined) {
 		return;
 	}
 
@@ -156,7 +156,7 @@ function showTrayAlert(badge, status = 'online') {
 	if (process.platform === 'darwin') {
 		app.dock.setBadge(badge.title);
 		if (trayDisplayed) {
-			mainWindow.tray.setTitle(getTrayIconTitle({ badge, status: statusDisplayed && status }));
+			trayIcon.setTitle(getTrayIconTitle({ badge, status: statusDisplayed && status }));
 		}
 	}
 
@@ -165,7 +165,7 @@ function showTrayAlert(badge, status = 'online') {
 	}
 
 	if (trayDisplayed) {
-		mainWindow.tray.setImage(getTrayIconPath({ badge }));
+		trayIcon.setImage(getTrayIconPath({ badge }));
 	}
 }
 

--- a/src/scripts/tray.js
+++ b/src/scripts/tray.js
@@ -3,7 +3,7 @@ import { EventEmitter } from 'events';
 import path from 'path';
 import i18n from '../i18n/index.js';
 
-const { Tray, Menu, app, systemPreferences } = remote;
+const { Tray: TrayIcon, Menu, app, systemPreferences } = remote;
 
 const getTrayIconFileNameSuffix = ({ badge: { title, count, showAlert } }) => {
 	if (title === '•') {
@@ -60,7 +60,7 @@ const createContextMenuTemplate = ({ isMainWindowVisible }, events) => ([
 	},
 ]);
 
-class SystemTray extends EventEmitter {
+class Tray extends EventEmitter {
 	constructor() {
 		super();
 
@@ -90,7 +90,7 @@ class SystemTray extends EventEmitter {
 	}
 
 	createTrayIcon() {
-		this.trayIcon = new Tray(getTrayIconPath(this.state));
+		this.trayIcon = new TrayIcon(getTrayIconPath(this.state));
 		this.trayIcon.setToolTip(app.getName());
 
 		const { isMainWindowVisible } = this.state;
@@ -140,4 +140,4 @@ class SystemTray extends EventEmitter {
 	}
 }
 
-export default new SystemTray();
+export default new Tray();

--- a/src/scripts/tray.js
+++ b/src/scripts/tray.js
@@ -123,7 +123,10 @@ function createAppTray() {
 		mainWindow.removeListener('show', onShow);
 		mainWindow.removeListener('hide', onHide);
 		_tray.destroy();
+		mainWindow.emit('tray-destroyed');
 	};
+
+	mainWindow.emit('tray-created');
 }
 
 let state = {

--- a/src/scripts/webview.js
+++ b/src/scripts/webview.js
@@ -92,8 +92,7 @@ class WebView extends EventEmitter {
 					servers.setActive(host.url);
 					break;
 				case 'user-status-manually-set':
-					const badge = sidebar.getGlobalBadge();
-					tray.showTrayAlert(badge, event.args[0]);
+					tray.setState({ status: event.args[0] });
 					break;
 				case 'get-sourceId':
 					desktopCapturer.getSources({ types: ['window', 'screen'] }, (error, sources) => {

--- a/src/scripts/webview.js
+++ b/src/scripts/webview.js
@@ -1,7 +1,6 @@
 import { EventEmitter } from 'events';
 import servers from './servers';
 import sidebar from './sidebar';
-import tray from './tray';
 import { desktopCapturer, ipcRenderer } from 'electron';
 
 class WebView extends EventEmitter {
@@ -90,9 +89,6 @@ class WebView extends EventEmitter {
 					break;
 				case 'focus':
 					servers.setActive(host.url);
-					break;
-				case 'user-status-manually-set':
-					tray.setState({ status: event.args[0] });
 					break;
 				case 'get-sourceId':
 					desktopCapturer.getSources({ types: ['window', 'screen'] }, (error, sources) => {


### PR DESCRIPTION
- [x] Close window instead of hide it if there is no tray icon (closes #847)
- [x] Make tray icon properties (including context menu) reactive
- [x] Detach tray icon module from main window module
- [x] Move tray icon handling to main process
- [x] Don't persist window state before application quit (due to event lifecycle inconsistency; close #851)