### PR TITLE
fix: Run menu bar event listeners asynchronously

### DIFF
--- a/src/ui/main/menuBar.ts
+++ b/src/ui/main/menuBar.ts
@@ -493,7 +493,13 @@ const createWindowMenu = createSelector(
         label: t('menus.downloads'),
         checked: currentView === 'downloads',
         accelerator: 'CommandOrControl+D',
-        click: () => {
+        click: async () => {
+          const browserWindow = await getRootWindow();
+
+          if (!browserWindow.isVisible()) {
+            browserWindow.showInactive();
+          }
+          browserWindow.focus();
           dispatch({ type: SIDE_BAR_DOWNLOADS_BUTTON_CLICKED });
         },
       },
@@ -502,7 +508,13 @@ const createWindowMenu = createSelector(
         label: t('menus.settings'),
         checked: currentView === 'settings',
         accelerator: 'CommandOrControl+I',
-        click: () => {
+        click: async () => {
+          const browserWindow = await getRootWindow();
+
+          if (!browserWindow.isVisible()) {
+            browserWindow.showInactive();
+          }
+          browserWindow.focus();
           dispatch({ type: SIDE_BAR_SETTINGS_BUTTON_CLICKED });
         },
       },


### PR DESCRIPTION
<!--
INSTRUCTION: Your Pull Request name should start with one of the following
prefixes:

- "feat:" for new features;
- "fix:" for bug fixes.
-->

Fix for https://github.com/RocketChat/Rocket.Chat/issues/23885

<!-- Inform the issue number that this PR closes, or remove the line below -->

Even listeners for two menu items `downloads` and `settings` were not being run async unlike the other items. This resulted in a crash on clicking those menu items. Fixed and verified the fix by running event listeners for both asynchronously.