### PR TITLE
fix: Remove wrong entitlements on MAS builds

### DIFF
--- a/build/entitlements.mas.plist
+++ b/build/entitlements.mas.plist
@@ -16,7 +16,5 @@
     <key>com.apple.security.files.user-selected.read-write</key><true/>
     <key>com.apple.security.network.client</key><true/>
     <key>com.apple.security.network.server</key><true/>
-    <key>com.apple.security.temporary-exception.files.absolute-path.read-only</key><true/>
-    <key>com.apple.security.temporary-exception.files.absolute-path.read-write</key><true/>
   </dict>
 </plist>


### PR DESCRIPTION
> com.apple.security.temporary-exception.files.absolute-path.read-only - Value must be string, or array or dictionary of strings, but contains value "True"
