### PR TITLE
feat: Optimize server loading by deferring inactive webviews

### DIFF
--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -103,27 +103,6 @@ jobs:
           snap: ${{ steps.find_snap.outputs.SNAP_FILE_PATH }}
           release: edge
 
-      - name: Find Snap File
-        id: find_snap
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: |
-          SNAP_FILE=$(find dist/ -maxdepth 1 -name 'rocketchat-*.snap' -print -quit)
-          if [ -z "$SNAP_FILE" ]; then
-            echo "::error::Snap file not found in dist/"
-            exit 1
-          fi
-          echo "Found snap file: $SNAP_FILE"
-          echo "SNAP_FILE_PATH=$SNAP_FILE" >> $GITHUB_OUTPUT
-
-      - name: Publish to Snap Store (Edge)
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        uses: snapcore/action-publish@v1
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
-        with:
-          snap: ${{ steps.find_snap.outputs.SNAP_FILE_PATH }}
-          release: edge
-
       # Install AWS CLI
       - name: Install AWS CLI
         run: pip install awscli

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "Rocket.Chat",
   "name": "rocketchat",
   "description": "Official OSX, Windows, and Linux Desktop Clients for Rocket.Chat",
-  "version": "4.3.3",
+  "version": "4.4.0-alpha.0",
   "author": "Rocket.Chat Support <support@rocket.chat>",
   "copyright": "© 2016-2025, Rocket.Chat",
   "homepage": "https://rocket.chat",

--- a/src/ui/components/ServersView/ServerPane.tsx
+++ b/src/ui/components/ServersView/ServerPane.tsx
@@ -24,6 +24,7 @@ type ServerPaneProps = {
   title: string | undefined;
   documentViewerOpenUrl: string | undefined;
   themeAppearance: string | undefined;
+  userLoggedIn?: boolean;
 };
 
 export const ServerPane = ({
@@ -34,6 +35,7 @@ export const ServerPane = ({
   isSupported,
   documentViewerOpenUrl,
   themeAppearance,
+  userLoggedIn,
 }: ServerPaneProps) => {
   const dispatch = useDispatch<Dispatch<RootAction>>();
 
@@ -140,10 +142,12 @@ export const ServerPane = ({
       return;
     }
 
-    if (!webview.src) {
+    const shouldLoad = isSelected || userLoggedIn !== false;
+
+    if (!webview.src && shouldLoad) {
       webview.src = lastPath || serverUrl;
     }
-  }, [lastPath, serverUrl]);
+  }, [lastPath, serverUrl, isSelected, userLoggedIn]);
 
   useEffect(() => {
     const webview = webviewRef.current;

--- a/src/ui/components/ServersView/index.tsx
+++ b/src/ui/components/ServersView/index.tsx
@@ -18,6 +18,7 @@ export const ServersView = () => {
           title={server.title}
           documentViewerOpenUrl={server.documentViewerOpenUrl}
           themeAppearance={server.themeAppearance}
+          userLoggedIn={server.userLoggedIn}
         />
       ))}
     </ReparentingContainer>


### PR DESCRIPTION
This PR introduces an optimization to defer the loading of server webviews.

**Changes:**

*   **Conditional Webview Loading:** Server webviews for inactive (not currently selected) tabs will now only have their content loaded if the user is known to be logged in or if their login status is not yet determined. If a server is inactive and the user is known to be logged out, its webview content will not be loaded, saving bandwidth and initial resource usage.
*   **User Experience:** When a user clicks on a server that was previously unloaded due to being logged out, the webview will now load as expected, allowing them to log in.

**Goal:**

The goal is to reduce unnecessary bandwidth consumption and improve performance by avoiding the loading of content for servers that are not actively in use and where the user is logged out.