### PR TITLE
refactor:Added-startup-and-run-after-finish-for .msi

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -97,6 +97,10 @@
     "createStartMenuShortcut": true,
     "menuCategory": false
   },
+  "msi":{
+    "runAfterFinish": true,
+    "createStartMenuShortcut": true 
+  },
   "appx": {
     "backgroundColor": "#2f343d",
     "languages": ["en-US", "en-GB", "pt-BR"],


### PR DESCRIPTION
Added run after installation and add to startup for .msi

Using this Documentation:https://www.electron.build/configuration/msi



Closes #463 

