### PR TITLE
[CHORE] Fix AppVeyor pipeline for pull requests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,15 +18,14 @@ branches:
     - /^release\/.*$/
 
 install:
+  - ps: Install-Product node $env:nodejs_version $env:platform
+
+build_script:
   - ps: |
       $tmp = New-TemporaryFile
       [Convert]::FromBase64String($env:CSC_LINK) | Set-Content ($tmp.FullName + ".p12") -Encoding Byte
       $env:CSC_LINK = ($tmp.FullName + ".p12")
-  - ps: Install-Product node $env:nodejs_version $env:platform
-  - set CI=true
   - yarn
   - yarn test
   - yarn e2e
-
-build_script:
   - yarn release


### PR DESCRIPTION
The steps of writing the code signing certificate into a temporary file and running tests should be at the `build_script` section instead of the `install` one. It's expected that can mitigate the building crash that occurs when a pull request is made.