### PR TITLE
[FIX] The behavior of clicking links when running RocketChat with subdir.

### DIFF
--- a/src/public/preload.js
+++ b/src/public/preload.js
@@ -85,8 +85,8 @@ window.addEventListener('load', () => {
 
 		const { href } = anchorElement;
 
-		// Check href matching current domain
-		if (RegExp(`^${ location.protocol }\/\/${ location.host }`).test(href)) {
+		// Check href matching Rochet.Chat URL
+		if (RegExp(`^${ Meteor.absoluteUrl() }`).test(href)) {
 			return;
 		}
 


### PR DESCRIPTION
@RocketChat/electron

If RocketChat be running with a subdir, A link which contains other subdir contents does not work.
I changed the validation code from a pair of protocol and hostname to ROOT_URL of RocketChat.