### PR TITLE
feat: Close video call window when Jitsi call is closed

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -10,7 +10,7 @@
     "category": "public.app-category.productivity",
     "target": ["dmg", "pkg", "zip", "mas"],
     "icon": "build/icon.icns",
-    "bundleVersion": "25053",
+    "bundleVersion": "25054",
     "helperBundleId": "chat.rocket.electron.helper",
     "type": "distribution",
     "artifactName": "rocketchat-${version}-${os}.${ext}",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "Rocket.Chat",
   "name": "rocketchat",
   "description": "Official OSX, Windows, and Linux Desktop Clients for Rocket.Chat",
-  "version": "4.4.1",
+  "version": "4.5.0-alpha.0",
   "author": "Rocket.Chat Support <support@rocket.chat>",
   "copyright": "© 2016-2025, Rocket.Chat",
   "homepage": "https://rocket.chat",

--- a/src/ipc/channels.ts
+++ b/src/ipc/channels.ts
@@ -30,6 +30,7 @@ type ChannelToArgsMap = {
   'video-call-window/open-screen-picker': () => void;
   'video-call-window/screen-sharing-source-responded': (source: string) => void;
   'video-call-window/screen-recording-is-permission-granted': () => boolean;
+  'video-call-window/close-requested': () => void;
   'jitsi-desktop-capturer-get-sources': (
     args: [options: Electron.SourcesOptions, jitsiDomain: string]
   ) => Electron.DesktopCapturerSource[];

--- a/src/videoCallWindow/videoCallWindow.tsx
+++ b/src/videoCallWindow/videoCallWindow.tsx
@@ -16,13 +16,33 @@ function VideoCallWindow() {
     ipcRenderer.once(
       'video-call-window/open-url',
       async (_event, url: string) => {
-        console.log('videoCallWindow/open-url', url);
         setVideoCallUrl(url);
       }
     );
 
     return () => {};
   }, []);
+
+  useEffect(() => {
+    const webview = webviewRef.current as any;
+    if (!webview) return;
+
+    const checkForClosePage = (url: string) => {
+      if (url.includes('close')) {
+        ipcRenderer.invoke('video-call-window/close-requested');
+      }
+    };
+
+    const handleNavigate = (event: any) => {
+      checkForClosePage(event.url);
+    };
+
+    webview.addEventListener('did-navigate', handleNavigate);
+
+    return () => {
+      webview.removeEventListener('did-navigate', handleNavigate);
+    };
+  }, [videoCallUrl]);
 
   return (
     <Box>

--- a/src/videoCallWindow/videoCallWindow.tsx
+++ b/src/videoCallWindow/videoCallWindow.tsx
@@ -28,7 +28,7 @@ function VideoCallWindow() {
     if (!webview) return;
 
     const checkForClosePage = (url: string) => {
-      if (url.includes('close')) {
+      if (url.includes('/close.html') || url.includes('/close2.html')) {
         ipcRenderer.invoke('video-call-window/close-requested');
       }
     };


### PR DESCRIPTION
## Automatically close video call window when Jitsi call ends

This PR implements automatic detection of Jitsi call termination to close the video call window gracefully. 

### What it does:
- Monitors URL navigation events in the video call webview
- Detects when the URL contains "close" (indicating the call has ended)  
- Automatically triggers the `video-call-window/close-requested` IPC handler
- Properly closes the video call window when Jitsi redirects to a "close" page

### Technical implementation:
- Adds a `did-navigate` event listener to the webview in `videoCallWindow.tsx`
- Implements `checkForClosePage()` function that inspects navigation URLs
- Leverages existing IPC infrastructure (`video-call-window/close-requested`) for clean window closure

### Benefits:
- Improves user experience by eliminating manually having to close the video call window
- Prevents orphaned video call windows after Jitsi calls end
- Uses Jitsi's standard redirect behavior to detect call termination


https://github.com/user-attachments/assets/92c2bb37-060c-4534-b6d1-b3ad596accc0



**Closes:** #2649 #2631 #2633
**Related:** [SUP-770](https://rocketchat.atlassian.net/browse/SUP-770)

[SUP-770]: https://rocketchat.atlassian.net/browse/SUP-770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ