### PR TITLE
Fix: Zoom-in shortcut (Ctrl +) not working, updated accelerator

### DIFF
--- a/src/ui/main/menuBar.ts
+++ b/src/ui/main/menuBar.ts
@@ -373,7 +373,7 @@ const createViewMenu = createSelector(
       {
         id: 'zoomIn',
         label: t('menus.zoomIn'),
-        accelerator: 'CommandOrControl+Plus',
+        accelerator: 'CommandOrControl+=',
         click: async () => {
           const guestWebContents = await getCurrentViewWebcontents();
           if (!guestWebContents) {
@@ -383,7 +383,7 @@ const createViewMenu = createSelector(
           if (zoomLevel >= 9) {
             return;
           }
-
+      
           guestWebContents.setZoomLevel(zoomLevel + 1);
         },
       },
@@ -400,7 +400,7 @@ const createViewMenu = createSelector(
           if (zoomLevel <= -9) {
             return;
           }
-
+      
           guestWebContents.setZoomLevel(zoomLevel - 1);
         },
       },


### PR DESCRIPTION

fix: #2999
-->

### Summary
Fixes the issue with the zoom-in shortcut (Ctrl +) not working on the Electron desktop app.

### Changes:
- Updated the accelerator for the zoom-in menu item to 'CommandOrControl+='.

### Context:
This change ensures that the Ctrl + shortcut works as expected, aligning with the behavior of the zoom-out shortcut and the view toolbar.

### Testing:
Verified that the zoom-in shortcut now functions correctly on Windows and macOS.

