### PR TITLE
fix: Add snap connection for camera

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -105,7 +105,8 @@
 		"artifactName": "rocketchat-${version}.${arch}.${ext}"
 	},
 	"snap": {
-		"artifactName": "rocketchat_${version}_${arch}.${ext}"
+		"artifactName": "rocketchat_${version}_${arch}.${ext}",
+		"plugs": ["desktop", "desktop-legacy", "home", "x11", "unity7", "browser-support", "network", "gsettings", "pulseaudio", "opengl", "camera"]
 	},
 	"afterSign": "./build/notarize.js",
 	"publish": [


### PR DESCRIPTION
<!-- feat: For new features -->

<!-- INSTRUCTION: Keep the line below to notify the developers about this new PR -->
@RocketChat/frontend

This PR adds the "camera" connection for SnapCraft, which is not added by default from electron-builder.

Without it a user can not use the webcam during video chat, and AFAIK has no way to add it manually.

In addition the user needs to connect the camera manually once:

	snap connect rocketchat-desktop:camera

We should probably mention this in the docs as well.

Thoughts?

See:
* https://www.electron.build/configuration/snap
* https://snapcraft.io/docs/supported-interfaces