### PR TITLE
feat: Open the app when clicking the tray icon

### DIFF
--- a/src/ui/main/trayIcon.ts
+++ b/src/ui/main/trayIcon.ts
@@ -27,19 +27,24 @@ const createTrayIcon = (): Tray => {
 
   const trayIcon = new Tray(nativeImage.createEmpty());
 
-  if (process.platform !== 'darwin') {
-    trayIcon.addListener('click', async () => {
-      const isRootWindowVisible = select(selectIsRootWindowVisible);
-      const browserWindow = await getRootWindow();
+  trayIcon.addListener('click', async () => {
+    const browserWindow = await getRootWindow();
 
-      if (isRootWindowVisible) {
-        browserWindow.hide();
-        return;
-      }
-
+    if (process.platform === 'darwin') {
       browserWindow.show();
-    });
-  }
+      browserWindow.focus();
+      return;
+    }
+
+    const isRootWindowVisible = select(selectIsRootWindowVisible);
+
+    if (isRootWindowVisible) {
+      browserWindow.hide();
+      return;
+    }
+
+    browserWindow.show();
+  });
 
   trayIcon.addListener('balloon-click', async () => {
     const isRootWindowVisible = select(selectIsRootWindowVisible);

--- a/src/ui/main/trayIcon.ts
+++ b/src/ui/main/trayIcon.ts
@@ -28,22 +28,29 @@ const createTrayIcon = (): Tray => {
   const trayIcon = new Tray(nativeImage.createEmpty());
 
   trayIcon.addListener('click', async () => {
+    try {
     const browserWindow = await getRootWindow();
 
-    if (process.platform === 'darwin') {
+      if (process.platform === 'darwin') {
+        browserWindow.show();
+        browserWindow.focus();
+        return;
+      }
+
+      const isRootWindowVisible = select(selectIsRootWindowVisible);
+
+      if (isRootWindowVisible) {
+        browserWindow.hide();
+        return;
+      }
+
       browserWindow.show();
-      browserWindow.focus();
+      
+        } catch (error) {
+      console.error('Failed to get root window on tray click:', error);
       return;
     }
 
-    const isRootWindowVisible = select(selectIsRootWindowVisible);
-
-    if (isRootWindowVisible) {
-      browserWindow.hide();
-      return;
-    }
-
-    browserWindow.show();
   });
 
   trayIcon.addListener('balloon-click', async () => {


### PR DESCRIPTION
This feature makes the app open when you push the tray icon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Refactor
  * Unified tray icon click behavior across platforms for a more consistent experience.
  * macOS: clicking the tray icon now always brings the main window to the front and focuses it.
  * Windows/Linux: clicking the tray icon now toggles the main window’s visibility.
  * Balloon notifications and the right-click context menu remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->