### PR TITLE
fix: Paused downloads after cancellation reflect changes on UI

### DIFF
--- a/src/downloads/main.ts
+++ b/src/downloads/main.ts
@@ -108,7 +108,7 @@ export const handleWillDownloadEvent = async (
       type: DOWNLOAD_UPDATED,
       payload: {
         itemId,
-        state: item.isPaused() ? 'paused' : item.getState(),
+        state: item.getState(),
         status:
           item.getState() === 'cancelled'
             ? DownloadStatus.CANCELLED


### PR DESCRIPTION
Closes #2483

# Issue in brief

User wasn't able to see changes on UI if the user paused the download first and then cancelled that download. Due to this the user wasn't able to `Remove Item from list` nor `Retry` the download!

# Suggested Fixes/Changes

Since the `pause` state on a download item after being **cancelled**(or interrupted/completed) doesn't matter, it was hence causing conflicting issues with the UI changes on the cancelled item! 

Hence I've removed the `pause` state on the item after its **cancelled** and updated the state of the item with its current state i.e. in this case **cancelled** using `item.getState()`

# Demo of the above Suggested Changes

![downloadFixGIF](https://user-images.githubusercontent.com/73993394/186744865-09210085-7953-46e5-8b69-35ea203ff1a2.gif)


