### PR TITLE
[FIX] Server icon not displayed on sidebar if server url ending with a trailing slash

### DIFF
--- a/src/scripts/sidebar.js
+++ b/src/scripts/sidebar.js
@@ -168,7 +168,7 @@ class SideBar extends EventEmitter {
 
 	setImage(hostUrl) {
 		const img = this.getByUrl(hostUrl).querySelector('img');
-		img.src = `${ hostUrl.replace(/\\/$/, "") }/assets/favicon.svg?v=${ Math.round(Math.random() * 10000) }`;
+		img.src = `${ hostUrl.replace(/\/$/, '') }/assets/favicon.svg?v=${ Math.round(Math.random() * 10000) }`;
 	}
 
 	remove(hostUrl) {

--- a/src/scripts/sidebar.js
+++ b/src/scripts/sidebar.js
@@ -168,7 +168,7 @@ class SideBar extends EventEmitter {
 
 	setImage(hostUrl) {
 		const img = this.getByUrl(hostUrl).querySelector('img');
-		img.src = `${ hostUrl }/assets/favicon.svg?v=${ Math.round(Math.random() * 10000) }`;
+		img.src = `${ hostUrl.replace(/\\/$/, "") }/assets/favicon.svg?v=${ Math.round(Math.random() * 10000) }`;
 	}
 
 	remove(hostUrl) {


### PR DESCRIPTION
If the server url ending with a trailing slash, the favicon is not displayed in the sidebar url :

![image](https://user-images.githubusercontent.com/1951866/46806718-967f0600-cd68-11e8-928d-fc2cec4f5bbb.png)

![image](https://user-images.githubusercontent.com/1951866/46806730-9e3eaa80-cd68-11e8-84b4-1fd86c335f05.png)

If I add the server without a trailing slash it works :

![image](https://user-images.githubusercontent.com/1951866/46806753-ae568a00-cd68-11e8-900b-1337053ddbc1.png)
