### PR TITLE
feat: Add desktop notification for user logout events

### DIFF
--- a/src/i18n/en.i18n.json
+++ b/src/i18n/en.i18n.json
@@ -162,7 +162,8 @@
       "downloadCancelled": "Download Cancelled",
       "downloadFailed": "Download Failed",
       "downloadExpired": "Downlaod Expired",
-      "downloadExpiredMessage": "Please retry downloading from source."
+      "downloadExpiredMessage": "Please retry downloading from source.",
+      "userLoggedOut": "You've been logged out"
     },
     "filters": {
       "search": "Search",


### PR DESCRIPTION
- Displays 'You've been logged out' notification when users are randomly logged out
- Helps users quickly notice logout events and reconnect promptly during working hours

Closes #2951 

## Changes

- **Notification System**: Added logout detection listener in `src/servers/main.ts` that monitors user login state changes
- **Internationalization**: Added `userLoggedOut` message in `src/i18n/en.i18n.json`
- **Integration**: Leverages existing notification infrastructure and user login monitoring

## Implementation Details

The solution builds on the existing user login detection system (`Meteor.userId()` monitoring in `injected.ts`) that already dispatches `WEBVIEW_USER_LOGGED_IN` actions. A new listener detects when users transition from logged in to logged out and shows a desktop notification.

## Screenshot

<img width="1366" height="768" alt="1759069566" src="https://github.com/user-attachments/assets/d34ce95c-a90b-43d8-a158-9ff6a7d238ca" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Shows a notification when you are logged out of a connected service, helping you quickly identify session changes.

- Chores
  - Updated English localization to include a “You’ve been logged out” message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->