### PR TITLE
fix: Set default server from serversMap

### DIFF
--- a/src/servers/main.ts
+++ b/src/servers/main.ts
@@ -222,7 +222,7 @@ export const setupServers = async (
   servers = Array.from(serversMap.values());
   currentServerUrl = currentServerUrl
     ? serversMap.get(currentServerUrl)?.url ?? servers[0]?.url ?? null
-    : null;
+    : servers[0]?.url;
 
   if (localStorage['rocket.chat.sortOrder']) {
     try {


### PR DESCRIPTION
Closes #1836

After importing the servers.json file and on the first launch of the application, the user was presented with the "enter server url" prompt instead of the first entry in the servers.json. This is a bad experience for organizations.

This really only affects enterprises that want to deploy Rocket.Chat and set servers from servers.json.

This fix assumes the organization would want the first listed server as the default server and really, this is enough to make most organizations happy as they can always deploy a new file with a different order. Unless for some reason, they really need to list the servers in a different order than what they want the default to be. In which case a different fix would be needed to select a default server from the servers.json file.