### PR TITLE
fix: remove `disable-library-validation` from builder

### DIFF
--- a/build/entitlements.mas.inherit.plist
+++ b/build/entitlements.mas.inherit.plist
@@ -8,7 +8,5 @@
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
-    <key>com.apple.security.cs.disable-library-validation</key>
-    <true/>
   </dict>
 </plist>

--- a/build/entitlements.mas.plist
+++ b/build/entitlements.mas.plist
@@ -12,8 +12,6 @@
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
-    <key>com.apple.security.cs.disable-library-validation</key>
-    <true/>
     <key>com.apple.security.device.audio-input</key>
     <true/>
     <key>com.apple.security.device.camera</key>


### PR DESCRIPTION
This issue is related to [VLN-61](https://rocketchat.atlassian.net/jira/software/c/projects/VLN/boards/194/?selectedIssue=VLN-61). In short, `disable-library-validation` would allow for the loading of unsigned libraries, which may carry security risks in certain scenarios. This PR removes this setting.

[VLN-61]: https://rocketchat.atlassian.net/browse/VLN-61?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ