### PR TITLE
fix: Preload script in sandboxed iframes

### DIFF
--- a/src/ipc/channels.ts
+++ b/src/ipc/channels.ts
@@ -1,6 +1,7 @@
 import { AnyAction } from 'redux';
 
 import { Download } from '../downloads/common';
+import { Server } from '../servers/common';
 import { SystemIdleState } from '../userPresence/common';
 
 type ChannelToArgsMap = {
@@ -16,6 +17,11 @@ type ChannelToArgsMap = {
   'downloads/cancel': (itemId: Download['itemId']) => void;
   'downloads/retry': (itemId: Download['itemId']) => void;
   'downloads/remove': (itemId: Download['itemId']) => void;
+  'server-view/get-url': () => Server['url'];
+  'server-view/get-initialization-data': () => {
+    serverUrl: Server['url'];
+    injectableCode: string;
+  };
 };
 
 export type Channel = keyof ChannelToArgsMap;

--- a/src/ipc/channels.ts
+++ b/src/ipc/channels.ts
@@ -18,10 +18,7 @@ type ChannelToArgsMap = {
   'downloads/retry': (itemId: Download['itemId']) => void;
   'downloads/remove': (itemId: Download['itemId']) => void;
   'server-view/get-url': () => Server['url'];
-  'server-view/get-initialization-data': () => {
-    serverUrl: Server['url'];
-    injectableCode: string;
-  };
+  'server-view/ready': () => void;
 };
 
 export type Channel = keyof ChannelToArgsMap;

--- a/src/ipc/main.ts
+++ b/src/ipc/main.ts
@@ -28,6 +28,10 @@ export const invoke = <N extends Channel>(
 export const handle = <N extends Channel>(
   channel: N,
   handler: (webContents: WebContents, ...args: Parameters<Handler<N>>) => Promise<ReturnType<Handler<N>>>,
-): void => {
+): (() => void) => {
   ipcMain.handle(channel, (event, ...args: Parameters<Handler<N>>) => handler(event.sender, ...args));
+
+  return () => {
+    ipcMain.removeHandler(channel);
+  };
 };

--- a/src/ipc/renderer.ts
+++ b/src/ipc/renderer.ts
@@ -1,12 +1,12 @@
-import { ipcRenderer } from 'electron';
+import { ipcRenderer, IpcRendererEvent } from 'electron';
 
 import { Handler, Channel } from './channels';
 
 export const handle = <N extends Channel>(
   channel: N,
   handler: (...args: Parameters<Handler<N>>) => Promise<ReturnType<Handler<N>>>,
-): void => {
-  ipcRenderer.on(channel, async (_, id: string, ...args: Parameters<typeof handler>): Promise<void> => {
+): (() => void) => {
+  const listener = async (_: IpcRendererEvent, id: string, ...args: Parameters<typeof handler>): Promise<void> => {
     try {
       const resolved = await handler(...args);
 
@@ -20,7 +20,13 @@ export const handle = <N extends Channel>(
         },
       });
     }
-  });
+  };
+
+  ipcRenderer.on(channel, listener);
+
+  return () => {
+    ipcRenderer.removeListener(channel, listener);
+  };
 };
 
 export const invoke = <N extends Channel>(

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,4 +1,4 @@
-import { contextBridge, webFrame } from 'electron';
+import { contextBridge } from 'electron';
 
 import { setupRendererErrorHandling } from './errors';
 import { invoke } from './ipc/renderer';
@@ -24,7 +24,7 @@ contextBridge.exposeInMainWorld('JitsiMeetElectron', JitsiMeetElectron);
 contextBridge.exposeInMainWorld('RocketChatDesktop', RocketChatDesktop);
 
 const start = async (): Promise<void> => {
-  const { serverUrl, injectableCode } = await invoke('server-view/get-initialization-data');
+  const serverUrl = await invoke('server-view/get-url');
 
   setServerUrl(serverUrl);
 
@@ -34,7 +34,7 @@ const start = async (): Promise<void> => {
 
   setupRendererErrorHandling('webviewPreload');
 
-  await webFrame.executeJavaScript(injectableCode);
+  await invoke('server-view/ready');
 
   if (!serverInfo) {
     return;

--- a/src/ui/main/serverView/index.ts
+++ b/src/ui/main/serverView/index.ts
@@ -305,12 +305,12 @@ export const attachGuestWebContentsEvents = async (): Promise<void> => {
   rootWindow.webContents.addListener('will-attach-webview', handleWillAttachWebview);
   rootWindow.webContents.addListener('did-attach-webview', handleDidAttachWebview);
 
+  handle('server-view/get-url', async (webContents) =>
+    Array.from(webContentsByServerUrl.entries())
+      .find(([, v]) => v === webContents)?.[0]);
+
   let injectableCode: string;
-
-  handle('server-view/get-initialization-data', async (webContents) => {
-    const serverUrl = Array.from(webContentsByServerUrl.entries())
-      .find(([, v]) => v === webContents)?.[0];
-
+  handle('server-view/ready', async (webContents) => {
     if (!injectableCode) {
       injectableCode = await fs.promises.readFile(
         path.join(select(({ appPath }) => appPath), 'app/injected.js'),
@@ -318,9 +318,6 @@ export const attachGuestWebContentsEvents = async (): Promise<void> => {
       );
     }
 
-    return {
-      serverUrl,
-      injectableCode,
-    };
+    webContents.executeJavaScript(injectableCode, true);
   });
 };


### PR DESCRIPTION
Probably related to #1919

The current release candidate of Rocket.Chat server renders oEmbed attachments inside sandboxed iframes. The preload script inside them may crash the server view renderer process (which leads to the gray blank page) if the iframe is unloaded while `webFrame.executeJavaScript()` is running. [This may be an Electron regression](https://github.com/electron/electron/pull/22975). As a workaround, we're only using IPC in the preload script to signal the main process to inject code in the server view via `webContents.executeJavaScript()`.
