### PR TITLE
fix: Skip signing non-singnable file types like appx

### DIFF
--- a/build/winSignKms.js
+++ b/build/winSignKms.js
@@ -167,7 +167,10 @@ signWindowsOnLinux = async function (config) {
   const ext = path.extname(input).toLowerCase();
   const skipExtensions = ['.appx', '.zip'];
   if (skipExtensions.includes(ext)) {
-    console.log(`[winSignKms] Skipping ${ext} file (not applicable for Authenticode signing):`, path.basename(input));
+    console.log(
+      `[winSignKms] Skipping ${ext} file (not applicable for Authenticode signing):`,
+      path.basename(input)
+    );
     return;
   }
 
@@ -309,7 +312,10 @@ signWindowsOnWindows = async function (config) {
   const ext = path.extname(input).toLowerCase();
   const skipExtensions = ['.appx', '.zip'];
   if (skipExtensions.includes(ext)) {
-    console.log(`[winSignKms] Skipping ${ext} file (not applicable for Authenticode signing):`, path.basename(input));
+    console.log(
+      `[winSignKms] Skipping ${ext} file (not applicable for Authenticode signing):`,
+      path.basename(input)
+    );
     return;
   }
 


### PR DESCRIPTION
- Added logic to skip files with extensions `.appx` and `.zip` in both `signWindowsOnLinux` and `signWindowsOnWindows` functions, improving the efficiency of the signing process by avoiding unnecessary operations on unsupported file types.
- Included console logging to inform users when a file is skipped, enhancing transparency in the signing workflow.

<!--
INSTRUCTION: Your Pull Request name should start with one of the following
prefixes:

- "feat:" for new features;
- "fix:" for bug fixes.
-->

<!-- Inform the issue number that this PR closes, or remove the line below -->
Closes #ISSUE_NUMBER

<!-- Tell us more about your PR with screen shots if you can -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Skips incompatible installer/archive file types (e.g., .appx, .zip) during Windows signing flows, emitting a log and returning early to avoid unnecessary processing and improve build efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->