### PR TITLE
fix: Notification popup click event does not open relevant chat window.

### DIFF
--- a/src/notifications/main.ts
+++ b/src/notifications/main.ts
@@ -149,4 +149,12 @@ export const setupNotifications = (): void => {
   listen(NOTIFICATIONS_NOTIFICATION_DISMISSED, (action) => {
     notifications.get(action.payload.id)?.close();
   });
+  
+  listen(NOTIFICATIONS_NOTIFICATION_CLICKED, async (action) => {
+    notifications.get(action.payload.id)?.close();
+
+    const rootWindow = await getRootWindow();
+    rootWindow.show();
+    rootWindow.focus();
+  });
 };


### PR DESCRIPTION
Closes #2091 and #2007.

When a notification arises, if user clicks on that notification, nothing happens. With this fix, it will open relevant chat window (with proper user) as supposed to be.

Tested locally.
