### PR TITLE
fix: Fix PowerShell script encoding issues causing build failures

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -11,7 +11,7 @@
     "category": "public.app-category.productivity",
     "target": ["dmg", "pkg", "zip", "mas"],
     "icon": "build/icon.icns",
-    "bundleVersion": "25072",
+    "bundleVersion": "25090",
     "helperBundleId": "chat.rocket.electron.helper",
     "type": "distribution",
     "artifactName": "rocketchat-${version}-${os}.${ext}",


### PR DESCRIPTION
## Problem
The KMS CNG provider installation script was failing on Windows runners with parse errors due to:
1. Emojis in the script causing encoding issues
2. Complex string formatting syntax that PowerShell couldn't parse

## Error Message
```
Unexpected token 'KB' in expression or statement.
Missing closing ')' in expression.
The string is missing the terminator: ".
```

## Solution
- Replaced all emojis with text indicators:
  - ✅ → [SUCCESS]
  - ❌ → [ERROR]  
  - 📁 → [INFO]
  - ⏳ → [WAIT]
  - 🔄 → [INFO]
  - 🧹 → [INFO]
  - 🎉 → [SUCCESS]
- Fixed string formatting by simplifying file size calculations
- Removed complex string interpolation that was causing parse errors

## Testing
- Script now parses correctly without syntax errors
- All functionality remains the same, just with text indicators instead of emojis
- File size calculations work correctly with simplified approach

## Impact
This fixes the immediate build failures on Windows runners in the CI pipeline.