### PR TITLE
fix: Force stop animation when download completes (#2630)

### DIFF
--- a/src/ui/components/DownloadsManagerView/DownloadItem.tsx
+++ b/src/ui/components/DownloadsManagerView/DownloadItem.tsx
@@ -236,6 +236,8 @@ const DownloadItem: FC<DownloadItemProps> = ({
           <ProgressBar
             percentage={percentage}
             error={errored ? t('downloads.item.errored') : undefined}
+            // TODO: get complete file details, such as file-size from different cloud storages
+            animated={percentage !== 100}
           />
         </Box>
       </Box>


### PR DESCRIPTION
<!--
INSTRUCTION: Your Pull Request name should start with one of the following
prefixes:

- "feat:" for new features;
- "fix:" for bug fixes.
-->

<!-- Inform the issue number that this PR closes, or remove the line below -->
Closes #2630 

<!-- Tell us more about your PR with screen shots if you can -->
The infinite loading animation of the progress bar of the download files is forcefully stopped when the percentage reaches 100. GridFS stored files are not able to provide total file size in the beginning of the download. Which makes the percentage go from NaN to Infinite then finally to 100 when download finishes. But if the percentage is provided correctly from start to finish the loading bar is animated as usual. With this fix it stops animating for all completed ones