### PR TITLE
fix: Prevent infinite retry loop in injected.ts

### DIFF
--- a/src/servers/preload/api.ts
+++ b/src/servers/preload/api.ts
@@ -22,6 +22,7 @@ import {
   getInternalVideoChatWindowEnabled,
   openInternalVideoChatWindow,
 } from './internalVideoChatWindow';
+import { reloadServer } from './reloadServer';
 import {
   setBackground,
   setServerVersionToSidebar,
@@ -76,6 +77,7 @@ export type RocketChatDesktopAPI = {
   clearOutlookCredentials: () => void;
   setUserToken: (token: string, userId: string) => void;
   openDocumentViewer: (url: string, format: string, options: any) => void;
+  reloadServer: () => void;
 };
 
 export const RocketChatDesktop: RocketChatDesktopAPI = {
@@ -111,4 +113,5 @@ export const RocketChatDesktop: RocketChatDesktopAPI = {
   setUserToken,
   setSidebarCustomTheme,
   openDocumentViewer,
+  reloadServer,
 };

--- a/src/servers/preload/reloadServer.ts
+++ b/src/servers/preload/reloadServer.ts
@@ -1,0 +1,13 @@
+import { dispatch } from '../../store';
+import { WEBVIEW_FORCE_RELOAD_WITH_CACHE_CLEAR } from '../../ui/actions';
+import { getServerUrl } from './urls';
+
+export const reloadServer = (): void => {
+  const url = getServerUrl();
+
+  // Dispatch action to trigger force reload with cache clear
+  dispatch({
+    type: WEBVIEW_FORCE_RELOAD_WITH_CACHE_CLEAR,
+    payload: url,
+  });
+};

--- a/src/ui/actions.ts
+++ b/src/ui/actions.ts
@@ -136,6 +136,8 @@ export const SIDE_BAR_SERVER_COPY_URL = 'side-bar/server-copy-url';
 export const SIDE_BAR_SERVER_OPEN_DEV_TOOLS = 'side-bar/server-open-dev-tools';
 export const SIDE_BAR_SERVER_FORCE_RELOAD = 'side-bar/server-force-reload';
 export const SIDE_BAR_SERVER_REMOVE = 'side-bar/server-remove';
+export const WEBVIEW_FORCE_RELOAD_WITH_CACHE_CLEAR =
+  'webview/force-reload-with-cache-clear';
 
 export type UiActionTypeToPayloadMap = {
   [ABOUT_DIALOG_DISMISSED]: void;
@@ -171,6 +173,7 @@ export type UiActionTypeToPayloadMap = {
   [SIDE_BAR_SERVER_OPEN_DEV_TOOLS]: Server['url'];
   [SIDE_BAR_SERVER_FORCE_RELOAD]: Server['url'];
   [SIDE_BAR_SERVER_REMOVE]: Server['url'];
+  [WEBVIEW_FORCE_RELOAD_WITH_CACHE_CLEAR]: Server['url'];
   [TOUCH_BAR_FORMAT_BUTTON_TOUCHED]:
     | 'bold'
     | 'italic'


### PR DESCRIPTION
## Summary

Fixes infinite retry loop when `window.require` is not available in the injected script. The script now retries for a maximum of 30 seconds before triggering an automatic recovery.

## Problem

The injected script was retrying indefinitely every second when `window.require` was not defined, causing performance issues and preventing recovery.

## Solution

- Added 30-second maximum retry time limit
- Implemented exponential backoff (1s to 5s cap per retry) 
- Automatic force reload with cache clear after timeout
- Preserves user session during recovery

## Implementation

- Created `WEBVIEW_FORCE_RELOAD_WITH_CACHE_CLEAR` Redux action
- Added `reloadServer` preload module following existing patterns
- Uses `listen()` for action handling in main process
- Clears all caches while keeping session data
- Uses `reloadIgnoringCache()` for proper cache bypass

## Test Plan

- [ ] App starts normally when servers load properly
- [ ] If `window.require` is delayed, console shows retry messages with increasing delays
- [ ] After 30 seconds total, automatic reload triggers if `window.require` is still unavailable
- [ ] User session is preserved after automatic reload
- [ ] No more infinite retry loops in console