### PR TITLE
fix: correct app version matched to release tag 4.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "Rocket.Chat",
   "name": "rocketchat",
   "description": "Official OSX, Windows, and Linux Desktop Clients for Rocket.Chat",
-  "version": "4.11.1",
+  "version": "4.11.2",
   "author": "Rocket.Chat Support <support@rocket.chat>",
   "copyright": "© 2016-2026, Rocket.Chat",
   "homepage": "https://rocket.chat",


### PR DESCRIPTION
The release tagged `4.11.2` was built while the app version in `package.json` was still `4.11.1`. This caused:

- Release asset filenames to show `4.11.1`
- The app "About" dialog to report `4.11.1`

This PR updates the root `package.json` version to `4.11.2` so future builds match the release tag and prevent version inconsistencies.
