### PR TITLE
feat(pdf-viewer): resolve issue #2911 – added close and back navigation buttons logic

### DIFF
--- a/src/ui/components/ServersView/DocumentViewer.tsx
+++ b/src/ui/components/ServersView/DocumentViewer.tsx
@@ -129,15 +129,15 @@ const DocumentViewer = ({
 
             <IconButton
               icon='cross'
-              onClick={() => {
+              onClick={async () => {
                 const webviewElement = webviewRef.current;
 
                 if (webviewElement) {
-                  webviewElement.executeJavaScript(`
-                    if (document.fullscreenElement) {
-                      document.exitFullscreen();
-                    }
-                  `);
+                  await webviewElement.executeJavaScript(`
+            if (document.fullscreenElement) {
+              document.exitFullscreen();
+                  }             
+               `);
                   webviewElement.src = 'about:blank';
                 }
 

--- a/src/ui/components/ServersView/DocumentViewer.tsx
+++ b/src/ui/components/ServersView/DocumentViewer.tsx
@@ -89,14 +89,15 @@ const DocumentViewer = ({
           display='flex'
           color={theme === 'dark' ? 'font-white' : 'font-text'}
         >
+          <IconButton
+            icon='arrow-back'
+            onClick={() => {
+              const webviewElement = webviewRef.current;
+              if (!webviewElement) return;
 
-           <IconButton
-              icon="arrow-back"
-              onClick={() => {
-                const webviewElement = webviewRef.current;
-                if (!webviewElement) return;
-              
-                webviewElement.executeJavaScript(`
+              webviewElement
+                .executeJavaScript(
+                  `
                   (async () => {
                     if (document.fullscreenElement) {
                       document.exitFullscreen();
@@ -105,32 +106,32 @@ const DocumentViewer = ({
                       return "no-fullscreen";
                     }
                   })();
-                `)
+                `
+                )
                 .then((result) => {
-                  if (result === "no-fullscreen") {
+                  if (result === 'no-fullscreen') {
                     closeDocumentViewer();
                   }
                 })
-                .catch((err) => console.error("Back button error:", err));
-              }}
-              mi="x8"
-              color={theme === "dark" ? "white" : "default"}
-            />
-
+                .catch((err) => console.error('Back button error:', err));
+            }}
+            mi='x8'
+            color={theme === 'dark' ? 'white' : 'default'}
+          />
 
           <Box
-          display='flex'
-          justifyContent='space-between'
-          alignItems='center'
-          width='100%'
+            display='flex'
+            justifyContent='space-between'
+            alignItems='center'
+            width='100%'
           >
-          <h2>PDF Viewer</h2>
+            <h2>PDF Viewer</h2>
 
-          <IconButton
+            <IconButton
               icon='cross'
               onClick={() => {
                 const webviewElement = webviewRef.current;
-              
+
                 if (webviewElement) {
                   webviewElement.executeJavaScript(`
                     if (document.fullscreenElement) {
@@ -139,17 +140,16 @@ const DocumentViewer = ({
                   `);
                   webviewElement.src = 'about:blank';
                 }
-              
-                // reset React state 
+
+                // reset React state
                 setDocumentUrl('about:blank');
-              
-                // finally close the viewer 
+
+                // finally close the viewer
                 closeDocumentViewer();
               }}
               mi='x8'
               color={theme === 'dark' ? 'white' : 'default'}
             />
-            
           </Box>
         </Box>
 

--- a/src/ui/components/ServersView/DocumentViewer.tsx
+++ b/src/ui/components/ServersView/DocumentViewer.tsx
@@ -133,11 +133,15 @@ const DocumentViewer = ({
                 const webviewElement = webviewRef.current;
 
                 if (webviewElement) {
-                  await webviewElement.executeJavaScript(`
-                    if (document.fullscreenElement) {
-                      document.exitFullscreen();
-                    }             
-                  `);
+                  try {
+                    await webviewElement.executeJavaScript(`
+                      if (document.fullscreenElement) {
+                        document.exitFullscreen();
+                      }
+                   `);
+                  } catch (err) {
+                    console.error('Close button error:', err);
+                  }
                   webviewElement.src = 'about:blank';
                 }
 

--- a/src/ui/components/ServersView/DocumentViewer.tsx
+++ b/src/ui/components/ServersView/DocumentViewer.tsx
@@ -134,10 +134,10 @@ const DocumentViewer = ({
 
                 if (webviewElement) {
                   await webviewElement.executeJavaScript(`
-            if (document.fullscreenElement) {
-              document.exitFullscreen();
-                  }             
-               `);
+                    if (document.fullscreenElement) {
+                      document.exitFullscreen();
+                    }             
+                  `);
                   webviewElement.src = 'about:blank';
                 }
 


### PR DESCRIPTION
<!--
INSTRUCTION: Your Pull Request name should start with one of the following
prefixes:

- "feat:" for new features;
- "fix:" for bug fixes.
-->

<!-- Inform the issue number that this PR closes, or remove the line below -->
Closes #2911 

<!-- Tell us more about your PR with screen shots if you can -->


Enhancement: Improved PDF viewer navigation and control

Introduced two key features to improve user experience:

A close button that exits the PDF viewer completely.

A back navigation button that lets users move one page backward within the document.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a close (cross) button to the document viewer for quick dismissal.
* **Bug Fixes**
  * Back button now attempts to exit fullscreen before closing the viewer.
  * Closing the viewer clears displayed content and resets the viewer to avoid lingering documents.
* **Style**
  * Header layout updated so the title and close control align neatly and respond better in fullscreen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->