### PR TITLE
fix: Notification Types for download cancelled & completed added.

### DIFF
--- a/src/downloads/main.ts
+++ b/src/downloads/main.ts
@@ -97,11 +97,14 @@ export const handleWillDownloadEvent = async (
     });
   });
 
-  item.on('done', () => {
+  item.on('done', (_event, state) => {
     createNotification({
       title: 'Downloads',
       body: item.getFilename(),
-      subtitle: t('downloads.notifications.downloadFinished'),
+      subtitle:
+        state === 'completed'
+          ? t('downloads.notifications.downloadFinished')
+          : t('downloads.notifications.downloadCancelled'),
     });
 
     dispatch({

--- a/src/i18n/en.i18n.json
+++ b/src/i18n/en.i18n.json
@@ -114,7 +114,10 @@
   "downloads": {
     "title": "Downloads",
     "notifications": {
-      "downloadFinished": "Download finished"
+      "downloadFinished": "Download Finished",
+      "downloadInterrupted": "Download Interrupted",
+      "downloadCancelled": "Download Cancelled",
+      "downloadFailed": "Download could not be completed"
     },
     "filters": {
       "search": "Search",


### PR DESCRIPTION
Closed #2484

## Issue in brief : 
After starting a new download when we cancel the download, we get a notification that the download has finished, which can be misleading.

## Suggested Fixes / Changes:
When the download item triggers the done event, it can have only 3 states `completed`, `cancelled`, `interrupted`. 

Hence, the possible fix would be to show a different notification when the download is not completed i.e. the download is in the above remaining two states. 

## Demo of the above suggestion : 
![downloadNotSolution2GIF](https://user-images.githubusercontent.com/72302948/186743063-981aaa81-e0c5-4bb1-9f61-4ece9f0e69fb.gif)


