### PR TITLE
fix:Settings and download page will change will match dark and light …

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -97,6 +97,10 @@
     "createStartMenuShortcut": true,
     "menuCategory": false
   },
+  "msi":{
+    "runAfterFinish": true,
+    "createStartMenuShortcut": true 
+  },
   "appx": {
     "backgroundColor": "#2f343d",
     "languages": ["en-US", "en-GB", "pt-BR"],

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -97,10 +97,6 @@
     "createStartMenuShortcut": true,
     "menuCategory": false
   },
-  "msi":{
-    "runAfterFinish": true,
-    "createStartMenuShortcut": true 
-  },
   "appx": {
     "backgroundColor": "#2f343d",
     "languages": ["en-US", "en-GB", "pt-BR"],

--- a/src/ui/components/DownloadsManagerView/index.tsx
+++ b/src/ui/components/DownloadsManagerView/index.tsx
@@ -7,7 +7,7 @@ import {
   IconButton,
   SelectLegacy,
 } from '@rocket.chat/fuselage';
-import { useLocalStorage } from '@rocket.chat/fuselage-hooks';
+import { useDarkMode, useLocalStorage } from '@rocket.chat/fuselage-hooks';
 import type { ChangeEvent } from 'react';
 import { useState, useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -176,13 +176,15 @@ const DownloadsManagerView = () => {
       payload: lastSelectedServerUrl,
     });
   };
+  const isDark=useDarkMode()
 
   return (
     <Box
       display={isVisible ? 'flex' : 'none'}
       flexDirection='column'
       height='100vh'
-      backgroundColor='light'
+      backgroundColor={isDark?'dark':'light'}
+
     >
       <Box
         minHeight={64}

--- a/src/ui/components/SettingsView/SettingsView.tsx
+++ b/src/ui/components/SettingsView/SettingsView.tsx
@@ -7,8 +7,10 @@ import { useSelector } from 'react-redux';
 import type { RootState } from '../../../store/rootReducer';
 import { CertificatesTab } from './CertificatesTab';
 import { GeneralTab } from './GeneralTab';
+import { useDarkMode } from '@rocket.chat/fuselage-hooks';
 
 export const SettingsView = () => {
+  const isDark=useDarkMode()
   const isVisible = useSelector(
     ({ currentView }: RootState) => currentView === 'settings'
   );
@@ -21,7 +23,7 @@ export const SettingsView = () => {
       display={isVisible ? 'flex' : 'none'}
       flexDirection='column'
       height='full'
-      backgroundColor='light'
+      backgroundColor={isDark?'dark':'light'}
     >
       <Box
         width='full'


### PR DESCRIPTION


Closes #2752 
Uses useDarkMode hook from fuselage and assigns dark or light based on output.
![darkmode](https://github.com/RocketChat/Rocket.Chat.Electron/assets/100520058/60e05b99-e305-4b0e-b0c2-1ac576af04cf)
![lightmode](https://github.com/RocketChat/Rocket.Chat.Electron/assets/100520058/633c0de0-d912-440b-971b-9cd595ee2b1a)



