### PR TITLE
chore(dev): bump electron to 37.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "chokidar": "~3.5.3",
     "conventional-changelog-cli": "~4.1.0",
     "convert-svg-to-png": "~0.6.4",
-    "electron": "37.2.4",
+    "electron": "37.6.0",
     "electron-builder": "26.0.3",
     "electron-devtools-installer": "^3.2.0",
     "electron-notarize": "^1.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8315,16 +8315,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:37.2.4":
-  version: 37.2.4
-  resolution: "electron@npm:37.2.4"
+"electron@npm:37.6.0":
+  version: 37.6.0
+  resolution: "electron@npm:37.6.0"
   dependencies:
     "@electron/get": "npm:^2.0.0"
     "@types/node": "npm:^22.7.7"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10/b6b379043fe1801c69d4cf1969c0a61a5ce7f27e2474d18e6591baf51b0ff303122475d9f6c4686532187c8e90488789da2ecb0db6278a5b773e43321ffb55d2
+  checksum: 10/b2b5179bb32e05db9e244e36bb2e1829675a18fb2466fa4fd9823566e204256d43efae1ef365db6f41501361bf1d7e354d3cb1692d643fcc0ce324b5417734c4
   languageName: node
   linkType: hard
 
@@ -14520,7 +14520,7 @@ __metadata:
     conventional-changelog-cli: "npm:~4.1.0"
     convert-svg-to-png: "npm:~0.6.4"
     detect-browsers: "npm:~6.1.0"
-    electron: "npm:37.2.4"
+    electron: "npm:37.6.0"
     electron-builder: "npm:26.0.3"
     electron-devtools-installer: "npm:^3.2.0"
     electron-dl: "npm:4.0.0"


### PR DESCRIPTION
### Upstream performance fixes
- [electron/electron#48376](https://github.com/electron/electron/pull/48376): macOS Tahoe — stop overriding private cornerMask to fix WindowServer GPU load. What: remove custom _cornerMask override and rely on AppKit default mask/shadow caching to reduce GPU usage when shadows are enabled.
- [electron/electron#48379](https://github.com/electron/electron/pull/48379): macOS Tahoe — disable NSAutoFillHeuristicController. What: turn off autofill heuristics that caused CPU spikes, improving responsiveness during text input and menus.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing features added in this release.

- Chores
  - Upgraded Electron to 37.6.0 to align with the latest stable release. This update brings general stability, performance, and security improvements from upstream. No functional changes are expected, but users may experience smoother operation and improved reliability across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->