### PR TITLE
chore(build): Split workflows for push and pull_request events

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@ name: Build
 
 on:
   - push
-  - pull_request
 
 jobs:
   test:
@@ -139,7 +138,6 @@ jobs:
           fi
 
   windows-build:
-    if: ${{ github.event_name == 'push' }}
     needs: smoke-test-windows-build
     runs-on: windows-latest
     steps:
@@ -167,7 +165,6 @@ jobs:
           path: ./dist
 
   macos-build:
-    if: ${{ github.event_name == 'push' }}
     needs: smoke-test-macos-build
     runs-on: macos-latest
     steps:
@@ -193,7 +190,7 @@ jobs:
           CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
           # Variables needed to notarization process:
-          IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
+          IS_PULL_REQUEST: false
           APPLEID: ${{ secrets.APPLEID }}
           APPLEIDPASS: ${{ secrets.APPLEIDPASS }}
       - uses: actions/upload-artifact@v2
@@ -202,7 +199,6 @@ jobs:
           path: ./dist
 
   linux-build:
-    if: ${{ github.event_name == 'push' }}
     needs: smoke-test-linux-build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,125 @@
+name: Build
+
+on:
+  - pull_request
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: '12'
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+      - run: yarn --check-files
+      - run: yarn test
+
+  bundle:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: '12'
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+      - run: yarn --check-files
+      - run: yarn eslint
+      - run: yarn build
+        env:
+          NODE_ENV: production
+      - uses: actions/upload-artifact@v2
+        with:
+          name: app
+          path: ./app
+
+  smoke-test-windows-build:
+    needs: bundle
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: '12'
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+      - run: yarn --check-files
+      - uses: actions/download-artifact@v2
+        with:
+          name: app
+          path: ./app
+      - run: yarn electron-builder --x64 --dir
+      - run: |
+          $job = Start-Job -ScriptBlock { .\dist\win-unpacked\Rocket.Chat.exe }
+          if (Wait-Job $job -Timeout 30) {
+            Write-Host $(Receive-Job -Job $job)
+          }
+          Remove-Job -force $job
+      - run: yarn electron-builder --ia32 --dir
+      - run: |
+          $job = Start-Job -ScriptBlock { .\dist\win-ia32-unpacked\Rocket.Chat.exe }
+          if (Wait-Job $job -Timeout 30) {
+            Write-Host $(Receive-Job -Job $job)
+          }
+          Remove-Job -force $job
+
+  smoke-test-macos-build:
+    needs: bundle
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: '12'
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+      - run: yarn --check-files
+      - uses: actions/download-artifact@v2
+        with:
+          name: app
+          path: ./app
+      - run: yarn electron-builder --dir
+      - run: |
+          brew install coreutils
+          gtimeout 30 ./dist/mac/Rocket.Chat.app/Contents/MacOS/Rocket.Chat || code=$?
+          if [[ $code -ne 124 && $code -ne 0 ]]; then
+            exit $code;
+          fi
+
+  smoke-test-linux-build:
+    needs: bundle
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: '12'
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+      - run: yarn --check-files
+      - uses: actions/download-artifact@v2
+        with:
+          name: app
+          path: ./app
+      - run: yarn electron-builder --dir
+      - run: |
+          xvfb-run timeout 30 ./dist/linux-unpacked/rocketchat-desktop || code=$?
+          if [[ $code -ne 124 && $code -ne 0 ]]; then
+            exit $code;
+          fi


### PR DESCRIPTION
Due to https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets#using-encrypted-secrets-in-a-workflow

> With the exception of GITHUB_TOKEN, secrets are not passed to the runner when a workflow is triggered from a forked repository.

splitting workflows for handling pull requests and pushes would be better to avoiding the accidental usage of encrypted secrets in pull request checks.