### PR TITLE
Fix: Add "rocketchat://" scheme for macOS application

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -2,6 +2,10 @@
   "files": ["app/**/*", "package.json"],
   "extraResources": ["build/icon.ico", "servers.json"],
   "appId": "chat.rocket",
+  "protocols": {
+        "name": "Rocket.Chat",
+        "schemes": ["rocketchat"]
+  },
   "mac": {
     "category": "public.app-category.productivity",
     "target": ["dmg", "pkg", "zip", "mas"],


### PR DESCRIPTION
**Issue**
---
Rocket.chat installed from Mac App Store(MAS) not handling `rocketchat://` URL scheme

**To Reproduce:**
1. On macOS that never ran Rocket.chat install app from [MAS](https://apps.apple.com/ru/app/rocket-chat/id1086818840?mt=12), launch it
2. Open `rocketchat://invite` in Safari/Chrome

_Expected result:_ Rocket.chat opens
_Actual result:_ Error

**Why is this happening**
---
MacOS applications are required to specify handled protocols inside `Info.plist`

**Electron:**
- https://www.electronjs.org/docs/latest/tutorial/launch-app-from-url-in-another-app#packaging
> When you package your app you'll need to make sure the macOS Info.plist and the Linux .desktop files for the app are updated to include the new protocol handler. Some of the Electron tools for bundling and distributing apps handle this for you.

**Official documentation:**
- https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app#Register-your-URL-scheme
- https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleurltypes

**But it works on my machine!**
---
- The reason why it works on your machine is that you once ran NON-AppStore version, which is not sandboxed. Runtime scheme registration by electron (`app.setAsDefaultProtocolClient`) works only outside of the sandbox (it uses deprecated `LSSetDefaultHandlerForURLScheme`). Scheme is registered even if you delete the app. You can check this by deleting app and running:
```sh
/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -dump | grep "rocketchat"
```
On machine that never launched Rocket.chat before and just installed it from MAS `app.setAsDefaultProtocolClient('rocketchat')` does not work without URL schemes in Info.plist (issue  https://github.com/electron/electron/issues/21319) 

Another point - check `Slack.app/Contents/Info.plist`, it contains supported URI schemes (search for `CFBundleURLSchemes`) (Rocket.chat does not)

**How to fix**
---
According to `electron-builder`'s documentation we can use protocols:
https://www.electron.build/configuration/configuration.html#PlatformSpecificBuildOptions-protocols
```js
protocols Array<Protocol> | Protocol - The URL protocol schemes.
name String - The name. e.g. IRC server URL.
schemes Array<String> - The schemes. e.g. ["irc", "ircs"].
role = Editor “Editor” | “Viewer” | “Shell” | “None” - macOS-only The app’s role with respect to the type.
```

---
As a result `Info.plist` will contain new entry:
<img width="544" alt="rocket_url" src="https://user-images.githubusercontent.com/3510864/178664199-6d98fa57-0f65-4499-9c44-2c473f46dca3.png">
