### PR TITLE
3124 - Settings menu section's icon's color fixes

### DIFF
--- a/src/ui/components/DownloadsManagerView/index.tsx
+++ b/src/ui/components/DownloadsManagerView/index.tsx
@@ -243,6 +243,7 @@ const DownloadsManagerView = () => {
           display='flex'
           flexGrow={3}
           flexShrink={3}
+          flexBasis='0'
           paddingInline={2}
         >
           <SelectLegacy
@@ -257,6 +258,7 @@ const DownloadsManagerView = () => {
           display='flex'
           flexGrow={3}
           flexShrink={3}
+          flexBasis='0'
           paddingInline={2}
         >
           <SelectLegacy

--- a/src/ui/components/DownloadsManagerView/index.tsx
+++ b/src/ui/components/DownloadsManagerView/index.tsx
@@ -224,6 +224,7 @@ const DownloadsManagerView = () => {
           />
         </Box>
         <Box
+          color='hint'
           display='flex'
           flexGrow={3}
           flexShrink={3}
@@ -237,7 +238,13 @@ const DownloadsManagerView = () => {
             onChange={handleServerFilterChange}
           />
         </Box>
-        <Box display='flex' flexGrow={3} flexShrink={3} paddingInline={2}>
+        <Box
+          color='hint'
+          display='flex'
+          flexGrow={3}
+          flexShrink={3}
+          paddingInline={2}
+        >
           <SelectLegacy
             value={mimeTypeFilter}
             placeholder={t('downloads.filters.mimeType')}
@@ -245,7 +252,13 @@ const DownloadsManagerView = () => {
             onChange={handleMimeFilter}
           />
         </Box>
-        <Box display='flex' flexGrow={3} flexShrink={3} paddingInline={2}>
+        <Box
+          color='hint'
+          display='flex'
+          flexGrow={3}
+          flexShrink={3}
+          paddingInline={2}
+        >
           <SelectLegacy
             value={statusFilter}
             placeholder={t('downloads.filters.status')}

--- a/src/ui/components/SettingsView/features/AvailableBrowsers.tsx
+++ b/src/ui/components/SettingsView/features/AvailableBrowsers.tsx
@@ -86,7 +86,7 @@ export const AvailableBrowsers = (props: AvailableBrowsersProps) => {
           color='hint'
           display='flex'
           alignItems='center'
-          style={{ paddingTop: '4px' }}
+          paddingBlockStart={4}
         >
           <SelectLegacy
             options={options}

--- a/src/ui/components/SettingsView/features/AvailableBrowsers.tsx
+++ b/src/ui/components/SettingsView/features/AvailableBrowsers.tsx
@@ -82,7 +82,12 @@ export const AvailableBrowsers = (props: AvailableBrowsersProps) => {
             {t('settings.options.availableBrowsers.description')}
           </FieldHint>
         </Box>
-        <Box display='flex' alignItems='center' style={{ paddingTop: '4px' }}>
+        <Box
+          color='hint'
+          display='flex'
+          alignItems='center'
+          style={{ paddingTop: '4px' }}
+        >
           <SelectLegacy
             options={options}
             value={selectedBrowser ?? 'system'}


### PR DESCRIPTION
## **📌 Ticket ID:** https://github.com/RocketChat/Rocket.Chat.Electron/issues/3124

## **✅ fix: making menu's ^ icon's color visible**

### **⌚ Before**

<img width="1586" height="897" alt="image" src="https://github.com/user-attachments/assets/332ff6b8-57fa-48c3-bdea-b0d7f179277e" />

### **🕛 After Fix**

<img width="959" height="539" alt="image" src="https://github.com/user-attachments/assets/ace1defb-7019-41ba-b18e-b1669c3ffda5" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated visual styling of filter containers to use a muted hint color for more consistent UI appearance and layout balance.
  * Wrapped the browser selector in a hint-colored container with adjusted spacing for improved presentation without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->