### PR TITLE
feat: Add copy image in context menu

### DIFF
--- a/src/i18n/en.i18n.json
+++ b/src/i18n/en.i18n.json
@@ -13,7 +13,8 @@
     "copyLinkAddress": "Copy link address",
     "copyLinkText": "Copy link text",
     "openLink": "Open link",
-    "saveImageAs": "Save image as..."
+    "saveImageAs": "Save image as...",
+    "copyImage": "Copy image"
   },
   "dialog": {
     "about": {

--- a/src/i18n/zh-CN.i18n.json
+++ b/src/i18n/zh-CN.i18n.json
@@ -12,7 +12,8 @@
     "copyLinkAddress": "复制链接URL",
     "copyLinkText": "复制链接文字",
     "openLink": "打开链接",
-    "saveImageAs": "保存图片..."
+    "saveImageAs": "保存图片...",
+    "copyImage": "复制图片"
   },
   "dialog": {
     "about": {

--- a/src/i18n/zh-TW.i18n.json
+++ b/src/i18n/zh-TW.i18n.json
@@ -12,7 +12,8 @@
     "copyLinkAddress": "複製連結",
     "copyLinkText": "複製連結文字",
     "openLink": "開啟連結",
-    "saveImageAs": "儲存影像為..."
+    "saveImageAs": "儲存影像為...",
+    "copyImage": "複製影像"
   },
   "dialog": {
     "about": {

--- a/src/ui/main/serverView/popupMenu.ts
+++ b/src/ui/main/serverView/popupMenu.ts
@@ -117,13 +117,17 @@ const createSpellCheckingMenuTemplate = (
 
 const createImageMenuTemplate = (
   serverViewWebContents: WebContents,
-  { mediaType, srcURL }: ContextMenuParams
+  { mediaType, srcURL, x, y }: ContextMenuParams
 ): MenuItemConstructorOptions[] =>
   mediaType === 'image'
     ? [
         {
           label: t('contextMenu.saveImageAs'),
           click: () => serverViewWebContents.downloadURL(srcURL),
+        },
+        {
+          label: t('contextMenu.copyImage'),
+          click: () => serverViewWebContents.copyImageAt(x, y)
         },
         { type: 'separator' },
       ]


### PR DESCRIPTION
<!--
INSTRUCTION: Your Pull Request name should start with one of the following
prefixes:

- "feat:" for new features;
- "fix:" for bug fixes.
-->

<!-- Inform the issue number that this PR closes, or remove the line below -->
Closes #2205
Closes #1279
Closes #1368

<!-- Tell us more about your PR with screen shots if you can -->
A menu item with name 'Copy image' is added in context menu to make it possible to copy images to clipboard. So, it's not necessary to save the image first if you just want to copy it.
![image](https://user-images.githubusercontent.com/6800026/149621001-c6f3c071-37b2-4464-b83e-f76e945ca9dd.png)


