### PR TITLE
FIX #2530 :SettingsView Added Scrolling By adding Overflow-Y:auto

### DIFF
--- a/src/ui/components/SettingsView/GeneralTab.tsx
+++ b/src/ui/components/SettingsView/GeneralTab.tsx
@@ -12,7 +12,7 @@ import { TrayIcon } from './features/TrayIcon';
 
 export const GeneralTab: FC = () => (
   <Box is='form' margin={24} maxWidth={960} flexGrow={1} flexShrink={1}>
-    <FieldGroup>
+    <FieldGroup >
       <ReportErrors />
       <FlashFrame />
       <HardwareAcceleration />

--- a/src/ui/components/SettingsView/GeneralTab.tsx
+++ b/src/ui/components/SettingsView/GeneralTab.tsx
@@ -12,7 +12,7 @@ import { TrayIcon } from './features/TrayIcon';
 
 export const GeneralTab: FC = () => (
   <Box is='form' margin={24} maxWidth={960} flexGrow={1} flexShrink={1}>
-    <FieldGroup >
+    <FieldGroup>
       <ReportErrors />
       <FlashFrame />
       <HardwareAcceleration />

--- a/src/ui/components/SettingsView/SettingsView.tsx
+++ b/src/ui/components/SettingsView/SettingsView.tsx
@@ -22,6 +22,7 @@ export const SettingsView: FC = () => {
       flexDirection='column'
       height='full'
       backgroundColor='surface'
+     
     >
       <Box
         width='full'
@@ -50,7 +51,7 @@ export const SettingsView: FC = () => {
           {t('settings.certificates')}
         </Tabs.Item>
       </Tabs>
-      <Box m='x24'>
+      <Box m='x24' overflowY='auto'>
         {(currentTab === 'general' && <GeneralTab />) ||
           (currentTab === 'certificates' && <CertificatesTab />)}
       </Box>

--- a/src/ui/components/SettingsView/SettingsView.tsx
+++ b/src/ui/components/SettingsView/SettingsView.tsx
@@ -22,7 +22,6 @@ export const SettingsView: FC = () => {
       flexDirection='column'
       height='full'
       backgroundColor='surface'
-     
     >
       <Box
         width='full'


### PR DESCRIPTION
Closes #2530  

Fix:SettingsView Added Scrolling By adding Overflow-Y:auto

Screenshots->
Before:
![image](https://user-images.githubusercontent.com/58637121/208612864-0aba64d6-164b-4b34-b195-65c2f7e2467d.png)

After:
![Screenshot from 2022-12-20 13-19-58](https://user-images.githubusercontent.com/58637121/208612783-6a050976-2c6f-4285-8217-ec10c1ca0ad2.png)
![Screenshot from 2022-12-20 13-20-11](https://user-images.githubusercontent.com/58637121/208612805-326941b0-89c5-4547-9531-333b2e49c41a.png)


