### PR TITLE
fix: Update Windows NSIS build command to include additional architectures

### DIFF
--- a/workspaces/desktop-release-action/src/windows/index.ts
+++ b/workspaces/desktop-release-action/src/windows/index.ts
@@ -49,7 +49,7 @@ export const packOnWindows = async (): Promise<void> => {
     
     // Build NSIS installer (unsigned)
     core.info('Building NSIS installer (unsigned)...');
-    await runElectronBuilder(`--x64 --win nsis`, buildEnv);
+    await runElectronBuilder(`--x64 --ia32 --arm64 --win nsis`, buildEnv);
     
     // Build MSI installer (unsigned)
     core.info('Building MSI installer (unsigned)...');


### PR DESCRIPTION
- Modified the `packOnWindows` function to build NSIS installer for x64, ia32, and arm64 architectures.
- This change ensures broader compatibility for the Windows installer package.
