### PR TITLE
fix: Electron i18n language setup

### DIFF
--- a/src/i18n/main.ts
+++ b/src/i18n/main.ts
@@ -15,21 +15,18 @@ const getLng = async (): Promise<keyof typeof resources | undefined> => {
 
   const locale = app.getSystemLocale();
 
-  let [languageCode, countryCode] = locale.split(/[-_]/) as [
-    string,
-    string | null,
-  ];
+  let [languageCode, countryCode] = locale.split(/[-_]/);
   if (!languageCode || languageCode.length !== 2) {
     return fallbackLng;
   }
 
   languageCode = languageCode.toLowerCase();
 
-  if (!countryCode || countryCode.length !== 2) {
-    countryCode = null;
-  } else {
-    countryCode = countryCode.toUpperCase();
-  }
+  const isCountryCodeInexistentOrNonStandard =
+    !countryCode || countryCode.length !== 2;
+  countryCode = isCountryCodeInexistentOrNonStandard
+    ? ''
+    : countryCode.toUpperCase();
 
   const lng = countryCode ? `${languageCode}-${countryCode}` : languageCode;
 
@@ -37,7 +34,9 @@ const getLng = async (): Promise<keyof typeof resources | undefined> => {
     return lng;
   }
 
-  return undefined;
+  return Object.keys(resources).find((language) =>
+    language.startsWith(languageCode)
+  ) as keyof typeof resources | undefined;
 };
 
 export let getLanguage = 'en';


### PR DESCRIPTION
<!--
INSTRUCTION: Your Pull Request name should start with one of the following
prefixes:

- "feat:" for new features;
- "fix:" for bug fixes.
-->
Added a safety check at the end of the getLng function. This check verifies if translations exist for the language portion of a locale (e.g., 'en' from 'en-US') when the full locale isn't found in the resources object. This prevents errors when translations exist for a base language but not for a specific regional variant.

Demo gif:
![electron_language](https://github.com/user-attachments/assets/7fd72c9b-f2b8-4121-8478-86ebaa251b0f)

<!-- Inform the issue number that this PR closes, or remove the line below -->
Closes #2960 

<!-- Tell us more about your PR with screen shots if you can -->
