### PR TITLE
fix: Command line args handling on packaged apps

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -72,7 +72,9 @@ function AppContent() {
 				return;
 			}
 
-			remote.app.relaunch({ args: [remote.process.argv[1], '--reset-app-data'] });
+			const command = remote.process.argv.slice(0, remote.app.isPackaged ? 1 : 2);
+
+			remote.app.relaunch({ args: [...command.slice(1), '--reset-app-data'] });
 			remote.app.quit();
 		});
 

--- a/src/main.js
+++ b/src/main.js
@@ -24,10 +24,17 @@ const prepareApp = () => {
 
 	app.setPath('userData', path.join(app.getPath('appData'), dirName));
 
-	if (process.argv[2] === '--reset-app-data') {
+	const [command, args] = [
+		process.argv.slice(0, app.isPackaged ? 1 : 2),
+		process.argv.slice(app.isPackaged ? 1 : 2),
+	];
+
+	console.log(args);
+
+	if (args.includes('--reset-app-data')) {
 		const dataDir = app.getPath('userData');
 		rimraf.sync(dataDir);
-		app.relaunch({ args: [process.argv[1]] });
+		app.relaunch({ args: [...command.slice(1)] });
 		app.exit();
 		return;
 	}

--- a/src/sagas/deepLinks.js
+++ b/src/sagas/deepLinks.js
@@ -54,11 +54,13 @@ function *takeAppEvents() {
 	});
 
 	yield takeEvery(secondInstanceChannel, function *([, argv]) {
-		yield all(argv.slice(2).map((arg) => fork(processDeepLink, arg)));
+		const args = argv.slice(remote.app.isPackaged ? 1 : 2);
+		yield all(args.map((arg) => fork(processDeepLink, arg)));
 	});
 }
 
 export function *deepLinksSaga() {
 	yield *takeAppEvents();
-	yield all(remote.process.argv.slice(2).map((arg) => fork(processDeepLink, arg)));
+	const args = remote.process.argv.slice(remote.app.isPackaged ? 1 : 2);
+	yield all(args.map((arg) => fork(processDeepLink, arg)));
 }


### PR DESCRIPTION
It handles both `./electron /path` and `./rocketchat-desktop` CLI invocations.