### PR TITLE
fix: Prevents links to navigate to outside of the server URL

### DIFF
--- a/src/injected.ts
+++ b/src/injected.ts
@@ -32,6 +32,9 @@ const start = (): void => {
   const { Meteor } = window.require('meteor/meteor');
   const { Session } = window.require('meteor/session');
   const { Tracker } = window.require('meteor/tracker');
+  const { ServiceConfiguration } = window.require(
+    'meteor/service-configuration'
+  );
   const { UserPresence } = window.require('meteor/konecty:user-presence');
   const { settings } = window.require('/app/settings');
   const { getUserPreference } = window.require('/app/utils');
@@ -77,7 +80,19 @@ const start = (): void => {
   });
 
   Tracker.autorun(() => {
+    const loginsWithRedirect = ServiceConfiguration.configurations
+      .find({ loginStyle: 'redirect' }, { fields: { serverURL: 1 } })
+      .fetch();
+    const array = loginsWithRedirect.map(
+      (url: { serverURL: string }) => url?.serverURL
+    );
+    window.RocketChatDesktop.setServerAllowedRedirects(array || []);
+  });
+
+  Tracker.autorun(() => {
     const { url, defaultUrl } = settings.get('Assets_background') || {};
+
+    console.log('Assets_background', url);
     window.RocketChatDesktop.setBackground(url || defaultUrl);
   });
 

--- a/src/servers/common.ts
+++ b/src/servers/common.ts
@@ -12,6 +12,7 @@ export type Server = {
   webContentsId?: number;
   userLoggedIn?: boolean;
   gitCommitHash?: string;
+  allowedRedirects?: string[];
 };
 
 export const enum ServerUrlResolutionStatus {

--- a/src/servers/preload/api.ts
+++ b/src/servers/preload/api.ts
@@ -8,6 +8,7 @@ import { setBadge } from './badge';
 import { setFavicon } from './favicon';
 import { setGitCommitHash } from './gitCommitHash';
 import { getInternalVideoChatWindowEnabled } from './internalVideoChatWindow';
+import { setServerAllowedRedirects } from './serverAllowedRedirects';
 import { setBackground } from './sidebar';
 import { setTitle } from './title';
 import { setUrlResolver } from './urls';
@@ -44,6 +45,7 @@ export type RocketChatDesktopAPI = {
   destroyNotification: (id: unknown) => void;
   getInternalVideoChatWindowEnabled: () => boolean;
   setGitCommitHash: (gitCommitHash: string) => void;
+  setServerAllowedRedirects: (allowedRedirects: string[]) => void;
 };
 
 export const RocketChatDesktop: RocketChatDesktopAPI = {
@@ -68,4 +70,5 @@ export const RocketChatDesktop: RocketChatDesktopAPI = {
   destroyNotification,
   getInternalVideoChatWindowEnabled,
   setGitCommitHash,
+  setServerAllowedRedirects,
 };

--- a/src/servers/preload/serverAllowedRedirects.ts
+++ b/src/servers/preload/serverAllowedRedirects.ts
@@ -1,0 +1,17 @@
+import { dispatch } from '../../store';
+import { WEBVIEW_ALLOWED_REDIRECTS_CHANGED } from '../../ui/actions';
+import { Server } from '../common';
+import { getServerUrl } from './urls';
+
+export const setServerAllowedRedirects = (
+  allowedRedirects: Server['allowedRedirects']
+): void => {
+  console.log('setServerAllowedRedirects', allowedRedirects);
+  dispatch({
+    type: WEBVIEW_ALLOWED_REDIRECTS_CHANGED,
+    payload: {
+      url: getServerUrl(),
+      allowedRedirects,
+    },
+  });
+};

--- a/src/servers/reducers.ts
+++ b/src/servers/reducers.ts
@@ -18,6 +18,7 @@ import {
   WEBVIEW_READY,
   WEBVIEW_ATTACHED,
   WEBVIEW_GIT_COMMIT_HASH_CHANGED,
+  WEBVIEW_ALLOWED_REDIRECTS_CHANGED,
 } from '../ui/actions';
 import { SERVERS_LOADED } from './actions';
 import { Server } from './common';
@@ -42,6 +43,7 @@ type ServersActionTypes =
   | ActionOf<typeof WEBVIEW_TITLE_CHANGED>
   | ActionOf<typeof WEBVIEW_UNREAD_CHANGED>
   | ActionOf<typeof WEBVIEW_USER_LOGGED_IN>
+  | ActionOf<typeof WEBVIEW_ALLOWED_REDIRECTS_CHANGED>
   | ActionOf<typeof WEBVIEW_FAVICON_CHANGED>
   | ActionOf<typeof APP_SETTINGS_LOADED>
   | ActionOf<typeof WEBVIEW_DID_START_LOADING>
@@ -109,6 +111,11 @@ export const servers: Reducer<Server[], ServersActionTypes> = (
     case WEBVIEW_USER_LOGGED_IN: {
       const { url, userLoggedIn } = action.payload;
       return upsert(state, { url, userLoggedIn });
+    }
+
+    case WEBVIEW_ALLOWED_REDIRECTS_CHANGED: {
+      const { url, allowedRedirects } = action.payload;
+      return upsert(state, { url, allowedRedirects });
     }
 
     case WEBVIEW_SIDEBAR_STYLE_CHANGED: {

--- a/src/ui/actions.ts
+++ b/src/ui/actions.ts
@@ -62,6 +62,8 @@ export const WEBVIEW_GIT_COMMIT_HASH_CHANGED =
 export const WEBVIEW_TITLE_CHANGED = 'webview/title-changed';
 export const WEBVIEW_UNREAD_CHANGED = 'webview/unread-changed';
 export const WEBVIEW_USER_LOGGED_IN = 'webview/user-loggedin';
+export const WEBVIEW_ALLOWED_REDIRECTS_CHANGED =
+  'webview/allowed-redirects-changed';
 export const SETTINGS_SET_REPORT_OPT_IN_CHANGED =
   'settings/set-bugsnag-opt-in-changed';
 export const SETTINGS_SET_FLASHFRAME_OPT_IN_CHANGED =
@@ -129,6 +131,10 @@ export type UiActionTypeToPayloadMap = {
   [WEBVIEW_GIT_COMMIT_HASH_CHANGED]: {
     url: Server['url'];
     gitCommitHash: Server['gitCommitHash'];
+  };
+  [WEBVIEW_ALLOWED_REDIRECTS_CHANGED]: {
+    url: Server['url'];
+    allowedRedirects: Server['allowedRedirects'];
   };
   [SETTINGS_SET_REPORT_OPT_IN_CHANGED]: boolean;
   [SETTINGS_SET_FLASHFRAME_OPT_IN_CHANGED]: boolean;

--- a/src/ui/main/serverView/index.ts
+++ b/src/ui/main/serverView/index.ts
@@ -334,9 +334,23 @@ export const attachGuestWebContentsEvents = async (): Promise<void> => {
       }
     );
 
+    const servers = select(({ servers }) => servers);
     // prevent the guest webContents from navigating away from the server URL
     guestWebContents.on('will-navigate', (e, redirectUrl) => {
-      if (!redirectUrl.startsWith(action.payload.url)) {
+      const server = servers.find(
+        (server) => server.url === action.payload.url
+      );
+
+      const isAllowedRedirect =
+        server &&
+        server.allowedRedirects &&
+        server.allowedRedirects.findIndex((allowedRedirect) =>
+          redirectUrl.startsWith(allowedRedirect)
+        ) > -1;
+
+      console.log('isAllowedRedirect', isAllowedRedirect);
+
+      if (!redirectUrl.startsWith(action.payload.url) && !isAllowedRedirect) {
         e.preventDefault();
         shell.openExternal(redirectUrl);
       }

--- a/src/ui/main/serverView/index.ts
+++ b/src/ui/main/serverView/index.ts
@@ -333,6 +333,14 @@ export const attachGuestWebContentsEvents = async (): Promise<void> => {
         event.preventDefault();
       }
     );
+
+    // prevent the guest webContents from navigating away from the server URL
+    guestWebContents.on('will-navigate', (e, redirectUrl) => {
+      if (!redirectUrl.startsWith(action.payload.url)) {
+        e.preventDefault();
+        shell.openExternal(redirectUrl);
+      }
+    });
   });
 
   listen(WEBVIEW_ATTACHED, (action) => {


### PR DESCRIPTION
If the link is redirecting to outside the server URL, it will open on web browser.
This prevents from the chat being replaced with another URL by clicking on a link. Making the server always stick to its server url.
<!--
INSTRUCTION: Your Pull Request name should start with one of the following
prefixes:

- "feat:" for new features;
- "fix:" for bug fixes.
-->

<!-- Inform the issue number that this PR closes, or remove the line below -->
Closes #2499

<!-- Tell us more about your PR with screen shots if you can -->
