### PR TITLE
fix: Displaying warning every time the window is minimized to tray

### DIFF
--- a/src/ui/main/trayIcon.ts
+++ b/src/ui/main/trayIcon.ts
@@ -75,15 +75,13 @@ const updateTrayIconToolTip = (trayIcon:Tray, globalBadge: Server['badge']): voi
   trayIcon.setToolTip(t('tray.tooltip.noUnreadMessage', { appName: app.name }));
 };
 
-// TODO: uncomment this, and implement a setting to only display this
-// warning once.
-// const warnStillRunning = (trayIcon: Tray): void => {
-//   trayIcon.displayBalloon({
-//     icon: getAppIconPath(),
-//     title: t('tray.balloon.stillRunning.title', { appName: app.name }),
-//     content: t('tray.balloon.stillRunning.content', { appName: app.name }),
-//   });
-// };
+const warnStillRunning = (trayIcon: Tray): void => {
+  trayIcon.displayBalloon({
+    icon: getAppIconPath(),
+    title: t('tray.balloon.stillRunning.title', { appName: app.name }),
+    content: t('tray.balloon.stillRunning.content', { appName: app.name }),
+  });
+};
 
 const manageTrayIcon = async (): Promise<() => void> => {
   const trayIcon = createTrayIcon();
@@ -93,6 +91,8 @@ const manageTrayIcon = async (): Promise<() => void> => {
     updateTrayIconTitle(trayIcon, globalBadge);
     updateTrayIconToolTip(trayIcon, globalBadge);
   });
+
+  let firstTrayIconBalloonShown = false;
 
   const unwatchIsRootWindowVisible = watch(selectIsRootWindowVisible, (isRootWindowVisible, prevIsRootWindowVisible) => {
     const menuTemplate = [
@@ -121,11 +121,10 @@ const manageTrayIcon = async (): Promise<() => void> => {
     const menu = Menu.buildFromTemplate(menuTemplate);
     trayIcon.setContextMenu(menu);
 
-    // TODO: uncomment this, and implement a setting to only display this
-    // warning once.
-    // if (prevIsRootWindowVisible && !isRootWindowVisible && process.platform === 'win32') {
-    //   warnStillRunning(trayIcon);
-    // }
+    if (prevIsRootWindowVisible && !isRootWindowVisible && process.platform === 'win32' && !firstTrayIconBalloonShown) {
+      warnStillRunning(trayIcon);
+      firstTrayIconBalloonShown = true;
+    }
   });
 
   const handleNativeThemeUpdatedEvent = (): void => {

--- a/src/ui/main/trayIcon.ts
+++ b/src/ui/main/trayIcon.ts
@@ -75,13 +75,15 @@ const updateTrayIconToolTip = (trayIcon:Tray, globalBadge: Server['badge']): voi
   trayIcon.setToolTip(t('tray.tooltip.noUnreadMessage', { appName: app.name }));
 };
 
-const warnStillRunning = (trayIcon: Tray): void => {
-  trayIcon.displayBalloon({
-    icon: getAppIconPath(),
-    title: t('tray.balloon.stillRunning.title', { appName: app.name }),
-    content: t('tray.balloon.stillRunning.content', { appName: app.name }),
-  });
-};
+// TODO: uncomment this, and implement a setting to only display this
+// warning once.
+// const warnStillRunning = (trayIcon: Tray): void => {
+//   trayIcon.displayBalloon({
+//     icon: getAppIconPath(),
+//     title: t('tray.balloon.stillRunning.title', { appName: app.name }),
+//     content: t('tray.balloon.stillRunning.content', { appName: app.name }),
+//   });
+// };
 
 const manageTrayIcon = async (): Promise<() => void> => {
   const trayIcon = createTrayIcon();
@@ -119,9 +121,11 @@ const manageTrayIcon = async (): Promise<() => void> => {
     const menu = Menu.buildFromTemplate(menuTemplate);
     trayIcon.setContextMenu(menu);
 
-    if (prevIsRootWindowVisible && !isRootWindowVisible && process.platform === 'win32') {
-      warnStillRunning(trayIcon);
-    }
+    // TODO: uncomment this, and implement a setting to only display this
+    // warning once.
+    // if (prevIsRootWindowVisible && !isRootWindowVisible && process.platform === 'win32') {
+    //   warnStillRunning(trayIcon);
+    // }
   });
 
   const handleNativeThemeUpdatedEvent = (): void => {


### PR DESCRIPTION
The actual fix would be to add a setting to only display this warning
once or never, but for a short term fix this solves the annoying
problem of having a bubble everytime the window is minimized to tray.

<!--
INSTRUCTION: Your Pull Request name should start with one of the following
prefixes:

- "feat:" for new features;
- "fix:" for bug fixes.
-->

<!-- Inform the issue number that this PR closes, or remove the line below -->
Closes #1749

<!-- Tell us more about your PR with screen shots if you can -->
