### PR TITLE
fix: Remove last remaining emoji from PowerShell script

### DIFF
--- a/build/install-kms-cng-provider.ps1
+++ b/build/install-kms-cng-provider.ps1
@@ -79,7 +79,7 @@ if ((Test-Path $CachedMsiPath) -and -not $Force) {
                 Write-Host "[SUCCESS] ZIP downloaded successfully ($zipSize MB)" -ForegroundColor Green
                 
                 # Extract MSI from ZIP
-                Write-Host "📦 Extracting MSI from ZIP..." -ForegroundColor Cyan
+                Write-Host "[INFO] Extracting MSI from ZIP..." -ForegroundColor Cyan
                 if (Test-Path $TempExtractDir) {
                     Remove-Item -Path $TempExtractDir -Recurse -Force
                 }


### PR DESCRIPTION
## Problem
One emoji was missed in PR #3090, causing the build to still fail with parsing errors.

## Fix
- Remove the 📦 emoji from line 82
- Replace with [INFO] text indicator

This completes the emoji removal that was started in #3090.