### PR TITLE
fix: Making menu's ^ icon's color visible

### DIFF
--- a/src/ui/components/DownloadsManagerView/index.tsx
+++ b/src/ui/components/DownloadsManagerView/index.tsx
@@ -229,6 +229,7 @@ const DownloadsManagerView = () => {
           flexShrink={3}
           flexBasis='0'
           paddingInline={2}
+          style={{ color: '#C0C0C0' }}
         >
           <SelectLegacy
             value={serverFilter}
@@ -237,7 +238,7 @@ const DownloadsManagerView = () => {
             onChange={handleServerFilterChange}
           />
         </Box>
-        <Box display='flex' flexGrow={3} flexShrink={3} paddingInline={2}>
+        <Box display='flex' flexGrow={3} flexShrink={3} paddingInline={2} style={{ color: '#C0C0C0' }}>
           <SelectLegacy
             value={mimeTypeFilter}
             placeholder={t('downloads.filters.mimeType')}
@@ -245,7 +246,7 @@ const DownloadsManagerView = () => {
             onChange={handleMimeFilter}
           />
         </Box>
-        <Box display='flex' flexGrow={3} flexShrink={3} paddingInline={2}>
+        <Box display='flex' flexGrow={3} flexShrink={3} paddingInline={2} style={{ color: '#C0C0C0' }}>
           <SelectLegacy
             value={statusFilter}
             placeholder={t('downloads.filters.status')}

--- a/src/ui/components/SettingsView/features/AvailableBrowsers.tsx
+++ b/src/ui/components/SettingsView/features/AvailableBrowsers.tsx
@@ -82,7 +82,7 @@ export const AvailableBrowsers = (props: AvailableBrowsersProps) => {
             {t('settings.options.availableBrowsers.description')}
           </FieldHint>
         </Box>
-        <Box display='flex' alignItems='center' style={{ paddingTop: '4px' }}>
+        <Box display='flex' alignItems='center' style={{ paddingTop: '4px', color: '#C0C0C0' }}>
           <SelectLegacy
             options={options}
             value={selectedBrowser ?? 'system'}


### PR DESCRIPTION
Ticket ID: 

Making menu's ^ icon's color visible

Before


After Fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Applied gray text color styling to filter controls in Downloads Manager view.
  * Updated text color in the Available Browsers section of Settings for visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->