### PR TITLE
Fix: Prevent text selection in WindowDragBar

### DIFF
--- a/src/ui/components/Shell/styles.tsx
+++ b/src/ui/components/Shell/styles.tsx
@@ -34,6 +34,7 @@ export const WindowDragBar = styled.div`
   width: 100vw;
   height: 22px;
   -webkit-app-region: drag;
+  user-select: none;
 `;
 
 export const Wrapper = styled.div`


### PR DESCRIPTION
Closes #2953

Fix: Prevent Text Selection in WindowDragBar
What does this PR do?

This PR prevents text selection in the WindowDragBar by adding user-select: none;.
It enhances the user experience by ensuring that no unwanted text highlighting occurs when dragging the window.

Changes Made:

Added user-select: none; to WindowDragBar in styles.tsx to prevent unintended text selection.
This ensures a smoother UI experience by eliminating accidental text selection in the draggable area.

Note: I couldn't run the desktop app locally due to setup issues, so I request a maintainer to verify if this fixes the problem. Let me know if any further modifications are needed.

