### PR TITLE
fix: Minimum width in split view on OS X is 600px

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -70,7 +70,7 @@ const createMainWindow = () => {
 	const mainWindow = new BrowserWindow({
 		width: 1000,
 		height: 600,
-		minWidth: 600,
+		minWidth: 400,
 		minHeight: 400,
 		titleBarStyle: 'hidden',
 		backgroundColor: '#2f343d',


### PR DESCRIPTION
<!--
INSTRUCTION: Your Pull Request name should start with one of the following
prefixes:

- "feat:" for new features;
- "fix:" for bug fixes.
-->
On macOS, the width is consistent with the web app. 400px for the smallest width is now possible. 
<!-- Inform the issue number that this PR closes, or remove the line below -->
Closes #190

<!-- Tell us more about your PR with screen shots if you can -->
<img width="1183" alt="Screenshot 2020-03-14 at 8 11 53 PM" src="https://user-images.githubusercontent.com/30270349/76684720-285f0280-6630-11ea-98fb-4ab80291bd96.png">
