### PR TITLE
fix: Disable Snapcraft upload

### DIFF
--- a/workspaces/desktop-release-action/src/index.ts
+++ b/workspaces/desktop-release-action/src/index.ts
@@ -1,5 +1,5 @@
 import { promises } from 'fs';
-import { basename, extname } from 'path';
+import { basename } from 'path';
 
 import * as core from '@actions/core';
 import * as github from '@actions/github';
@@ -14,14 +14,14 @@ import {
   getTaggedRelease,
   overrideAsset,
 } from './github';
-import { packOnLinux, uploadSnap, setupSnapcraft } from './linux';
+import { packOnLinux } from './linux';
 import { disableSpotlightIndexing, packOnMacOS } from './macos';
 import { packOnWindows } from './windows';
 
 const pack = async () => {
   switch (process.platform) {
     case 'linux':
-      await setupSnapcraft();
+      // await setupSnapcraft();
       await packOnLinux();
       break;
 
@@ -63,14 +63,14 @@ const releaseDevelopment = async (commitSha: string) => {
 
   for (const path of await getFilesToUpload()) {
     const name = basename(path);
-    const extension = extname(path).toLowerCase();
+    // const extension = extname(path).toLowerCase();
     const { size } = await promises.stat(path);
     const data = await promises.readFile(path);
 
     await overrideAsset(release, assets, name, size, data);
-    if (extension === '.snap') {
-      await uploadSnap(path, 'edge');
-    }
+    // if (extension === '.snap') {
+    //   await uploadSnap(path, 'edge');
+    // }
   }
 };
 
@@ -82,14 +82,14 @@ const releaseSnapshot = async (commitSha: string) => {
 
   for (const path of await getFilesToUpload()) {
     const name = basename(path);
-    const extension = extname(path).toLowerCase();
+    // const extension = extname(path).toLowerCase();
     const { size } = await promises.stat(path);
     const data = await promises.readFile(path);
 
     await overrideAsset(release, assets, name, size, data);
-    if (extension === '.snap') {
-      await uploadSnap(path, 'edge');
-    }
+    // if (extension === '.snap') {
+    //   await uploadSnap(path, 'edge');
+    // }
   }
 };
 
@@ -106,20 +106,20 @@ const releaseTagged = async (version: SemVer, commitSha: string) => {
 
   for (const path of await getFilesToUpload()) {
     const name = basename(path);
-    const extension = extname(path).toLowerCase();
+    // const extension = extname(path).toLowerCase();
     const { size } = await promises.stat(path);
     const data = await promises.readFile(path);
 
     await overrideAsset(release, assets, name, size, data);
-    if (extension === '.snap') {
-      await uploadSnap(
-        path,
-        (!version.prerelease && 'stable') ||
-          (version.prerelease[0] === 'candidate' && 'candidate') ||
-          (version.prerelease[0] === 'beta' && 'beta') ||
-          'edge'
-      );
-    }
+    // if (extension === '.snap') {
+    //   await uploadSnap(
+    //     path,
+    //     (!version.prerelease && 'stable') ||
+    //     (version.prerelease[0] === 'candidate' && 'candidate') ||
+    //     (version.prerelease[0] === 'beta' && 'beta') ||
+    //     'edge'
+    //   );
+    // }
   }
 };
 


### PR DESCRIPTION
Disabled Snapcraft uploading from Github Actions while it doesn't have a fix for gnome-keyring headless.
<!--
INSTRUCTION: Your Pull Request name should start with one of the following
prefixes:

- "feat:" for new features;
- "fix:" for bug fixes.
-->

<!-- Inform the issue number that this PR closes, or remove the line below -->


<!-- Tell us more about your PR with screen shots if you can -->
