### PR TITLE
[IMPROVE] Fix remember window state on load

### DIFF
--- a/src/background/windowState.js
+++ b/src/background/windowState.js
@@ -79,9 +79,19 @@ export default (name, defaults) => {
 			window.setSize(this.width, this.height, false);
 		}
 
-		this.isMaximized ? window.maximize() : window.unmaximize();
-		this.isMinimized ? window.minimize() : window.restore();
-		this.isHidden ? window.hide() : window.show();
+		if (this.isMaximized) {
+			window.maximize();
+		} else if (this.isMinimized) {
+			window.minimize();
+		} else {
+			window.restore();
+		}
+
+		if (this.isHidden) {
+			window.hide();
+		} else if (!this.isMinimized) {
+			window.show();
+		}
 	};
 
 	return {


### PR DESCRIPTION
@RocketChat/electron

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
The window state (minimized / maximized) does not persist between when I close and reopen the application. I can see the changes reflected in the `window-state-main.json` file but as soon as the application loads those previous values would be overwritten. This is to correctly set the state (window size) on load of the application.