### PR TITLE
fix: Opening links with external protocol

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,8 +1,23 @@
-import { Certificate } from 'electron';
-
-import { Server } from '../servers/common';
-import { Dictionary } from '../spellChecking/common';
-import { WindowState } from '../ui/common';
+import {
+  externalProtocols,
+  trustedCertificates,
+} from '../navigation/reducers';
+import {
+  currentServerUrl,
+  servers,
+} from '../servers/reducers';
+import { spellCheckingDictionaries } from '../spellChecking/reducers';
+import { isMenuBarEnabled } from '../ui/reducers/isMenuBarEnabled';
+import { isShowWindowOnUnreadChangedEnabled } from '../ui/reducers/isShowWindowOnUnreadChangedEnabled';
+import { isSideBarEnabled } from '../ui/reducers/isSideBarEnabled';
+import { isTrayIconEnabled } from '../ui/reducers/isTrayIconEnabled';
+import { mainWindowState } from '../ui/reducers/mainWindowState';
+import {
+  doCheckForUpdatesOnStartup,
+  isEachUpdatesSettingConfigurable,
+  isUpdatingEnabled,
+  skippedUpdateVersion,
+} from '../updates/reducers';
 
 export const APP_ERROR_THROWN = 'app/error-thrown';
 export const APP_PATH_SET = 'app/path-set';
@@ -14,18 +29,19 @@ export type AppActionTypeToPayloadMap = {
   [APP_PATH_SET]: string;
   [APP_VERSION_SET]: string;
   [APP_SETTINGS_LOADED]: {
-    currentServerUrl: Server['url'] | null;
-    doCheckForUpdatesOnStartup: boolean;
-    isEachUpdatesSettingConfigurable: boolean;
-    isMenuBarEnabled: boolean;
-    isShowWindowOnUnreadChangedEnabled: boolean;
-    isSideBarEnabled: boolean;
-    isTrayIconEnabled: boolean;
-    isUpdatingEnabled: boolean;
-    mainWindowState: WindowState;
-    servers: Server[];
-    skippedUpdateVersion: string | null;
-    spellCheckingDictionaries: Dictionary[];
-    trustedCertificates: Record<Server['url'], Certificate['fingerprint']>;
+    currentServerUrl: ReturnType<typeof currentServerUrl>;
+    doCheckForUpdatesOnStartup: ReturnType<typeof doCheckForUpdatesOnStartup>;
+    externalProtocols: ReturnType<typeof externalProtocols>;
+    isEachUpdatesSettingConfigurable: ReturnType<typeof isEachUpdatesSettingConfigurable>;
+    isMenuBarEnabled: ReturnType<typeof isMenuBarEnabled>;
+    isShowWindowOnUnreadChangedEnabled: ReturnType<typeof isShowWindowOnUnreadChangedEnabled>;
+    isSideBarEnabled: ReturnType<typeof isSideBarEnabled>;
+    isTrayIconEnabled: ReturnType<typeof isTrayIconEnabled>;
+    isUpdatingEnabled: ReturnType<typeof isUpdatingEnabled>;
+    mainWindowState: ReturnType<typeof mainWindowState>;
+    servers: ReturnType<typeof servers>;
+    skippedUpdateVersion: ReturnType<typeof skippedUpdateVersion>;
+    spellCheckingDictionaries: ReturnType<typeof spellCheckingDictionaries>;
+    trustedCertificates: ReturnType<typeof trustedCertificates>;
   };
 };

--- a/src/app/selectors.ts
+++ b/src/app/selectors.ts
@@ -1,6 +1,10 @@
 import { createStructuredSelector } from 'reselect';
 
-export const selectPersistableValues = createStructuredSelector({
+import { ActionOf } from '../store/actions';
+import { RootState } from '../store/rootReducer';
+import { APP_SETTINGS_LOADED } from './actions';
+
+export const selectPersistableValues = createStructuredSelector<Partial<RootState>, ActionOf<typeof APP_SETTINGS_LOADED>['payload']>({
   currentServerUrl: ({ currentServerUrl }) => currentServerUrl,
   doCheckForUpdatesOnStartup: ({ doCheckForUpdatesOnStartup }) => doCheckForUpdatesOnStartup,
   isMenuBarEnabled: ({ isMenuBarEnabled }) => isMenuBarEnabled,
@@ -14,4 +18,5 @@ export const selectPersistableValues = createStructuredSelector({
   trustedCertificates: ({ trustedCertificates }) => trustedCertificates,
   isEachUpdatesSettingConfigurable: ({ isEachUpdatesSettingConfigurable }) => isEachUpdatesSettingConfigurable,
   isUpdatingEnabled: ({ isUpdatingEnabled }) => isUpdatingEnabled,
+  externalProtocols: ({ externalProtocols }) => externalProtocols,
 });

--- a/src/i18n/en.i18n.json
+++ b/src/i18n/en.i18n.json
@@ -95,6 +95,13 @@
       "announcement": "Select Certificate",
       "select": "Select",
       "validDates": "Valid from {{-validStart,}} to {{-validExpiry,}}"
+    },
+    "openingExternalProtocol": {
+      "title": "Link with custom protocol",
+      "message": "{{- protocol }} link requires an external application.",
+      "detail": "The requested link is {{- url }} . Do you want to continue?",
+      "yes": "Yes",
+      "no": "No"
     }
   },
   "error": {

--- a/src/i18n/en.i18n.json
+++ b/src/i18n/en.i18n.json
@@ -100,6 +100,7 @@
       "title": "Link with custom protocol",
       "message": "{{- protocol }} link requires an external application.",
       "detail": "The requested link is {{- url }} . Do you want to continue?",
+      "dontAskAgain": "Always open these types of links in the associated app",
       "yes": "Yes",
       "no": "No"
     }

--- a/src/navigation/actions.ts
+++ b/src/navigation/actions.ts
@@ -8,6 +8,7 @@ export const CERTIFICATES_CLIENT_CERTIFICATE_REQUESTED = 'certificates/client-ce
 export const CERTIFICATES_UPDATED = 'certificates/updated';
 export const SELECT_CLIENT_CERTIFICATE_DIALOG_CERTIFICATE_SELECTED = 'select-client-certificate-dialog/certificate-selected';
 export const SELECT_CLIENT_CERTIFICATE_DIALOG_DISMISSED = 'select-client-certificatedialog/dismissed';
+export const EXTERNAL_PROTOCOL_PERMISSION_UPDATED = 'navigation/external-protocol-permission-updated';
 
 export type NavigationActionTypeToPayloadMap = {
   [CERTIFICATES_CLEARED]: never;
@@ -16,4 +17,5 @@ export type NavigationActionTypeToPayloadMap = {
   [CERTIFICATES_UPDATED]: Record<Server['url'], Certificate['fingerprint']>;
   [SELECT_CLIENT_CERTIFICATE_DIALOG_CERTIFICATE_SELECTED]: Certificate['fingerprint'];
   [SELECT_CLIENT_CERTIFICATE_DIALOG_DISMISSED]: never;
+  [EXTERNAL_PROTOCOL_PERMISSION_UPDATED]: { protocol: string; allowed: boolean };
 };

--- a/src/navigation/reducers.ts
+++ b/src/navigation/reducers.ts
@@ -11,6 +11,7 @@ import {
   CERTIFICATES_UPDATED,
   CERTIFICATES_CLEARED,
   CERTIFICATES_LOADED,
+  EXTERNAL_PROTOCOL_PERMISSION_UPDATED,
 } from './actions';
 
 type ClientCertificatesActionTypes = (
@@ -52,6 +53,32 @@ export const trustedCertificates: Reducer<Record<Server['url'], Certificate['fin
     case APP_SETTINGS_LOADED: {
       const { trustedCertificates = state } = action.payload;
       return trustedCertificates;
+    }
+
+    default:
+      return state;
+  }
+};
+
+type ExternalProtocolsAction = (
+  ActionOf<typeof APP_SETTINGS_LOADED>
+  | ActionOf<typeof EXTERNAL_PROTOCOL_PERMISSION_UPDATED>
+);
+
+export const externalProtocols: Reducer<Record<string, boolean>, ExternalProtocolsAction> = (state = {}, action) => {
+  switch (action.type) {
+    case APP_SETTINGS_LOADED: {
+      const { externalProtocols } = action.payload;
+      state = externalProtocols;
+      return state;
+    }
+
+    case EXTERNAL_PROTOCOL_PERMISSION_UPDATED: {
+      state = {
+        ...state,
+        [action.payload.protocol]: action.payload.allowed,
+      };
+      return state;
     }
 
     default:

--- a/src/store/rootReducer.ts
+++ b/src/store/rootReducer.ts
@@ -4,6 +4,7 @@ import { appPath } from '../app/reducers/appPath';
 import { appVersion } from '../app/reducers/appVersion';
 import {
   clientCertificates,
+  externalProtocols,
   trustedCertificates,
 } from '../navigation/reducers';
 import {
@@ -35,6 +36,7 @@ const reducersMap = {
   clientCertificates,
   currentServerUrl,
   doCheckForUpdatesOnStartup,
+  externalProtocols,
   isCheckingForUpdates,
   isEachUpdatesSettingConfigurable,
   isMenuBarEnabled,

--- a/src/ui/main/dialogs.ts
+++ b/src/ui/main/dialogs.ts
@@ -124,3 +124,20 @@ export const warnAboutUpdateSkipped = async (parentWindow: BrowserWindow = getRo
     defaultId: 0,
   });
 };
+
+export const askForOpeningExternalProtocol = async (url: URL, parentWindow: BrowserWindow = getRootWindow()): Promise<{
+  allowed: boolean;
+}> => {
+  const { response } = await dialog.showMessageBox(parentWindow, {
+    type: 'warning',
+    buttons: [t('dialog.openingExternalProtocol.yes'), t('dialog.openingExternalProtocol.no')],
+    defaultId: 1,
+    title: t('dialog.openingExternalProtocol.title'),
+    message: t('dialog.openingExternalProtocol.message', { protocol: url.protocol }),
+    detail: t('dialog.openingExternalProtocol.detail', { url: url.toString() }),
+  });
+
+  return {
+    allowed: response === 0,
+  };
+};

--- a/src/ui/main/dialogs.ts
+++ b/src/ui/main/dialogs.ts
@@ -127,17 +127,21 @@ export const warnAboutUpdateSkipped = async (parentWindow: BrowserWindow = getRo
 
 export const askForOpeningExternalProtocol = async (url: URL, parentWindow: BrowserWindow = getRootWindow()): Promise<{
   allowed: boolean;
+  dontAskAgain: boolean;
 }> => {
-  const { response } = await dialog.showMessageBox(parentWindow, {
+  const { response, checkboxChecked } = await dialog.showMessageBox(parentWindow, {
     type: 'warning',
     buttons: [t('dialog.openingExternalProtocol.yes'), t('dialog.openingExternalProtocol.no')],
     defaultId: 1,
     title: t('dialog.openingExternalProtocol.title'),
     message: t('dialog.openingExternalProtocol.message', { protocol: url.protocol }),
     detail: t('dialog.openingExternalProtocol.detail', { url: url.toString() }),
+    checkboxLabel: t('dialog.openingExternalProtocol.dontAskAgain'),
+    checkboxChecked: false,
   });
 
   return {
     allowed: response === 0,
+    dontAskAgain: checkboxChecked,
   };
 };

--- a/src/ui/main/webviews.ts
+++ b/src/ui/main/webviews.ts
@@ -16,6 +16,7 @@ import {
 } from 'electron';
 import i18next from 'i18next';
 
+import { isProtocolAllowed } from '../../navigation/main';
 import { Server } from '../../servers/common';
 import { Dictionary } from '../../spellChecking/common';
 import { importSpellCheckingDictionaries, getCorrectionsForMisspelling } from '../../spellChecking/main';
@@ -30,7 +31,7 @@ import {
   SIDE_BAR_CONTEXT_MENU_TRIGGERED,
   SIDE_BAR_REMOVE_SERVER_CLICKED,
 } from '../actions';
-import { browseForSpellCheckingDictionary, askForOpeningExternalProtocol } from './dialogs';
+import { browseForSpellCheckingDictionary } from './dialogs';
 
 const t = i18next.t.bind(i18next);
 
@@ -298,18 +299,11 @@ const initializeServerWebContents = (serverUrl: string, guestWebContents: WebCon
 const handleExternalLink = async (rawUrl: string): Promise<void> => {
   const url = new URL(rawUrl);
 
-  const allowedProtocols = ['http:', 'https:', 'mailto:'];
-
-  if (allowedProtocols.includes(url.protocol)) {
-    shell.openExternal(rawUrl);
+  if (!await isProtocolAllowed(url)) {
     return;
   }
 
-  const { allowed } = await askForOpeningExternalProtocol(url);
-
-  if (allowed) {
-    shell.openExternal(rawUrl);
-  }
+  shell.openExternal(rawUrl);
 };
 
 


### PR DESCRIPTION
Links not using schemas like `http:`, `https:`, and `mailto:` can spawn unsafe operations when their protocols are associated to external programs. This PR aims to ask for user permission before triggering anything else.