### PR TITLE
fix: disable dangerous fuses in `afterPack.js`

### DIFF
--- a/build/afterPack.js
+++ b/build/afterPack.js
@@ -34,7 +34,7 @@ exports.default = async function afterPack(context) {
     [FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false,
     [FuseV1Options.EnableNodeCliInspectArguments]: false,
     [FuseV1Options.LoadBrowserProcessSpecificV8Snapshot]: false,
-    [FuseV1Options.GrantFileProtocolExtraPrivileges]: false,
+    [FuseV1Options.GrantFileProtocolExtraPrivileges]: true,
   });
 
   console.log('Electron fuses applied successfully');

--- a/build/afterPack.js
+++ b/build/afterPack.js
@@ -31,10 +31,10 @@ exports.default = async function afterPack(context) {
     [FuseV1Options.OnlyLoadAppFromAsar]: true,
     [FuseV1Options.RunAsNode]: false,
     [FuseV1Options.EnableCookieEncryption]: false,
-    [FuseV1Options.EnableNodeOptionsEnvironmentVariable]: true,
-    [FuseV1Options.EnableNodeCliInspectArguments]: true,
+    [FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false,
+    [FuseV1Options.EnableNodeCliInspectArguments]: false,
     [FuseV1Options.LoadBrowserProcessSpecificV8Snapshot]: false,
-    [FuseV1Options.GrantFileProtocolExtraPrivileges]: true,
+    [FuseV1Options.GrantFileProtocolExtraPrivileges]: false,
   });
 
   console.log('Electron fuses applied successfully');


### PR DESCRIPTION
As part of our efforts to disable fuses that may bring security issues, I'm disabling 2 fuses - namely, `EnableNodeOptionsEnvironmentVariable` and `EnableNodeCliInspectArguments`. This issue is related to [VLN-137](https://rocketchat.atlassian.net/browse/VLN-137).

[VLN-137]: https://rocketchat.atlassian.net/browse/VLN-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ