### PR TITLE
feat: TrayIcon show and hide on focus

### DIFF
--- a/src/components/TrayIcon.js
+++ b/src/components/TrayIcon.js
@@ -17,7 +17,7 @@ import { createEventChannelFromEmitter } from '../sagaUtils';
 
 export function TrayIcon() {
 	const appName = remote.app.name;
-	const isMainWindowToBeShown = useSelector(({ mainWindowState: { visible } }) => !visible);
+	const isMainWindowToBeShown = useSelector(({ mainWindowState: { focused } }) => !focused);
 	const isTrayIconEnabled = useSelector(({ isTrayIconEnabled }) => isTrayIconEnabled);
 
 	const badge = useSelector(({ servers }) => {


### PR DESCRIPTION
<!--
INSTRUCTION: Your Pull Request name should start with one of the following
prefixes:

- "feat:" for new features;
- "fix:" for bug fixes.
-->

<!-- Inform the issue number that this PR closes, or remove the line below -->
Closes #1564 

<!-- Tell us more about your PR with screen shots if you can -->
This is a partial solution to the suggestion present in the issue tagged above. The issue had two feature requests and this PR addresses the first one. They asked for the Tray Menu in macOS to display "show" and "hide" based on whether the rocket chat window is focussed or not or in another workspace and this feature has now been implemented.

Screenshot shows the finder window above in focus and the Rocket.Chat tray menu giving the option to "show" which will bring the Rocket.Chat window into back on top and in focus instead of the previously shown "hide" option: 

<img width="1322" alt="Screenshot 2020-05-03 at 9 46 04 PM" src="https://user-images.githubusercontent.com/30270349/80920184-951c9080-8d87-11ea-9d59-183f9040fa42.png">

