### PR TITLE
chore: Add flip fuses to all the builds

### DIFF
--- a/build/afterPack.js
+++ b/build/afterPack.js
@@ -8,25 +8,19 @@ exports.default = async function afterPack(context) {
     context.appOutDir
   );
 
-  // Skip fuses for MAS builds - they are incompatible
-  if (
-    context.electronPlatformName === 'mas' ||
-    context.appOutDir.includes('mas-universal')
-  ) {
-    console.log(
-      'Skipping fuses for MAS build (App Store has its own integrity validation)'
-    );
-    return;
-  }
-
-  // Apply security fuses for regular builds
+  // Apply security fuses for all builds
   let appPath;
-  if (context.electronPlatformName === 'darwin') {
-    appPath = `${context.appOutDir}/Rocket.Chat.app`;
-  } else if (context.electronPlatformName === 'win32') {
-    appPath = `${context.appOutDir}/Rocket.Chat.exe`;
-  } else {
-    appPath = `${context.appOutDir}/rocketchat-desktop`;
+  switch (context.electronPlatformName) {
+    case 'darwin':
+    case 'mas':
+      appPath = `${context.appOutDir}/Rocket.Chat.app`;
+      break;
+    case 'win32':
+      appPath = `${context.appOutDir}/Rocket.Chat.exe`;
+      break;
+    default:
+      appPath = `${context.appOutDir}/rocketchat-desktop`;
+      break;
   }
 
   console.log('Applying electron fuses for enhanced security to:', appPath);


### PR DESCRIPTION
This PR removes the special handling that was skipping electron fuses for Mac App Store (MAS) builds and now applies security fuses consistently across all platforms including MAS.

### Changes Made
- **Removed MAS skip logic**: Eliminated the conditional check that was bypassing fuse application for MAS builds
- **Unified platform handling**: Now both `darwin` and `mas` builds receive the same security fuses
- **Improved code structure**: Replaced if-else chain with a cleaner switch statement for better maintainability
- **Consistent security posture**: All macOS builds (regular and MAS) now have the same security enhancements

### Background
Previously, the build process was skipping electron fuses for MAS builds under the assumption that "App Store has its own integrity validation." However, electron fuses provide additional security benefits that are compatible with and complementary to App Store validation:

- `EnableEmbeddedAsarIntegrityValidation`: Validates app.asar content integrity
- `OnlyLoadAppFromAsar`: Prevents loading code from outside the ASAR archive  
- And other security-focused fuses

### Benefits
- **Enhanced Security**: MAS builds now receive the same security hardening as other builds
- **Consistency**: Uniform security configuration across all distribution channels
- **Future-proof**: Aligned with current best practices for Electron app security

This change brings our MAS builds in line with modern Electron security best practices while maintaining compatibility with App Store requirements.