### PR TITLE
fix: handled Download states w.r.t Electron across app restarts

### DIFF
--- a/src/downloads/reducers/downloads.ts
+++ b/src/downloads/reducers/downloads.ts
@@ -6,7 +6,7 @@ import {
   DOWNLOAD_REMOVED,
   DOWNLOAD_UPDATED,
 } from '../actions';
-import { Download } from '../common';
+import { Download, DownloadStatus } from '../common';
 
 type DownloadsAction =
   | ActionOf<typeof APP_SETTINGS_LOADED>
@@ -20,8 +20,16 @@ export const downloads = (
   action: DownloadsAction
 ): Record<Download['itemId'], Download> => {
   switch (action.type) {
-    case APP_SETTINGS_LOADED:
-      return action.payload.downloads ?? {};
+    case APP_SETTINGS_LOADED: {
+      const initDownloads = action.payload.downloads ?? {};
+      Object.values(initDownloads).forEach((value) => {
+        if (value.state === 'progressing' || value.state === 'paused') {
+          value.state = 'cancelled';
+          value.status = DownloadStatus.CANCELLED;
+        }
+      });
+      return initDownloads ?? {};
+    }
 
     case DOWNLOAD_CREATED: {
       const download = action.payload;


### PR DESCRIPTION
Closes #2489

## Issue in brief

When the user pauses a download and then closes the app, on reopening the app they aren't able to `resume` the download or even `remove the download from list`!

## Suggested Fixes/Changes

Since in Electron, when the app is closed, automatically the `cancelled` state is triggered by electron for the DownloadItem, but unfortunately due to the abrupt quitting of the app by the user, the `cancelled` state doesn't get updated properly in our data store!

Hence in-order to tackle the above situation, I thought of changing the state of all the downloads (except `completed` ones) to `cancelled` as the app starts and hence I've made the following change:

- When the app is first loaded after the restart i.e. when `APP_SETTINGS_LOADED` is called upon...
- I iterate through all the download items and change their **`status`** and **`state`** to `cancelled` if their previous states were `progressing` or `paused`!
- The status of a DownloadItem is `paused` if the user had paused the download before closing the app
- The status of a DownloadItem is `progressing` if the download was in progress while closing the app

## Demo of the above Suggested Changes

- Now the user is able to `retry` the cancelled download and even `remove it from the list`!

https://user-images.githubusercontent.com/73993394/186996975-9056f7f6-b9eb-4cae-955f-9f0c971a084e.mp4
