### PR TITLE
Change back and forward shortcuts

### DIFF
--- a/src/background/menus.js
+++ b/src/background/menus.js
@@ -134,12 +134,12 @@ const createTemplate = ({
 			},
 			{
 				label: i18n.__('&Back'),
-				accelerator: process.platform === 'darwin' ? 'Command+Left' : 'Alt+Left',
+				accelerator: process.platform === 'darwin' ? 'Command+[' : 'Alt+Left',
 				click: () => events.emit('go-back'),
 			},
 			{
 				label: i18n.__('&Forward'),
-				accelerator: process.platform === 'darwin' ? 'Command+Right' : 'Alt+Right',
+				accelerator: process.platform === 'darwin' ? 'Command+]' : 'Alt+Right',
 				click: () => events.emit('go-forward'),
 			},
 			{


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [IMPROVE] For non-breaking changes that enhance some existing feature -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/electron

I wish I could add them both as shortcuts, but it seems to not be supported right on menu, so only doing few workarounds (like listening to global events or duplicating the menu)..

the motivations are:

* <kbd>⌘</kbd> + <kbd>[</kbd> seems to be used by the majority
* <kbd>⌘</kbd> + <kbd>←</kbd> have another behavior if you're on a text field (exactly where you're most of the time on rocket.chat) that is to go the beginning of the line.