### PR TITLE
[FIX] Autoupdate in MacOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rocketchat",
   "productName": "Rocket.Chat",
   "description": "Rocket.Chat Native Cross-Platform Desktop Application via Electron.",
-  "version": "2.15.0-develop",
+  "version": "2.13.3",
   "author": "Rocket.Chat Support <support@rocket.chat>",
   "copyright": "© 2018, Rocket.Chat",
   "homepage": "https://rocket.chat",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@paulcbetts/system-idle-time": "^1.0.4",
-    "electron-updater": "^3.1.2",
+    "electron-updater": "3.0.4",
     "fs-jetpack": "^2.1.1",
     "lodash": "^4.17.10",
     "spellchecker": "^3.5.0"

--- a/src/background/autoUpdate.js
+++ b/src/background/autoUpdate.js
@@ -1,6 +1,7 @@
-import { app, ipcMain, BrowserWindow, dialog } from 'electron';
+import { app, dialog, ipcMain, BrowserWindow } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import jetpack from 'fs-jetpack';
+import { getMainWindow } from './mainWindow';
 import i18n from '../i18n/index.js';
 
 const appDir = jetpack.cwd(app.getAppPath());
@@ -36,6 +37,42 @@ const saveUpdateSettings = () => {
 
 	userDataDir.write(updateSettingsFileName, userUpdateSettings, { atomic: true });
 };
+
+export const canUpdate = () => updateSettings.canUpdate &&
+	(
+		(process.platform === 'linux' && Boolean(process.env.APPIMAGE)) ||
+		(process.platform === 'win32' && !process.windowsStore) ||
+		(process.platform === 'darwin' && !process.mas)
+	);
+
+export const canAutoUpdate = () => updateSettings.autoUpdate !== false;
+
+export const canSetAutoUpdate = () => !appUpdateSettings.forced || appUpdateSettings.autoUpdate !== false;
+
+export const setAutoUpdate = (canAutoUpdate) => {
+	if (!canSetAutoUpdate()) {
+		return;
+	}
+
+	updateSettings.autoUpdate = userUpdateSettings.autoUpdate = Boolean(canAutoUpdate);
+	saveUpdateSettings();
+};
+
+ipcMain.on('can-update', (event) => {
+	event.returnValue = canUpdate();
+});
+
+ipcMain.on('can-auto-update', (event) => {
+	event.returnValue = canAutoUpdate();
+});
+
+ipcMain.on('can-set-auto-update', (event) => {
+	event.returnValue = canSetAutoUpdate();
+});
+
+ipcMain.on('set-auto-update', (event, canAutoUpdate) => {
+	setAutoUpdate(canAutoUpdate);
+});
 
 let checkForUpdatesEvent;
 
@@ -127,45 +164,30 @@ function updateAvailable({ version }) {
 	});
 }
 
-export const canUpdate = () => {
-	return (updateSettings.canUpdate) && (
-		(process.platform === 'linux' && Boolean(process.env.APPIMAGE)) ||
-    		(process.platform === 'win32' && !process.windowsStore) ||
-		(process.platform === 'darwin' && !process.mas)
-	);
-};
+autoUpdater.autoDownload = false;
 
-export const canAutoUpdate = () => updateSettings.autoUpdate !== false;
+const sendToRenderer = async(channel, ...args) => {
+	const mainWindow = await getMainWindow();
+	const send = () => mainWindow.send(channel, ...args);
 
-export const canSetAutoUpdate = () => !appUpdateSettings.forced || appUpdateSettings.autoUpdate !== false;
-
-export const setAutoUpdate = (canAutoUpdate) => {
-	if (!canSetAutoUpdate()) {
+	if (mainWindow.webContents.isLoading()) {
+		mainWindow.webContents.on('dom-ready', send);
 		return;
 	}
 
-	updateSettings.autoUpdate = userUpdateSettings.autoUpdate = Boolean(canAutoUpdate);
-	saveUpdateSettings();
+	send();
 };
 
-ipcMain.on('can-update', (event) => {
-	event.returnValue = canUpdate();
+autoUpdater.on('error', async(error) => {
+	sendToRenderer('update-error', error);
 });
 
-ipcMain.on('can-auto-update', (event) => {
-	event.returnValue = canAutoUpdate();
+autoUpdater.on('checking-for-update', async() => {
+	sendToRenderer('update-checking');
 });
 
-ipcMain.on('can-set-auto-update', (event) => {
-	event.returnValue = canSetAutoUpdate();
-});
-
-ipcMain.on('set-auto-update', (event, canAutoUpdate) => {
-	setAutoUpdate(canAutoUpdate);
-});
-
-autoUpdater.autoDownload = false;
 autoUpdater.on('update-available', updateAvailable);
+
 autoUpdater.on('update-not-available', updateNotAvailable);
 autoUpdater.on('update-downloaded', updateDownloaded);
 

--- a/src/background/autoUpdate.js
+++ b/src/background/autoUpdate.js
@@ -76,8 +76,8 @@ ipcMain.on('set-auto-update', (event, canAutoUpdate) => {
 
 let checkForUpdatesEvent;
 
-function updateDownloaded() {
-	dialog.showMessageBox({
+async function updateDownloaded() {
+	const response = dialog.showMessageBox({
 		title: i18n.__('Update_ready'),
 		message: i18n.__('Update_ready_message'),
 		buttons: [
@@ -85,17 +85,20 @@ function updateDownloaded() {
 			i18n.__('Update_Install_Now'),
 		],
 		defaultId: 1,
-	}, (response) => {
-		if (response === 0) {
-			dialog.showMessageBox({
-				title: i18n.__('Update_installing_later'),
-				message: i18n.__('Update_installing_later_message'),
-			});
-		} else {
-			autoUpdater.quitAndInstall();
-			setTimeout(() => app.quit(), 1000);
-		}
 	});
+
+	if (response === 0) {
+		dialog.showMessageBox({
+			title: i18n.__('Update_installing_later'),
+			message: i18n.__('Update_installing_later_message'),
+		});
+		return;
+	}
+
+	const mainWindow = await getMainWindow();
+	mainWindow.removeAllListeners();
+	app.removeAllListeners('window-all-closed');
+	autoUpdater.quitAndInstall();
 }
 
 function updateNotAvailable() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1757,9 +1757,9 @@ electron-publish@20.28.3:
     lazy-val "^1.0.3"
     mime "^2.3.1"
 
-electron-updater@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/electron-updater/-/electron-updater-3.1.2.tgz#30d9790d5b16048e4afc74a31748790348b153bf"
+electron-updater@3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/electron-updater/-/electron-updater-3.0.4.tgz#de3f394038a29c5d06815a118279528b039db03f"
   dependencies:
     bluebird-lst "^1.0.5"
     builder-util-runtime "~4.4.1"
@@ -1768,8 +1768,8 @@ electron-updater@^3.1.2:
     js-yaml "^3.12.0"
     lazy-val "^1.0.3"
     lodash.isequal "^4.5.0"
-    semver "^5.5.1"
-    source-map-support "^0.5.9"
+    semver "^5.5.0"
+    source-map-support "^0.5.6"
 
 electron-window@^0.8.0:
   version "0.8.1"
@@ -5922,7 +5922,7 @@ source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.9:
+source-map-support@^0.5.6, source-map-support@^0.5.9:
   version "0.5.9"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"
   dependencies:


### PR DESCRIPTION
Closes #894

Unfortunately, autoupdate fixes can't be applied backwardly. Therefore, versions listed in #894 will fail on update regardlessly; we advise users to click the "Install later" button to update.