### PR TITLE
[NEW] Disable autoupdate on windows installer

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -35,3 +35,21 @@
     Delete "$SMSTARTUP\Rocket.Chat.lnk"
   ${EndIf}
 !macroend
+
+!macro disableAutoUpdates
+  ${GetParameters} $R0
+  ClearErrors
+  ${GetOptions} $R0 "--disableAutoUpdates" $R1
+  ${IfNot} ${Errors}
+    MessageBox mb_ok $R1
+  ${EndIf}
+!macroend
+
+!macro writeUpdateFile
+  FileOpen $4 "$PROFILE\update.json" w
+  FileWrite $4 "{$\r$\n"
+  FileWrite $4 " \"autoUpdate\": \"false\"$\r$\n"
+  FileWrite $4 "}"
+  FileWrite $4 "$\r$\n"
+  FileClose $4
+!macroend

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -27,6 +27,7 @@
   ${Else}
     DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\66bed7da-e601-54e6-b2e8-7be611d82556"
   ${EndIf}
+  !insertMacro disableAutoUpdates
   Delete "$SMSTARTUP\Rocket.Chat+.lnk"
 !macroend
 
@@ -39,16 +40,17 @@
 !macro disableAutoUpdates
   ${GetParameters} $R0
   ClearErrors
-  ${GetOptions} $R0 "--disableAutoUpdates" $R1
+  ${GetOptions} $R0 "/disableAutoUpdates" $R1
   ${IfNot} ${Errors}
-    MessageBox mb_ok $R1
+    !insertMacro writeUpdateFile
   ${EndIf}
 !macroend
 
 !macro writeUpdateFile
-  FileOpen $4 "$PROFILE\update.json" w
+  FileOpen $4 "$APPDATA\Rocket.Chat\update.json" w
   FileWrite $4 "{$\r$\n"
-  FileWrite $4 " \"autoUpdate\": \"false\"$\r$\n"
+  FileWrite $4 '  "canUpdate": false,$\r$\n'
+  FileWrite $4 '  "autoUpdate": false$\r$\n'
   FileWrite $4 "}"
   FileWrite $4 "$\r$\n"
   FileClose $4

--- a/src/background/autoUpdate.js
+++ b/src/background/autoUpdate.js
@@ -130,7 +130,7 @@ function updateAvailable({ version }) {
 export const canUpdate = () => {
 	return (updateSettings.canUpdate) && (
 		(process.platform === 'linux' && Boolean(process.env.APPIMAGE)) ||
-    	(process.platform === 'win32' && !process.windowsStore) ||
+    		(process.platform === 'win32' && !process.windowsStore) ||
 		(process.platform === 'darwin' && !process.mas)
 	);
 };

--- a/src/background/autoUpdate.js
+++ b/src/background/autoUpdate.js
@@ -19,7 +19,7 @@ const loadUpdateSettings = (dir) => {
 const appUpdateSettings = loadUpdateSettings(appDir);
 const userUpdateSettings = loadUpdateSettings(userDataDir);
 const updateSettings = (() => {
-	const defaultUpdateSettings = { autoUpdate: true };
+	const defaultUpdateSettings = { autoUpdate: true, canUpdate: true };
 
 	if (appUpdateSettings.forced) {
 		return Object.assign({}, defaultUpdateSettings, appUpdateSettings);
@@ -127,10 +127,13 @@ function updateAvailable({ version }) {
 	});
 }
 
-export const canUpdate = () =>
-	(process.platform === 'linux' && Boolean(process.env.APPIMAGE)) ||
-    (process.platform === 'win32' && !process.windowsStore) ||
-    (process.platform === 'darwin' && !process.mas);
+export const canUpdate = () => {
+	return (updateSettings.canUpdate) && (
+		(process.platform === 'linux' && Boolean(process.env.APPIMAGE)) ||
+    	(process.platform === 'win32' && !process.windowsStore) ||
+		(process.platform === 'darwin' && !process.mas)
+	);
+};
 
 export const canAutoUpdate = () => updateSettings.autoUpdate !== false;
 


### PR DESCRIPTION
[NEW] Allow setup to disable autoupdate

Closes #849 

you can run the installer with the option "/disableAutoUpdates" to disable the update function in rocket.chat (like the windows App Store version)

 