### PR TITLE
Fix: Stop setting build id links for rpm packages

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -137,6 +137,9 @@
     },
     "artifactName": "rocketchat-${version}-${os}-${arch}.${ext}"
   },
+  "rpm": {
+    "fpm": ["--rpm-rpmbuild-define=_build_id_links none"]
+  },
   "snap": {
     "plugs": [
       "desktop",


### PR DESCRIPTION
Closes #2303 

`rpmbuild` generates build_id links by default, which are debugging symbols for binaries included in a package. This causes problems between Electron applications which share the same Electron binary, as the debugging symbols conflict with each other.

By disabling the generation of these links i can verify that i can install the resulting `rpm` package again along with other Electron applications.

See also : 
- https://unix.stackexchange.com/questions/411727/what-is-the-purpose-of-usr-lib-build-id-dir
- https://github.com/rpm-software-management/rpm/blob/rpm-4.18.x/macros.in#L470
- https://github.com/microsoft/vscode/pull/116105