### PR TITLE
fix: Recover minimized/maximized state on show window when unread count changes

### DIFF
--- a/src/ui/main/rootWindow.ts
+++ b/src/ui/main/rootWindow.ts
@@ -153,8 +153,19 @@ export const setupRootWindow = (): void => {
 
       const isShowWindowOnUnreadChangedEnabled = select(({ isShowWindowOnUnreadChangedEnabled }) => isShowWindowOnUnreadChangedEnabled);
 
-      if (isShowWindowOnUnreadChangedEnabled) {
+      if (isShowWindowOnUnreadChangedEnabled && !browserWindow.isVisible()) {
+        const isMinimized = browserWindow.isMinimized();
+        const isMaximized = browserWindow.isMaximized();
+
         browserWindow.showInactive();
+
+        if (isMinimized) {
+          browserWindow.minimize();
+        }
+
+        if (isMaximized) {
+          browserWindow.maximize();
+        }
         return;
       }
 


### PR DESCRIPTION
<!--
INSTRUCTION: Your Pull Request name should start with one of the following
prefixes:

- "feat:" for new features;
- "fix:" for bug fixes.
-->

<!-- Inform the issue number that this PR closes, or remove the line below -->
Closes #1590
Closes #1612

`BrowserWindow`'s API doesn't keep "minimized" and "maximized" window states when a hidden window is shown. So, we should forcedly set it again through imperative methods.

<!-- Tell us more about your PR with screen shots if you can -->
