### PR TITLE
refactor: Reusable sidebar action's label style component

### DIFF
--- a/src/ui/components/SideBar/index.tsx
+++ b/src/ui/components/SideBar/index.tsx
@@ -17,18 +17,17 @@ import {
 } from '../../actions';
 import {
   AddServerButton,
-  AddServerButtonLabel,
   Avatar,
   Badge,
   Content,
   DownloadsManagerButton,
-  DownloadsManagerLabel,
   Favicon,
   Initials,
   KeyboardShortcut,
   ServerButtonWrapper,
   ServerList,
   Wrapper,
+  SidebarActionButton,
 } from './styles';
 import { useKeyboardShortcuts } from './useKeyboardShortcuts';
 import { useSorting } from './useSorting';
@@ -176,18 +175,18 @@ export const SideBar: FC = () => {
         />)}
       </ServerList>
       <AddServerButton>
-        <AddServerButtonLabel
+        <SidebarActionButton
           tooltip={t('sidebar.addNewServer')}
           onClick={handleAddServerButtonClicked}
-        >+</AddServerButtonLabel>
+        >+</SidebarActionButton>
       </AddServerButton>
       <DownloadsManagerButton>
-        <DownloadsManagerLabel
+        <SidebarActionButton
           tooltip={t('sidebar.downloads')}
           onClick={handelDownloadsButtonClicked}
         >
           <Icon name='download'/>
-        </DownloadsManagerLabel>
+        </SidebarActionButton>
       </DownloadsManagerButton>
     </Content>
   </Wrapper>;

--- a/src/ui/components/SideBar/styles.tsx
+++ b/src/ui/components/SideBar/styles.tsx
@@ -283,3 +283,23 @@ export const DownloadsManagerLabel = styled.span`
 
 	${ withTooltip }
 `;
+
+export const SidebarActionButton = styled.span`
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	width: 40px;
+	height: 40px;
+	line-height: 30px;
+	transition: opacity var(--transitions-duration);
+	opacity: 0.6;
+	color: inherit;
+	background-color: rgba(0, 0, 0, 0.1);
+	cursor: pointer;
+
+	&:hover {
+		opacity: 1;
+	}
+
+	${ withTooltip }
+`;


### PR DESCRIPTION
**Existing**: We have 2 separate style components for both the buttons, which were redundant, and in case we want to add a new button we will have to add a new component.
![Screenshot from 2021-02-26 13-33-05](https://user-images.githubusercontent.com/48203006/109292739-d919de00-7850-11eb-96c3-ce3c1029c1b9.png)
![Screenshot from 2021-02-26 13-33-11](https://user-images.githubusercontent.com/48203006/109292750-dd45fb80-7850-11eb-843d-588d27cee9bd.png)

**Addition**: New reusable style component for the sidebar action labels, **fixes the existing UI issues of "add server", "download" buttons, considering RC's design standards such as 2px border-radius, etc, also it can be used if we add more such action buttons in the future.**

![Screenshot from 2021-02-26 16-38-20](https://user-images.githubusercontent.com/48203006/109292910-14b4a800-7851-11eb-895c-2d1bc8fe81a5.png)
![Screenshot from 2021-02-26 16-38-26](https://user-images.githubusercontent.com/48203006/109292915-15e5d500-7851-11eb-9435-291b411e79a1.png)


Closes #1959
