### PR TITLE
fix: Fix dom-ready not being ready

### DIFF
--- a/src/ui/components/ServersView/ServerPane.tsx
+++ b/src/ui/components/ServersView/ServerPane.tsx
@@ -68,12 +68,14 @@ export const ServerPane: FC<ServerPaneProps> = ({
 
     const handleAttachReady = (): void => {
       step &&
-        dispatch({
-          type: WEBVIEW_READY,
-          payload: {
-            url: serverUrl,
-            webContentsId: webview.getWebContentsId(),
-          },
+        setImmediate(() => {
+          dispatch({
+            type: WEBVIEW_READY,
+            payload: {
+              url: serverUrl,
+              webContentsId: webview.getWebContentsId(),
+            },
+          });
         });
       step = true;
     };
@@ -100,12 +102,14 @@ export const ServerPane: FC<ServerPaneProps> = ({
     };
 
     const handleAttachReady = (): void => {
-      dispatch({
-        type: WEBVIEW_ATTACHED,
-        payload: {
-          url: serverUrl,
-          webContentsId: webview.getWebContentsId(),
-        },
+      setImmediate(() => {
+        dispatch({
+          type: WEBVIEW_ATTACHED,
+          payload: {
+            url: serverUrl,
+            webContentsId: webview.getWebContentsId(),
+          },
+        });
       });
     };
 


### PR DESCRIPTION
<!--
INSTRUCTION: Your Pull Request name should start with one of the following
prefixes:

- "feat:" for new features;
- "fix:" for bug fixes.
-->
![image](https://user-images.githubusercontent.com/1177482/209828541-e6f57d61-e48d-4d7a-93af-b98c8d2a8b96.png)
`Uncaught Error: The WebView must be attached to the DOM and the dom-ready event emitted before this method can be called.
    at WebViewElement.getWebContentsId (node:electron/js2c/renderer_init:105:695)
    at handleAttachReady (ServerPane.tsx:107:34)
    at WebViewElement.handler (ServerPane.tsx:96:9)
    at WebViewElement.__trace__ (bugsnag.js:1:1)
    at WebViewImpl.dispatchEvent (node:electron/js2c/renderer_init:109:1993)
    at EventEmitter.<anonymous> (node:electron/js2c/renderer_init:97:862)
    at EventEmitter.emit (node:events:390:28)
    at Object.onMessage (node:electron/js2c/renderer_init:69:833)`
<!-- Inform the issue number that this PR closes, or remove the line below -->


<!-- Tell us more about your PR with screen shots if you can -->
