### PR TITLE
fix: Add asset management functions for GitHub releases

### DIFF
--- a/workspaces/desktop-release-action/src/index.ts
+++ b/workspaces/desktop-release-action/src/index.ts
@@ -9,6 +9,8 @@ import type { SemVer } from 'semver';
 import { parse } from 'semver';
 
 import {
+  clearStaleAssets,
+  forceCleanOldAssets,
   getDevelopmentRelease,
   getReleaseAssets,
   getSnapshotRelease,
@@ -68,6 +70,18 @@ const releaseDevelopment = async (commitSha: string) => {
   await pack();
 
   const release = await getDevelopmentRelease(commitSha);
+  const existingAssets = await getReleaseAssets(release.id);
+  
+  // Force clean old assets if we have too many (close to GitHub's 1000 limit)
+  if (existingAssets.length > 900) {
+    core.info(`Release has ${existingAssets.length} assets, cleaning old assets to prevent GitHub limit`);
+    await forceCleanOldAssets(release.id, 100);
+  } else {
+    const filesToUpload = await getFilesToUpload();
+    const expectedAssetNames = filesToUpload.map(path => basename(path));
+    await clearStaleAssets(release.id, expectedAssetNames);
+  }
+  
   const assets = await getReleaseAssets(release.id);
 
   for (const path of await getFilesToUpload()) {
@@ -87,6 +101,18 @@ const releaseSnapshot = async (commitSha: string) => {
   await pack();
 
   const release = await getSnapshotRelease(commitSha);
+  const existingAssets = await getReleaseAssets(release.id);
+  
+  // Force clean old assets if we have too many (close to GitHub's 1000 limit)
+  if (existingAssets.length > 900) {
+    core.info(`Release has ${existingAssets.length} assets, cleaning old assets to prevent GitHub limit`);
+    await forceCleanOldAssets(release.id, 100);
+  } else {
+    const filesToUpload = await getFilesToUpload();
+    const expectedAssetNames = filesToUpload.map(path => basename(path));
+    await clearStaleAssets(release.id, expectedAssetNames);
+  }
+  
   const assets = await getReleaseAssets(release.id);
 
   for (const path of await getFilesToUpload()) {


### PR DESCRIPTION
This commit introduces two new functions: `clearStaleAssets` and `forceCleanOldAssets`. The `clearStaleAssets` function deletes assets not included in the expected list, while `forceCleanOldAssets` removes older assets when the total exceeds a specified limit, ensuring compliance with GitHub's asset constraints. These functions are integrated into the release process to maintain optimal asset management during development and snapshot releases.

<!--
INSTRUCTION: Your Pull Request name should start with one of the following
prefixes:

- "feat:" for new features;
- "fix:" for bug fixes.
-->

<!-- Inform the issue number that this PR closes, or remove the line below -->
Closes #ISSUE_NUMBER

<!-- Tell us more about your PR with screen shots if you can -->
