### PR TITLE
Make Ctrl+Shift+R Perform a True Force Reload

### DIFF
--- a/src/ui/main/menuBar.ts
+++ b/src/ui/main/menuBar.ts
@@ -575,13 +575,19 @@ const createHelpMenu = createSelector(
         label: t('menus.reload'),
         accelerator: 'CommandOrControl+Shift+R',
         click: async () => {
-          const browserWindow = await getRootWindow();
-
-          if (!browserWindow.isVisible()) {
-            browserWindow.showInactive();
+          const guestWebContents = await getCurrentViewWebcontents();
+          if (guestWebContents)
+            dispatch({
+              type: CLEAR_CACHE_TRIGGERED,
+              payload: guestWebContents.id,
+            });
+          const currentView = await getCurrentView();
+          if (typeof currentView === 'object' && !!currentView.url) {
+            dispatch({
+              type: WEBVIEW_SERVER_RELOADED,
+              payload: { url: currentView.url },
+            });
           }
-          browserWindow.focus();
-          browserWindow.webContents.reload();
         },
       },
       {


### PR DESCRIPTION
## Fix: Make `Ctrl+Shift+R` Perform a True Force Reload

### Closes #3053 

### Summary
This PR fixes the behavior of the `Ctrl+Shift+R` keyboard shortcut (Help menu "Reload") so that it performs a true "force reload" of the current server view, matching the behavior of the "Force reload" option in the View menu.

---

### Details of the Change
- **Before:**  
  - `Ctrl+Shift+R` reloaded the entire Electron main window (`browserWindow.webContents.reload()`), which could result in a blank screen and did not clear the webview’s cache or storage.
- **After:**  
  - `Ctrl+Shift+R` now triggers the same logic as the View menu’s "Force reload":
    - Clears the cache and storage for the current webview.
    - Reloads the webview using `reloadIgnoringCache()`.
    - Ensures the app state and view are properly restored.

---

### Reason for the Change
- Users expect `Ctrl+Shift+R` to perform a "force reload" of the current server view, not just reload the main window.
- The previous behavior could leave the app in a blank or broken state.
- This change makes the shortcut consistent with the menu option and improves reliability.

---

### Changeset
- Updated the Help menu’s "Reload" (`Ctrl+Shift+R`) click handler in `src/ui/main/menuBar.ts` to:
  - Dispatch `CLEAR_CACHE_TRIGGERED` for the current webview.
  - Dispatch `WEBVIEW_SERVER_RELOADED` for the current view.
  - Remove the old logic that reloaded the main window.

---
### Before fix (on pressing ctrl + shift + R):
<img width="1037" height="568" alt="image" src="https://github.com/user-attachments/assets/2ad72c3d-d33d-404d-aa66-ecb7ed0b2371" />

---
### After fix (on pressing ctrl + shift + R):
<img width="1898" height="1069" alt="image" src="https://github.com/user-attachments/assets/151cde59-5574-4934-bf18-379941b18e2a" />
