### PR TITLE
fix: add validation to 'will-navigate' to disallow the `smb://` protocol

### DIFF
--- a/src/ui/main/rootWindow.ts
+++ b/src/ui/main/rootWindow.ts
@@ -66,7 +66,20 @@ export const createRootWindow = (): void => {
     webPreferences,
   });
 
-  _rootWindow.addListener('close', (event) => {
+  // Block navigation to smb:// protocol
+  _rootWindow.webContents.on('will-navigate', (event, url) => {
+    if (typeof url === 'string' && url.toLowerCase().startsWith('smb://')) {
+      event.preventDefault();
+    }
+  });
+  _rootWindow.webContents.setWindowOpenHandler(({ url }: { url: string }) => {
+    if (url.toLowerCase().startsWith('smb://')) {
+      return { action: 'deny' };
+    }
+    return { action: 'allow' };
+  });
+
+  _rootWindow.addListener('close', (event: any) => {
     event.preventDefault();
   });
 


### PR DESCRIPTION
This PR closes a security issue in our backlog, namely [VLN-10](https://rocketchat.atlassian.net/browse/VLN-10). In short, in very specific scenarios - e.g. when using XUbuntu - navigating to the `smb://` protocol may bring risks that could, although unlikely, lead to RCE. Since there's no need for Rocket.Chat to navigate to SMB shares, we can block navigating to them altogether. More details can be seen in the issue mentioned above.

[VLN-10]: https://rocketchat.atlassian.net/browse/VLN-10?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ