### PR TITLE
fix: Sidebar not resizing with webview using both shortcuts and menu bar

### DIFF
--- a/src/ui/main/menuBar.ts
+++ b/src/ui/main/menuBar.ts
@@ -1,5 +1,5 @@
 import type { MenuItemConstructorOptions } from 'electron';
-import { Menu, app, shell, BrowserWindow } from 'electron';
+import { app, BrowserWindow, Menu, shell } from 'electron';
 import i18next from 'i18next';
 import { createSelector, createStructuredSelector } from 'reselect';
 
@@ -405,7 +405,15 @@ const createViewMenu = createSelector(
         accelerator: 'CommandOrControl+0',
         click: async () => {
           const guestWebContents = await getCurrentViewWebcontents();
+          if (!guestWebContents) {
+            return;
+          }
+
           guestWebContents?.setZoomLevel(0);
+
+          const rootWindow = await getRootWindow();
+          rootWindow.focus();
+          rootWindow.webContents.setZoomLevel(0);
         },
       },
       {
@@ -417,12 +425,16 @@ const createViewMenu = createSelector(
           if (!guestWebContents) {
             return;
           }
-          const zoomLevel = guestWebContents?.getZoomLevel();
+
+          const zoomLevel = guestWebContents.getZoomLevel();
           if (zoomLevel >= 9) {
             return;
           }
-
           guestWebContents.setZoomLevel(zoomLevel + 1);
+
+          const rootWindow = await getRootWindow();
+          rootWindow.focus();
+          rootWindow.webContents.setZoomLevel(zoomLevel + 1);
         },
       },
       {
@@ -438,8 +450,11 @@ const createViewMenu = createSelector(
           if (zoomLevel <= -9) {
             return;
           }
-
           guestWebContents.setZoomLevel(zoomLevel - 1);
+
+          const rootWindow = await getRootWindow();
+          rootWindow.focus();
+          rootWindow.webContents.setZoomLevel(zoomLevel - 1);
         },
       },
     ],


### PR DESCRIPTION
<!--
INSTRUCTION: Your Pull Request name should start with one of the following
prefixes:

- "feat:" for new features;
- "fix:" for bug fixes.
-->

<!-- Inform the issue number that this PR closes, or remove the line below -->
Closes #2444, #2761

<!-- Tell us more about your PR with screen shots if you can -->
In the Rocket.Chat's electron app, there're primarily two parts in the layout, one is sidebar (in the left) and the other is the webview representing the chosen server (in the right). In the mentioned issue it was noted that when user tries to zoom in the app either by pressing shortcut keys (Ctrl+-0) or using the menu bar, the webview zooms in perfectly but the sidebar simply don't respect it and stay at 100% zoom level.

On further investigation, I need noted that the the zoom commands are handled by custom functions bound though the electron's menu bar accelarators. These functions (notably reset, zoom in, zoom out) forwards the zoom command to the webview but don't actually applies the same to the root window's DOM causing the sidebar to be unknown of the zoom command.

Here're the final results:
1. Using menu bar:
    ![Menu bar](https://github.com/RocketChat/Rocket.Chat.Electron/assets/126406840/c1af3126-f73e-41b8-ac9a-4d4ef0b26092)
2. Using shortcut keys:
    ![Shortcut Key](https://github.com/RocketChat/Rocket.Chat.Electron/assets/126406840/e3bd7a04-6678-4453-b127-a3a43872332b)

### Scope of improvements
As you can note, there's a slight delay in the zoom command to actually take effect. Upon further research I found that's a delay from the electron's way of handing the DOM. My idea is to simulate the delay in the webview too for creating a smooth and connected zoom effect.

@jeanfbrito let me know if this idea sounds good to you. I am willing to implement this as personally some milliseconds of delay will be cool enough for me if it improves my overall UX.