### PR TITLE
fix: Unavailable languages in electron.session()

### DIFF
--- a/src/spellChecking/main.ts
+++ b/src/spellChecking/main.ts
@@ -8,7 +8,6 @@ import {
 
 export const setupSpellChecking = async (): Promise<void> => {
   const availaibleLanguages = session.fromPartition('persist:rocketchat-server').availableSpellCheckerLanguages;
-  console.log(availaibleLanguages);
   const defaultSessionLanguage = session.defaultSession.getSpellCheckerLanguages();
   const spellCheckerLanguages = availaibleLanguages.includes(defaultSessionLanguage[0]) ? defaultSessionLanguage : ["en-US"];
   session.fromPartition('persist:rocketchat-server').setSpellCheckerLanguages(spellCheckerLanguages);

--- a/src/spellChecking/main.ts
+++ b/src/spellChecking/main.ts
@@ -7,7 +7,10 @@ import {
 } from './actions';
 
 export const setupSpellChecking = async (): Promise<void> => {
-  const spellCheckerLanguages = session.defaultSession.getSpellCheckerLanguages();
+  const availaibleLanguages = session.fromPartition('persist:rocketchat-server').availableSpellCheckerLanguages;
+  console.log(availaibleLanguages);
+  const defaultSessionLanguage = session.defaultSession.getSpellCheckerLanguages();
+  const spellCheckerLanguages = availaibleLanguages.includes(defaultSessionLanguage[0]) ? defaultSessionLanguage : ["en-US"];
   session.fromPartition('persist:rocketchat-server').setSpellCheckerLanguages(spellCheckerLanguages);
 
   listen(SPELL_CHECKING_TOGGLED, (action) => {


### PR DESCRIPTION
<!--
INSTRUCTION: Your Pull Request name should start with one of the following
prefixes:

- "feat:" for new features;
- "fix:" 
-->
- "feat : i18n" 
- "fix:"
<!-- Inform the issue number that this PR closes, or remove the line below -->
Closes #1799

Have set the default language to en-US for the languages unavailable in 
<pre>
session.fromPartition('persist:rocketchat-server').availableSpellCheckerLanguages;
</pre>

Previous Code: 
<pre>
const spellCheckerLanguages = session.defaultSession.getSpellCheckerLanguages();
session.fromPartition('persist:rocketchat-server').setSpellCheckerLanguages(spellCheckerLanguages);
</pre>

Modified code : 
<pre>
const availaibleLanguages = session.fromPartition('persist:rocketchat-server').availableSpellCheckerLanguages;
const defaultSessionLanguage = session.defaultSession.getSpellCheckerLanguages();
const spellCheckerLanguages = availaibleLanguages.includes(defaultSessionLanguage[0]) ? defaultSessionLanguage : ["en-US"];
session.fromPartition('persist:rocketchat-server').setSpellCheckerLanguages(spellCheckerLanguages);
</pre>
<!-- Tell us more about your PR with screen shots if you can -->
