### PR TITLE
Potential fix for code scanning alert no. 36: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Build release
 
 on:

--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -1,5 +1,9 @@
 name: Build pull request artifacts
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request:
     branches:

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -9,6 +9,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
 jobs:
   check:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/RocketChat/Rocket.Chat.Electron/security/code-scanning/36](https://github.com/RocketChat/Rocket.Chat.Electron/security/code-scanning/36)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/pull-request-build.yml`. This block should be placed at the top level (recommended) so it applies to all jobs unless overridden. The minimal required permissions for this workflow are:
- `contents: read` (to allow reading repository contents)
- `pull-requests: write` (to allow posting comments to pull requests)

Add the following block after the `name:` and before the `on:` section:
```yaml
permissions:
  contents: read
  pull-requests: write
```
No additional imports or definitions are needed, as this is a YAML configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
