### PR TITLE
fix: ensure supportedVersions cache uses secure file permissions (0600)

### DIFF
--- a/src/servers/supportedVersions/main.ts
+++ b/src/servers/supportedVersions/main.ts
@@ -47,7 +47,8 @@ const supportedVersionsStore = new ElectronStore<{
   [key: string]: SupportedVersions;
 }>({
   name: 'supportedVersions',
-});
+  fileMode: 0o600,
+} as any);
 
 let builtinSupportedVersions: SupportedVersions | undefined;
 
@@ -69,21 +70,21 @@ const getBuiltinSupportedVersions = async (): Promise<
 
 const logRequestError =
   (description: string) =>
-  (error: unknown): undefined => {
-    if (axios.isAxiosError(error)) {
-      if (error.response) {
-        console.error(
-          `Couldn't load ${description}: ${error.response.status} ${error.response.data}`
-        );
+    (error: unknown): undefined => {
+      if (axios.isAxiosError(error)) {
+        if (error.response) {
+          console.error(
+            `Couldn't load ${description}: ${error.response.status} ${error.response.data}`
+          );
+        } else {
+          // Something happened in setting up the request that triggered an Error
+          console.error(`Couldn't load ${description}: ${error.message}`);
+        }
       } else {
-        // Something happened in setting up the request that triggered an Error
-        console.error(`Couldn't load ${description}: ${error.message}`);
+       console.error(`Fetching ${description} error:`, error);
       }
-    } else {
-      console.error('Fetching ${description} error:', error);
-    }
-    return undefined;
-  };
+      return undefined;
+    };
 
 const getCacheKey = (serverUrl: string): string =>
   `supportedVersions:${serverUrl}`;


### PR DESCRIPTION
This PR fixes incorrect permission mode for the `supportedVersions` ElectronStore cache file.

The file was created with default permissions (~644), which caused permission errors when reading the cache in some environments.  
This fix sets `fileMode: 0o600` so the cache is readable and writable only by the current user.

Tested on Windows and WSL — the cache file is now created with 600 permissions.

Screenshot:
<img src="https://github.com/user-attachments/assets/07166791-3a0a-4d8a-857e-7b92d20e203f" width="600" />

Closes #3147


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging for network failures to provide clearer, more actionable diagnostics for requests with no remote response.
  * Adjusted non-network error messages to be more consistent and readable.

* **Chores**
  * Strengthened on-disk store permissions for stored data.
  * Internal configuration and logging refinements to enhance security and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->