### PR TITLE
fix: Set connection status instead of user's default status

### DIFF
--- a/src/injected.ts
+++ b/src/injected.ts
@@ -62,7 +62,11 @@ const start = (): void => {
       isAutoAwayEnabled,
       idleThreshold,
       setUserOnline: (online) => {
-        Meteor.call('UserPresence:setDefaultStatus', online ? 'online' : 'away');
+        if (!online) {
+          Meteor.call('UserPresence:away');
+          return;
+        }
+        Meteor.call('UserPresence:online');
       },
     });
   });


### PR DESCRIPTION
The idleness detection was changing the user's preferred status instead of changing his connection status, this PR calls the correct Meteor method to set the connection status.