### PR TITLE
[FIX] Resolves issue with timing out when Rocket.Chat is in the background …

### DIFF
--- a/src/preload/userPresence.js
+++ b/src/preload/userPresence.js
@@ -1,23 +1,18 @@
 import { ipcRenderer } from 'electron';
 import { getMeteor, getTracker, getGetUserPreference, getUserPresence } from './rocketChat';
 
-
 const pollUserPresence = (UserPresence, maximumIdleTime) => {
-	let wasUserPresent = false;
-
+	
 	return () => {
 		let isUserPresent = true;
 
 		try {
 			const idleTime = ipcRenderer.sendSync('request-system-idle-time');
 			isUserPresent = idleTime < maximumIdleTime;
-
-			if (isUserPresent === wasUserPresent) {
-				return;
-			}
-
-			if (isUserPresent) {
+		
+			if (isUserPresent) {	
 				UserPresence.setOnline();
+				
 			} else {
 				UserPresence.setAway();
 			}

--- a/src/preload/userPresence.js
+++ b/src/preload/userPresence.js
@@ -54,6 +54,7 @@ const handleUserPresence = () => {
 		}
 
 		delete UserPresence.awayTime;
+		UserPresence.awayOnWindowBlur = false;
 		UserPresence.start();
 
 		const isAutoAwayEnabled = getUserPreference(uid, 'enableAutoAway');
@@ -64,7 +65,7 @@ const handleUserPresence = () => {
 		}
 
 		const maximumIdleTime = (getUserPreference(uid, 'idleTimeLimit') || 300) * 1000;
-		const idleTimeDetectionInterval = maximumIdleTime / 2;
+		const idleTimeDetectionInterval = 5000;
 		const callback = pollUserPresence(UserPresence, maximumIdleTime);
 
 		intervalID = setInterval(callback, idleTimeDetectionInterval);


### PR DESCRIPTION
@RocketChat/electron

Closes #1260 

Resolves issue with Rocket.Chat client going to away when in the background. Solved it by explicitly setting the awayOnWindowBlur: false instead of relying on the default value

Also, shortened the idleTimeDetectionInterval to 5000 ms. The original value was 1/2 of the idleTimeLimit, which is way too long to change state (e.g. the default of 300 would only check every 150 seconds!)
