### PR TITLE
[FIX] Add additional condition for option "Show on unread"

### DIFF
--- a/src/scripts/events.js
+++ b/src/scripts/events.js
@@ -173,7 +173,8 @@ export default () => {
 	webview.on('ipc-message-unread-changed', (hostUrl, [count]) => {
 		if (typeof count === 'number' && localStorage.getItem('showWindowOnUnreadChanged') === 'true') {
 			const mainWindow = remote.getCurrentWindow();
-			if (!mainWindow.isFocused()) {
+			const isNeededToShow = !mainWindow.isFocused() || (mainWindow.isFocused() && !mainWindow.isVisible());
+			if (isNeededToShow) {
 				mainWindow.once('focus', () => mainWindow.flashFrame(false));
 				mainWindow.showInactive();
 				mainWindow.flashFrame(true);


### PR DESCRIPTION
Add additional condition for option "Show on unread" to show Rocket.Chat window

<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [IMPROVE] For non-breaking changes that enhance some existing feature -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/electron

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #1003 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
The strange behavior of the function `isFocused()` or a bug in it. 
After closing the application to tray (and no to click anywhere), the focus still remains in the application window (`isFocused()` return `True`). If client received a message in this moment then "show on unread" option is not working correctly (No window shown). In this case `isFocused()` returned `True`, but `isVisible()` returned `False`.
If after that we change focus manually (for example click anywhere or go to another window) then function `isFocused()` returned `False` (as expected) and `isVisible()` returned `False` too.  
In order to solve this problem, added an additional condition that handles this situation and shows a window.

The described issue is displayed [in this video. ](https://www.youtube.com/watch?v=QO2nJZXgRGY)