### PR TITLE
fix: making menu's ^ icon's color visible

### DIFF
--- a/src/ui/components/DownloadsManagerView/index.tsx
+++ b/src/ui/components/DownloadsManagerView/index.tsx
@@ -224,12 +224,12 @@ const DownloadsManagerView = () => {
           />
         </Box>
         <Box
+          color='hint'
           display='flex'
           flexGrow={3}
           flexShrink={3}
           flexBasis='0'
           paddingInline={2}
-          style={{ color: '#C0C0C0' }}
         >
           <SelectLegacy
             value={serverFilter}
@@ -238,11 +238,12 @@ const DownloadsManagerView = () => {
             onChange={handleServerFilterChange}
           />
         </Box>
-        <Box display='flex'
+        <Box
+          color='hint'
+          display='flex'
           flexGrow={3}
           flexShrink={3}
           paddingInline={2}
-          style={{ color: '#C0C0C0' }}
         >
           <SelectLegacy
             value={mimeTypeFilter}
@@ -251,11 +252,12 @@ const DownloadsManagerView = () => {
             onChange={handleMimeFilter}
           />
         </Box>
-        <Box display='flex'
+        <Box
+          color='hint'
+          display='flex'
           flexGrow={3}
           flexShrink={3}
           paddingInline={2}
-          style={{ color: '#C0C0C0' }}
         >
           <SelectLegacy
             value={statusFilter}

--- a/src/ui/components/SettingsView/features/AvailableBrowsers.tsx
+++ b/src/ui/components/SettingsView/features/AvailableBrowsers.tsx
@@ -83,9 +83,10 @@ export const AvailableBrowsers = (props: AvailableBrowsersProps) => {
           </FieldHint>
         </Box>
         <Box
+          color='hint'
           display='flex'
           alignItems='center'
-          style={{ paddingTop: '4px', color: '#C0C0C0' }}
+          style={{ paddingTop: '4px' }}
         >
           <SelectLegacy
             options={options}


### PR DESCRIPTION
Ticket ID: https://github.com/RocketChat/Rocket.Chat.Electron/issues/3124

fix: making menu's ^ icon's color visible

Before
<img width="1586" height="897" alt="image" src="https://github.com/user-attachments/assets/332ff6b8-57fa-48c3-bdea-b0d7f179277e" />

After Fix
<img width="959" height="539" alt="image" src="https://github.com/user-attachments/assets/ace1defb-7019-41ba-b18e-b1669c3ffda5" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated text color for filter boxes in the Downloads Manager to improve visual consistency and legibility.
  * Adjusted text color in the Available Browsers settings area to better match the UI palette and enhance presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->