### PR TITLE
Fix zoom in keyboard shortcut (Ctrl++) not working

### DIFF
--- a/src/ui/main/menuBar.ts
+++ b/src/ui/main/menuBar.ts
@@ -374,7 +374,7 @@ const createViewMenu = createSelector(
       {
         id: 'zoomIn',
         label: t('menus.zoomIn'),
-        accelerator: 'CommandOrControl+Plus',
+        accelerator: 'CommandOrControl+=',
         click: async () => {
           const guestWebContents = await getCurrentViewWebcontents();
           if (!guestWebContents) {


### PR DESCRIPTION
### Problem
The zoom in keyboard shortcut `Ctrl++` was not working after app resize, while zoom out (`Ctrl+-`) worked correctly. Users could only zoom in through the View menu.

### Root Cause
The accelerator was defined as `CommandOrControl+Plus`, which requires `Ctrl+Shift+=` to trigger on most keyboard layouts since the `+` character is typically accessed via `Shift+=`. This is a known Electron limitation where `Plus` doesn't map correctly to the `+` key on many keyboards.

### Solution
Changed the accelerator from `CommandOrControl+Plus` to `CommandOrControl+=`, which properly maps to the `Ctrl++` key combination across different keyboard layouts.

Closes #2999