### PR TITLE
fix: Enable prerelease updates for alpha and beta channels in autoUpdates

### DIFF
--- a/src/updates/main.ts
+++ b/src/updates/main.ts
@@ -211,10 +211,19 @@ export const setupUpdates = async (): Promise<void> => {
   // Set initial channel
   autoUpdater.channel = updateChannel;
 
+  // Enable prerelease updates for alpha and beta channels
+  if (updateChannel === 'alpha' || updateChannel === 'beta') {
+    autoUpdater.allowPrerelease = true;
+  }
+
   // Listen for channel changes
   listen(ABOUT_DIALOG_UPDATE_CHANNEL_CHANGED, async (action) => {
     const newChannel = action.payload;
     autoUpdater.channel = newChannel;
+
+    // Enable prerelease updates for alpha and beta channels
+    autoUpdater.allowPrerelease =
+      newChannel === 'alpha' || newChannel === 'beta';
 
     dispatch({
       type: UPDATES_CHANNEL_CHANGED,


### PR DESCRIPTION
This commit modifies the autoUpdater configuration to allow prerelease updates when the update channel is set to 'alpha' or 'beta'. The changes ensure that the application can receive updates from these channels, enhancing the update management process.

<!--
INSTRUCTION: Your Pull Request name should start with one of the following
prefixes:

- "feat:" for new features;
- "fix:" for bug fixes.
-->

<!-- Inform the issue number that this PR closes, or remove the line below -->
Closes #ISSUE_NUMBER

<!-- Tell us more about your PR with screen shots if you can -->
