### PR TITLE
Fix: Channel name truncation visibility #3166

### DIFF
--- a/src/injected.ts
+++ b/src/injected.ts
@@ -392,6 +392,7 @@ const start = async () => {
     gitCommitHash: false,
     themeAppearance: false,
     userPresence: false,
+    hoverTooltips: false,
   };
 
   // Setup reactive features that depend on modules (with polling)
@@ -593,6 +594,24 @@ const start = async () => {
         });
       });
       setupFlags.userPresence = true;
+    }
+    // Generic hover tooltip for truncated text
+    if (!setupFlags.hoverTooltips) {
+      document.body.addEventListener('mouseover', (e) => {
+        const target = e.target as HTMLElement;
+
+        if (
+          target.nodeType === Node.ELEMENT_NODE &&
+          target.scrollWidth > target.clientWidth &&
+          target.innerText &&
+          !target.hasAttribute('title') &&
+          target.className.includes &&
+          target.className.includes('title')
+        ) {
+          target.setAttribute('title', target.innerText);
+        }
+      });
+      setupFlags.hoverTooltips = true;
     }
   };
 


### PR DESCRIPTION
### Description
This PR addresses issue RocketChat/Rocket.Chat#38316 where long channel names in the sidebar are truncated without a way to view the full name.

It implements a solution using ```bash src/injected.ts ```  to inject a ```bash mouseover``` event listener. This listener detects if an element with a class containing "title" (like sidebar items) is truncated ```bash (scrollWidth > clientWidth)```. If so, it adds a native browser ```bash title``` attribute, displaying the full text in a tooltip on hover.

### Logic

- **Event: Global** ```bash mouseover``` on ```bash document.body``` (delegated).

**- Condition:**

1. Element is truncated.
2. Element text is present.
3. Element does not already have a ```bash title.```
4. Element class name includes "title" (to target sidebar items and avoid chat messages).

- **Action:** Sets ```bash title ``` attribute to  ```bash innerText.```

**Tasks**
 

- [ ] Verified tooltips appear for truncated sidebar items.

 

- [ ] Verified tooltips do NOT appear for long chat messages.

**Issue**
Closes RocketChat/Rocket.Chat#38316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hover tooltips now automatically display for elements with truncated text, allowing users to view complete content on hover.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->