### PR TITLE
fix: Broken Jitsi's browser check

### DIFF
--- a/src/navigation/main.ts
+++ b/src/navigation/main.ts
@@ -40,8 +40,7 @@ const serializeCertificate = (certificate: Certificate): string =>
 const queuedTrustRequests = new Map<Certificate['fingerprint'], Array<(isTrusted: boolean) => void>>();
 
 export const setupNavigation = async (): Promise<void> => {
-  app.userAgentFallback = app.userAgentFallback.replace(`Electron/${ process.versions.electron }`, 'Electron');
-  app.userAgentFallback = app.userAgentFallback.replace(`Chrome/${ process.versions.chrome }`, 'Chrome');
+  app.userAgentFallback = app.userAgentFallback.replace(`${ app.name }/${ app.getVersion() } `, '');
 
   app.addListener('certificate-error', async (event, _webContents, requestedUrl, error, certificate, callback) => {
     event.preventDefault();

--- a/src/ui/main/serverView/index.ts
+++ b/src/ui/main/serverView/index.ts
@@ -162,7 +162,7 @@ export const attachGuestWebContentsEvents = async (): Promise<void> => {
       setupPreloadReload(webContents);
     }
 
-    webContents.addListener('new-window', (event, url, _frameName, disposition, options, _additionalFeatures, referrer, postBody) => {
+    webContents.addListener('new-window', (event, url, frameName, disposition, options, _additionalFeatures, referrer, postBody) => {
       event.preventDefault();
 
       if (disposition === 'foreground-tab' || disposition === 'background-tab') {
@@ -191,7 +191,14 @@ export const attachGuestWebContentsEvents = async (): Promise<void> => {
           return;
         }
 
+        const isGoogleSignIn = frameName === 'Login'
+          && disposition === 'new-window'
+          && new URL(url).hostname.match(/accounts.google.com$/);
+
         newWindow.loadURL(url, {
+          userAgent: isGoogleSignIn
+            ? app.userAgentFallback.replace(`Electron/${ process.versions.electron } `, '')
+            : app.userAgentFallback,
           httpReferrer: referrer,
           ...postBody && {
             extraHeaders: `Content-Type: ${ postBody.contentType }; boundary=${ postBody.boundary }`,

--- a/src/ui/main/serverView/index.ts
+++ b/src/ui/main/serverView/index.ts
@@ -193,7 +193,7 @@ export const attachGuestWebContentsEvents = async (): Promise<void> => {
 
         const isGoogleSignIn = frameName === 'Login'
           && disposition === 'new-window'
-          && new URL(url).hostname.match(/accounts.google.com$/);
+          && new URL(url).hostname.match(/(\.)?google\.com$/);
 
         newWindow.loadURL(url, {
           userAgent: isGoogleSignIn


### PR DESCRIPTION
<!--
INSTRUCTION: Your Pull Request name should start with one of the following
prefixes:

- "feat:" for new features;
- "fix:" for bug fixes.
-->

<!-- Inform the issue number that this PR closes, or remove the line below -->
Closes #1834
Closes #1841
Closes #1881

<!-- Tell us more about your PR with screen shots if you can -->
Jitsi tries to check if it's running in an Electron view by locating it's version string in user agent string. Due to a previous spoof, this check fails because it expects an `Electron/x.y.z` pattern which is absent. Spoofing the user agent only for Google subdomains will help a little for now.