### PR TITLE
feat: Alpha and beta update channels

### DIFF
--- a/alpha-app-update.yml
+++ b/alpha-app-update.yml
@@ -1,0 +1,5 @@
+owner: RocketChat
+repo: Rocket.Chat.Electron
+provider: github
+vPrefixedTagName: false
+channel: alpha 

--- a/beta-app-update.yml
+++ b/beta-app-update.yml
@@ -1,0 +1,5 @@
+owner: RocketChat
+repo: Rocket.Chat.Electron
+provider: github
+vPrefixedTagName: false
+channel: beta 

--- a/src/app/PersistableValues.ts
+++ b/src/app/PersistableValues.ts
@@ -79,9 +79,13 @@ type PersistableValues_4_4_0 = PersistableValues_4_2_0 & {
   isDeveloperModeEnabled: boolean;
 };
 
+type PersistableValues_4_5_0 = PersistableValues_4_4_0 & {
+  updateChannel: string;
+};
+
 export type PersistableValues = Pick<
-  PersistableValues_4_4_0,
-  keyof PersistableValues_4_4_0
+  PersistableValues_4_5_0,
+  keyof PersistableValues_4_5_0
 >;
 
 export const migrations = {
@@ -146,5 +150,9 @@ export const migrations = {
   '>=4.4.0': (before: PersistableValues_4_2_0): PersistableValues_4_4_0 => ({
     ...before,
     isDeveloperModeEnabled: false,
+  }),
+  '>=4.5.0': (before: PersistableValues_4_4_0): PersistableValues_4_5_0 => ({
+    ...before,
+    updateChannel: 'latest',
   }),
 };

--- a/src/app/selectors.ts
+++ b/src/app/selectors.ts
@@ -62,4 +62,5 @@ export const selectPersistableValues = createStructuredSelector({
   isVideoCallWindowPersistenceEnabled: ({
     isVideoCallWindowPersistenceEnabled,
   }: RootState) => isVideoCallWindowPersistenceEnabled,
+  updateChannel: ({ updateChannel }: RootState) => updateChannel,
 });

--- a/src/i18n/de-DE.i18n.json
+++ b/src/i18n/de-DE.i18n.json
@@ -24,7 +24,13 @@
       "checkUpdatesOnStart": "Beim Start auf Aktualisierungen prüfen",
       "noUpdatesAvailable": "Es sind keine Aktualisierungen verfügbar.",
       "copyright": "Copyright {{copyright}}",
-      "errorWhenLookingForUpdates": "Bei der Suche nach Updates ist ein Fehler aufgetreten"
+      "errorWhenLookingForUpdates": "Bei der Suche nach Updates ist ein Fehler aufgetreten",
+      "updateChannel": {
+        "label": "Update-Kanal",
+        "latest": "Stabil",
+        "beta": "Beta",
+        "alpha": "Alpha (Experimentell)"
+      }
     },
     "addServer": {
       "title": "Server hinzufügen",

--- a/src/i18n/en.i18n.json
+++ b/src/i18n/en.i18n.json
@@ -24,7 +24,13 @@
       "checkUpdatesOnStart": "Check for Updates on Start",
       "noUpdatesAvailable": "No updates are available.",
       "copyright": "Copyright {{copyright}}",
-      "errorWhenLookingForUpdates": "An error has occurred when looking for updates"
+      "errorWhenLookingForUpdates": "An error has occurred when looking for updates",
+      "updateChannel": {
+        "label": "Update Channel",
+        "latest": "Stable",
+        "beta": "Beta",
+        "alpha": "Alpha (Experimental)"
+      }
     },
     "addServer": {
       "title": "Add Server",

--- a/src/i18n/es.i18n.json
+++ b/src/i18n/es.i18n.json
@@ -24,7 +24,13 @@
       "checkUpdatesOnStart": "Buscar actualizaciones al iniciar",
       "noUpdatesAvailable": "No hay actualizaciones disponibles.",
       "copyright": "Derechos de autor {{copyright}}",
-      "errorWhenLookingForUpdates": "Ha ocurrido un error al buscar actualizaciones"
+      "errorWhenLookingForUpdates": "Ha ocurrido un error al buscar actualizaciones",
+      "updateChannel": {
+        "label": "Canal de actualización",
+        "latest": "Estable",
+        "beta": "Beta",
+        "alpha": "Alfa (Experimental)"
+      }
     },
     "addServer": {
       "title": "Agregar servidor",

--- a/src/i18n/fi.i18n.json
+++ b/src/i18n/fi.i18n.json
@@ -24,7 +24,13 @@
       "checkUpdatesOnStart": "Tarkista päivitykset käynnistettäessä",
       "noUpdatesAvailable": "Päivityksiä ei ole saatavilla.",
       "copyright": "Copyright {{copyright}}",
-      "errorWhenLookingForUpdates": "Virhe etsittäessä päivityksiä"
+      "errorWhenLookingForUpdates": "Virhe etsittäessä päivityksiä",
+      "updateChannel": {
+        "label": "Päivityskanava",
+        "latest": "Vakaa",
+        "beta": "Beta",
+        "alpha": "Alpha (Kokeellinen)"
+      }
     },
     "addServer": {
       "title": "Lisää palvelin",

--- a/src/i18n/fr.i18n.json
+++ b/src/i18n/fr.i18n.json
@@ -24,7 +24,13 @@
       "checkUpdatesOnStart": "Vérifier les mises à jour au démarrage",
       "noUpdatesAvailable": "Aucune mise à jour n'est disponible.",
       "copyright": "Copyright {{copyright}}",
-      "errorWhenLookingForUpdates": "Une erreur s'est produite lors de la recherche de mises à jour"
+      "errorWhenLookingForUpdates": "Une erreur s'est produite lors de la recherche de mises à jour",
+      "updateChannel": {
+        "label": "Canal de mise à jour",
+        "latest": "Stable",
+        "beta": "Bêta",
+        "alpha": "Alpha (Expérimental)"
+      }
     },
     "addServer": {
       "title": "Ajouter un serveur",

--- a/src/i18n/hu.i18n.json
+++ b/src/i18n/hu.i18n.json
@@ -24,7 +24,13 @@
       "checkUpdatesOnStart": "Frissítések keresése indításkor",
       "noUpdatesAvailable": "Nincsenek elérhető frissítések.",
       "copyright": "Copyright {{copyright}}",
-      "errorWhenLookingForUpdates": "Hiba történt a frissítések keresésekor"
+      "errorWhenLookingForUpdates": "Hiba történt a frissítések keresésekor",
+      "updateChannel": {
+        "label": "Frissítési csatorna",
+        "latest": "Stabil",
+        "beta": "Beta",
+        "alpha": "Alpha (Kísérleti)"
+      }
     },
     "addServer": {
       "title": "Kiszolgáló hozzáadása",

--- a/src/i18n/pl.i18n.json
+++ b/src/i18n/pl.i18n.json
@@ -22,7 +22,13 @@
       "checkUpdatesOnStart": "Sprawdzanie aktualizacji przy uruchomieniu",
       "noUpdatesAvailable": "Brak dostępnych aktualizacji.",
       "copyright": "Prawa autorskie {{copyright}}",
-      "errorWhenLookingForUpdates": "Wystąpił błąd podczas wyszukiwania aktualizacji"
+      "errorWhenLookingForUpdates": "Wystąpił błąd podczas wyszukiwania aktualizacji",
+      "updateChannel": {
+        "label": "Kanał aktualizacji",
+        "latest": "Stabilny",
+        "beta": "Beta",
+        "alpha": "Alfa (Eksperymentalny)"
+      }
     },
     "addServer": {
       "title": "Dodaj Serwer",

--- a/src/i18n/pt-BR.i18n.json
+++ b/src/i18n/pt-BR.i18n.json
@@ -24,7 +24,13 @@
       "checkUpdatesOnStart": "Verificar Atualizações ao Abrir",
       "noUpdatesAvailable": "Não há atualizações disponíveis.",
       "copyright": "{{copyright}} Todos os direitos reservados.",
-      "errorWhenLookingForUpdates": "Ocorreu um erro ao procurar por atualizações"
+      "errorWhenLookingForUpdates": "Ocorreu um erro ao procurar por atualizações",
+      "updateChannel": {
+        "label": "Canal de atualização",
+        "latest": "Estável",
+        "beta": "Beta",
+        "alpha": "Alpha (Experimental)"
+      }
     },
     "addServer": {
       "title": "Adicionar Servidor",

--- a/src/i18n/ru.i18n.json
+++ b/src/i18n/ru.i18n.json
@@ -24,7 +24,13 @@
       "checkUpdatesOnStart": "Проверять обновления при запуске",
       "noUpdatesAvailable": "Нет обновлений.",
       "copyright": "Все права защищены {{copyright}}",
-      "errorWhenLookingForUpdates": "При поиске обновлений произошла ошибка"
+      "errorWhenLookingForUpdates": "При поиске обновлений произошла ошибка",
+      "updateChannel": {
+        "label": "Канал обновлений",
+        "latest": "Стабильный",
+        "beta": "Бета",
+        "alpha": "Альфа (Экспериментальный)"
+      }
     },
     "addServer": {
       "title": "Добавить сервер",

--- a/src/store/rootReducer.ts
+++ b/src/store/rootReducer.ts
@@ -46,6 +46,7 @@ import {
   newUpdateVersion,
   skippedUpdateVersion,
   updateError,
+  updateChannel,
 } from '../updates/reducers';
 
 export const rootReducer = combineReducers({
@@ -92,6 +93,7 @@ export const rootReducer = combineReducers({
   videoCallWindowState,
   isVideoCallWindowPersistenceEnabled,
   isDeveloperModeEnabled,
+  updateChannel,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/src/ui/actions.ts
+++ b/src/ui/actions.ts
@@ -6,6 +6,8 @@ import type { RootWindowIcon, WindowState } from './common';
 export const ABOUT_DIALOG_DISMISSED = 'about-dialog/dismissed';
 export const ABOUT_DIALOG_TOGGLE_UPDATE_ON_START =
   'about-dialog/toggle-update-on-start';
+export const ABOUT_DIALOG_UPDATE_CHANNEL_CHANGED =
+  'about-dialog/update-channel-changed';
 export const ADD_SERVER_VIEW_SERVER_ADDED = 'add-server/view-server-added';
 export const CLEAR_CACHE_TRIGGERED = 'clear-cache/triggered';
 export const CLEAR_CACHE_DIALOG_DISMISSED = 'clear-cache-dialog/dismissed';
@@ -134,6 +136,7 @@ export const SIDE_BAR_SERVER_REMOVE = 'side-bar/server-remove';
 export type UiActionTypeToPayloadMap = {
   [ABOUT_DIALOG_DISMISSED]: void;
   [ABOUT_DIALOG_TOGGLE_UPDATE_ON_START]: boolean;
+  [ABOUT_DIALOG_UPDATE_CHANNEL_CHANGED]: string;
   [ADD_SERVER_VIEW_SERVER_ADDED]: Server['url'];
   [CLEAR_CACHE_TRIGGERED]: WebContents['id'];
   [CLEAR_CACHE_DIALOG_DISMISSED]: void;

--- a/src/ui/components/AboutDialog/index.tsx
+++ b/src/ui/components/AboutDialog/index.tsx
@@ -5,7 +5,6 @@ import {
   FieldLabel,
   FieldRow,
   Margins,
-  Select,
   Throbber,
   ToggleSwitch,
 } from '@rocket.chat/fuselage';

--- a/src/ui/components/AboutDialog/index.tsx
+++ b/src/ui/components/AboutDialog/index.tsx
@@ -5,6 +5,7 @@ import {
   FieldLabel,
   FieldRow,
   Margins,
+  Select,
   Throbber,
   ToggleSwitch,
 } from '@rocket.chat/fuselage';
@@ -19,9 +20,11 @@ import { packageJsonInformation } from '../../../app/main/app';
 import type { RootAction } from '../../../store/actions';
 import type { RootState } from '../../../store/rootReducer';
 import { UPDATES_CHECK_FOR_UPDATES_REQUESTED } from '../../../updates/actions';
+import { UPDATE_CHANNELS } from '../../../updates/common';
 import {
   ABOUT_DIALOG_TOGGLE_UPDATE_ON_START,
   ABOUT_DIALOG_DISMISSED,
+  ABOUT_DIALOG_UPDATE_CHANNEL_CHANGED,
 } from '../../actions';
 import { Dialog } from '../Dialog';
 import { RocketChatLogo } from '../RocketChatLogo';
@@ -53,6 +56,12 @@ export const AboutDialog = () => {
   );
   const openDialog = useSelector(({ openDialog }: RootState) => openDialog);
   const updateError = useSelector(({ updateError }: RootState) => updateError);
+  const updateChannel = useSelector(
+    ({ updateChannel }: RootState) => updateChannel
+  );
+  const isDeveloperModeEnabled = useSelector(
+    ({ isDeveloperModeEnabled }: RootState) => isDeveloperModeEnabled
+  );
 
   const isVisible = openDialog === 'about';
   const canUpdate = isUpdatingAllowed && isUpdatingEnabled;
@@ -119,8 +128,21 @@ export const AboutDialog = () => {
     });
   };
 
+  const handleUpdateChannelChange = (channel: string): void => {
+    dispatch({
+      type: ABOUT_DIALOG_UPDATE_CHANNEL_CHANGED,
+      payload: channel,
+    });
+  };
+
   const checkForUpdatesButtonRef = useAutoFocus(isVisible);
   const checkForUpdatesOnStartupToggleSwitchId = useId();
+  const updateChannelSelectId = useId();
+
+  const updateChannelOptions = UPDATE_CHANNELS.map(
+    (channel) =>
+      [channel, t(`dialog.about.updateChannel.${channel}`)] as [string, string]
+  );
 
   return (
     <Dialog
@@ -170,6 +192,24 @@ export const AboutDialog = () => {
                     )}
                   </Margins>
                 </Box>
+              )}
+
+              {isDeveloperModeEnabled && (
+                <Field>
+                  <FieldRow>
+                    <FieldLabel htmlFor={updateChannelSelectId}>
+                      {t('dialog.about.updateChannel.label')}
+                    </FieldLabel>
+                    <Select
+                      id={updateChannelSelectId}
+                      value={updateChannel}
+                      options={updateChannelOptions}
+                      onChange={(value) =>
+                        handleUpdateChannelChange(value as string)
+                      }
+                    />
+                  </FieldRow>
+                </Field>
               )}
 
               <Field>

--- a/src/ui/components/AboutDialog/index.tsx
+++ b/src/ui/components/AboutDialog/index.tsx
@@ -137,7 +137,6 @@ export const AboutDialog = () => {
 
   const checkForUpdatesButtonRef = useAutoFocus(isVisible);
   const checkForUpdatesOnStartupToggleSwitchId = useId();
-  const updateChannelSelectId = useId();
 
   const updateChannelOptions = UPDATE_CHANNELS.map(
     (channel) =>
@@ -163,6 +162,53 @@ export const AboutDialog = () => {
 
         {canUpdate && (
           <Box display='flex' flexDirection='column'>
+            {isDeveloperModeEnabled && (
+              <Box marginBlockEnd={16}>
+                <Field>
+                  <FieldRow style={{ verticalAlign: 'middle' }}>
+                    <FieldLabel
+                      htmlFor='updateChannelSelect'
+                      marginBlock='auto'
+                    >
+                      {t('dialog.about.updateChannel.label')}
+                    </FieldLabel>
+                    <select
+                      id='updateChannelSelect'
+                      value={updateChannel}
+                      onChange={(e) =>
+                        handleUpdateChannelChange(e.target.value)
+                      }
+                      style={{
+                        width: '200px',
+                        height: '40px',
+                        padding: '8px 12px',
+                        border: '2px solid #e4e7ea',
+                        borderRadius: '4px',
+                        backgroundColor: '#ffffff',
+                        fontSize: '14px',
+                        color: '#2f343d',
+                        outline: 'none',
+                        cursor: 'pointer',
+                        fontFamily: 'inherit',
+                        appearance: 'none',
+                        backgroundImage: `url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6,9 12,15 18,9'%3e%3c/polyline%3e%3c/svg%3e")`,
+                        backgroundRepeat: 'no-repeat',
+                        backgroundPosition: 'right 12px center',
+                        backgroundSize: '16px',
+                        paddingRight: '40px',
+                      }}
+                    >
+                      {updateChannelOptions.map(([value, label]) => (
+                        <option key={value} value={value}>
+                          {label}
+                        </option>
+                      ))}
+                    </select>
+                  </FieldRow>
+                </Field>
+              </Box>
+            )}
+
             <Margins block='x8'>
               {!checkingForUpdates && (
                 <Button
@@ -192,24 +238,6 @@ export const AboutDialog = () => {
                     )}
                   </Margins>
                 </Box>
-              )}
-
-              {isDeveloperModeEnabled && (
-                <Field>
-                  <FieldRow>
-                    <FieldLabel htmlFor={updateChannelSelectId}>
-                      {t('dialog.about.updateChannel.label')}
-                    </FieldLabel>
-                    <Select
-                      id={updateChannelSelectId}
-                      value={updateChannel}
-                      options={updateChannelOptions}
-                      onChange={(value) =>
-                        handleUpdateChannelChange(value as string)
-                      }
-                    />
-                  </FieldRow>
-                </Field>
               )}
 
               <Field>

--- a/src/ui/components/AboutDialog/index.tsx
+++ b/src/ui/components/AboutDialog/index.tsx
@@ -141,7 +141,7 @@ export const AboutDialog = () => {
   const updateChannelOptions = UPDATE_CHANNELS.map(
     (channel) =>
       [channel, t(`dialog.about.updateChannel.${channel}`)] as [string, string]
-  );
+  ).sort((a, b) => a[1].localeCompare(b[1]));
 
   return (
     <Dialog

--- a/src/updates/actions.ts
+++ b/src/updates/actions.ts
@@ -9,6 +9,7 @@ export const UPDATES_NEW_VERSION_AVAILABLE = 'updates/new-version-available';
 export const UPDATES_NEW_VERSION_NOT_AVAILABLE =
   'updates/new-version-not-available';
 export const UPDATES_READY = 'updates/ready';
+export const UPDATES_CHANNEL_CHANGED = 'updates/channel-changed';
 
 export type UpdatesActionTypeToPayloadMap = {
   [UPDATE_SKIPPED]: string | null;
@@ -18,4 +19,5 @@ export type UpdatesActionTypeToPayloadMap = {
   [UPDATES_NEW_VERSION_AVAILABLE]: string;
   [UPDATES_NEW_VERSION_NOT_AVAILABLE]: void;
   [UPDATES_READY]: UpdateConfiguration;
+  [UPDATES_CHANNEL_CHANGED]: string;
 };

--- a/src/updates/common.ts
+++ b/src/updates/common.ts
@@ -8,6 +8,7 @@ export type UpdateConfiguration = {
   isHardwareAccelerationEnabled: boolean;
   isFlashFrameEnabled: boolean;
   isInternalVideoChatWindowEnabled: boolean;
+  updateChannel: string;
 };
 
 export type AppLevelUpdateConfiguration = {
@@ -15,9 +16,14 @@ export type AppLevelUpdateConfiguration = {
   canUpdate?: boolean;
   autoUpdate?: boolean;
   skip?: string | null;
+  channel?: string;
 };
 
 export type UserLevelUpdateConfiguration = {
   autoUpdate?: boolean;
   skip?: string | null;
+  channel?: string;
 };
+
+export const UPDATE_CHANNELS = ['latest', 'beta', 'alpha'] as const;
+export type UpdateChannel = (typeof UPDATE_CHANNELS)[number];

--- a/src/updates/main.spec.ts
+++ b/src/updates/main.spec.ts
@@ -17,6 +17,7 @@ describe('mergeConfigurations', () => {
       isFlashFrameEnabled: true,
       isHardwareAccelerationEnabled: true,
       isInternalVideoChatWindowEnabled: true,
+      updateChannel: 'latest',
     };
     const appConfiguration: AppLevelUpdateConfiguration = {};
     const userConfiguration: UserLevelUpdateConfiguration = {};
@@ -41,6 +42,7 @@ describe('mergeConfigurations', () => {
       isFlashFrameEnabled: true,
       isHardwareAccelerationEnabled: true,
       isInternalVideoChatWindowEnabled: true,
+      updateChannel: 'latest',
     };
     const appConfiguration: AppLevelUpdateConfiguration = {
       autoUpdate: false,
@@ -72,6 +74,7 @@ describe('mergeConfigurations', () => {
       isFlashFrameEnabled: true,
       isHardwareAccelerationEnabled: true,
       isInternalVideoChatWindowEnabled: true,
+      updateChannel: 'latest',
     };
     const appConfiguration: AppLevelUpdateConfiguration = {
       autoUpdate: false,
@@ -107,6 +110,7 @@ describe('mergeConfigurations', () => {
       isFlashFrameEnabled: true,
       isHardwareAccelerationEnabled: true,
       isInternalVideoChatWindowEnabled: true,
+      updateChannel: 'latest',
     };
     const appConfiguration: AppLevelUpdateConfiguration = {
       forced: true,

--- a/src/updates/reducers.ts
+++ b/src/updates/reducers.ts
@@ -2,7 +2,10 @@ import type { Reducer } from 'redux';
 
 import { APP_SETTINGS_LOADED } from '../app/actions';
 import type { ActionOf } from '../store/actions';
-import { ABOUT_DIALOG_TOGGLE_UPDATE_ON_START } from '../ui/actions';
+import {
+  ABOUT_DIALOG_TOGGLE_UPDATE_ON_START,
+  ABOUT_DIALOG_UPDATE_CHANNEL_CHANGED,
+} from '../ui/actions';
 import {
   UPDATES_CHECKING_FOR_UPDATE,
   UPDATES_ERROR_THROWN,
@@ -10,6 +13,7 @@ import {
   UPDATES_NEW_VERSION_NOT_AVAILABLE,
   UPDATES_READY,
   UPDATE_SKIPPED,
+  UPDATES_CHANNEL_CHANGED,
 } from './actions';
 
 type DoCheckForUpdatesOnStartupAction =
@@ -137,18 +141,23 @@ export const isUpdatingEnabled: Reducer<boolean, IsUpdatingEnabledAction> = (
 
 type NewUpdateVersionAction =
   | ActionOf<typeof UPDATES_NEW_VERSION_AVAILABLE>
-  | ActionOf<typeof UPDATES_NEW_VERSION_NOT_AVAILABLE>;
+  | ActionOf<typeof UPDATES_NEW_VERSION_NOT_AVAILABLE>
+  | ActionOf<typeof UPDATE_SKIPPED>;
 
 export const newUpdateVersion: Reducer<
   string | null,
   NewUpdateVersionAction
 > = (state = null, action) => {
   switch (action.type) {
-    case UPDATES_NEW_VERSION_AVAILABLE:
-      return action.payload;
+    case UPDATES_NEW_VERSION_AVAILABLE: {
+      const newUpdateVersion = action.payload;
+      return newUpdateVersion;
+    }
 
     case UPDATES_NEW_VERSION_NOT_AVAILABLE:
+    case UPDATE_SKIPPED: {
       return null;
+    }
 
     default:
       return state;
@@ -207,6 +216,37 @@ export const updateError: Reducer<Error | null, UpdateErrorAction> = (
 
     case UPDATES_NEW_VERSION_AVAILABLE:
       return null;
+
+    default:
+      return state;
+  }
+};
+
+type UpdateChannelAction =
+  | ActionOf<typeof ABOUT_DIALOG_UPDATE_CHANNEL_CHANGED>
+  | ActionOf<typeof UPDATES_CHANNEL_CHANGED>
+  | ActionOf<typeof UPDATES_READY>
+  | ActionOf<typeof APP_SETTINGS_LOADED>;
+
+export const updateChannel: Reducer<string, UpdateChannelAction> = (
+  state = 'latest',
+  action
+) => {
+  switch (action.type) {
+    case ABOUT_DIALOG_UPDATE_CHANNEL_CHANGED:
+    case UPDATES_CHANNEL_CHANGED: {
+      return action.payload;
+    }
+
+    case UPDATES_READY: {
+      const { updateChannel } = action.payload;
+      return updateChannel;
+    }
+
+    case APP_SETTINGS_LOADED: {
+      const { updateChannel = state } = action.payload;
+      return updateChannel;
+    }
 
     default:
       return state;


### PR DESCRIPTION
## Introducing Update Channels

This PR enables the use of **update channels** for Rocket.Chat Desktop, allowing us to deliver more stable releases through a structured testing process.

### What are Update Channels?

Update channels let users choose how they want to receive updates:

- **🟢 Latest (Stable)** - Fully tested, production-ready releases
- **🟡 Beta** - Feature-complete releases ready for final testing  
- **🔴 Alpha** - Early releases with newest features (may have bugs)

### How It Works

Users can switch channels in **Settings → About → Update Channel** and will only receive updates from their chosen channel.

**Note:** Developer mode must be enabled for the update channel selector to appear in the About dialog. Enable it via **Help → Developer Mode** in the menu bar.

### Release Process

Instead of releasing everything directly to stable, we now follow this flow:

1. **Alpha Release** (`4.5.1-alpha.1`) - Early testing with power users
2. **Beta Release** (`4.5.1-beta.1`) - Broader testing when alpha is stable
3. **Stable Release** (`4.5.1`) - Final release for everyone

### Benefits

- **🛡️ More Stable Releases** - Issues caught in alpha/beta before reaching stable users
- **⚡ Faster Feature Delivery** - Early adopters get features sooner
- **🔄 Better Testing** - Real-world testing across different user groups
- **📱 Auto-Updates** - Works seamlessly with existing auto-update system