### PR TITLE
build(osx): Remove unnecessary MAS entitlement

### DIFF
--- a/build/entitlements.mas.plist
+++ b/build/entitlements.mas.plist
@@ -26,7 +26,5 @@
     <true/>
     <key>com.apple.security.network.client</key>
     <true/>
-    <key>com.apple.security.network.server</key>
-    <true/>
   </dict>
 </plist>


### PR DESCRIPTION
It removes unused entitlement blocking Mac App Store submission.