### PR TITLE
fix: Added Will-download action on cancel and save

### DIFF
--- a/src/ui/main/serverView/index.ts
+++ b/src/ui/main/serverView/index.ts
@@ -5,6 +5,7 @@ import {
   app,
   BrowserWindow,
   ContextMenuParams,
+  dialog,
   Event,
   Input,
   Menu,
@@ -318,7 +319,20 @@ export const attachGuestWebContentsEvents = async (): Promise<void> => {
     guestWebContents.session.setPermissionRequestHandler(
       handlePermissionRequest
     );
-    guestWebContents.session.on('will-download', handleWillDownloadEvent);
+    guestWebContents.session.on(
+      'will-download',
+      (event, item, _webContents) => {
+        const savePath = dialog.showSaveDialogSync(rootWindow, {
+          defaultPath: item.getFilename(),
+        });
+        if (savePath !== undefined) {
+          item.setSavePath(savePath);
+          handleWillDownloadEvent(event, item, _webContents);
+          return;
+        }
+        event.preventDefault();
+      }
+    );
   });
 
   listen(WEBVIEW_ATTACHED, (action) => {


### PR DESCRIPTION
- fixed the bug in the will-download event listener.
    - Changed the default behavior of the will-download listener.
    - Added custom dialog popup on the listener.
    - Handled both the states of the save path dialog.

Closes https://github.com/RocketChat/Rocket.Chat.Electron/issues/2469
