### PR TITLE
fix: Set server from first entry of serversMap

### DIFF
--- a/src/mainProcess/mergeServers.ts
+++ b/src/mainProcess/mergeServers.ts
@@ -75,6 +75,8 @@ export const mergeServers = async (
     localStorage['rocket.chat.currentHost'] !== 'null'
   ) {
     currentServerUrl = localStorage['rocket.chat.currentHost'];
+  } else if (serversMap.size >= 1) {
+    currentServerUrl = serversMap.keys().next().value;
   }
 
   servers = Array.from(serversMap.values());


### PR DESCRIPTION
Closes #1836 

After importing the servers.json file and on the first launch of the application, the user was presented with the "enter server url" prompt instead of the first entry in the servers.json.  This is a bad experience for organizations.

This really only affects enterprises that want to deploy Rocket.Chat and set servers from servers.json.

This fix assumes the organization would want the first listed server as the default server and really, this is enough to make most organizations happy as they can always deploy a new file with a different order.  Unless for some reason, they really need to list the servers in a different order than what they want the default to be.  In which case a different fix would be needed to select a default server from the servers.json file.