### PR TITLE
Add Claude Code automations for developer workflow

### DIFF
--- a/.claude/agents/cross-platform-validator.md
+++ b/.claude/agents/cross-platform-validator.md
@@ -1,0 +1,42 @@
+# Cross-Platform Validator
+
+Review code changes for cross-platform compatibility issues across Windows, macOS, and Linux.
+
+## What to Check
+
+### Linux-Only APIs
+Flag any usage of Linux-only Node.js APIs without defensive coding:
+- `process.getuid()` must use `process.getuid?.() ?? 1000`
+- `process.getgid()` must use `process.getgid?.() ?? 1000`
+- `process.geteuid()` must use `process.geteuid?.() ?? 1000`
+- `process.getegid()` must use `process.getegid?.() ?? 1000`
+
+### Path Handling
+- Hardcoded `/` path separators - should use `path.join()` or `path.resolve()`
+- Hardcoded Unix paths like `/tmp`, `/home` - should use `os.tmpdir()`, `os.homedir()`
+- Case-sensitive file path comparisons - Windows is case-insensitive
+
+### Electron API Compatibility
+- Check that Electron APIs used exist on all target platforms
+- `app.dock` is macOS-only - must be guarded with `process.platform === 'darwin'`
+- `systemPreferences.getUserDefault()` is macOS-only
+- `app.setLoginItemSettings()` differs per platform
+- `BrowserWindow.setThumbarButtons()` is Windows-only
+- `Tray` behavior differs significantly per platform
+
+### Environment Variables
+- `HOME` vs `USERPROFILE` (use `os.homedir()` instead)
+- `XDG_*` variables are Linux-only
+- Path list separator `:` vs `;` (use `path.delimiter`)
+
+### Native Modules
+- Flag any new native module dependencies that may need platform-specific builds
+- Check that `optionalDependencies` are properly guarded
+
+## Output Format
+
+For each issue found, report:
+1. File path and line number
+2. The problematic code
+3. The recommended fix
+4. Severity: `error` (will break on a platform) or `warning` (may cause issues)

--- a/.claude/agents/i18n-validator.md
+++ b/.claude/agents/i18n-validator.md
@@ -1,0 +1,50 @@
+# i18n Validator
+
+Validate translation key completeness and consistency across all language files when i18n files are modified.
+
+## When to Use
+
+Run this agent when any file in `src/i18n/` is modified to ensure translations stay consistent.
+
+## Validation Steps
+
+### 1. Load Reference
+
+Read `src/i18n/en.i18n.json` as the reference. Flatten all nested keys into dot-notation paths (e.g., `dialog.about.title`).
+
+### 2. Compare Each Language
+
+For each `*.i18n.json` file in `src/i18n/` (except English):
+
+**Check for missing keys:**
+- Keys present in English but absent in this language
+- Report the English value so translators know what to translate
+
+**Check for extra keys:**
+- Keys present in this language but absent in English
+- These are likely outdated and should be removed
+
+**Check for structural mismatches:**
+- A key is a string in English but an object in the translation (or vice versa)
+- Interpolation variables (e.g., `{{name}}`, `<1>...</1>`) present in English but missing in translation
+
+### 3. Report
+
+Output findings grouped by severity:
+
+**Errors** (must fix):
+- Structural mismatches (wrong type: string vs object)
+- Missing interpolation variables that would cause runtime errors
+
+**Warnings** (should fix):
+- Missing translation keys (will fall back to English)
+- Extra keys not in English reference (dead translations)
+
+**Info**:
+- Coverage percentage per language
+- Total missing keys across all languages
+
+## Language Files
+
+Located in `src/i18n/`:
+ar, de-DE, en (reference), es, fi, fr, hu, it-IT, ja, nb-NO, nn, no, pl, pt-BR, ru, se, sv, tr-TR, uk-UA, zh, zh-CN, zh-TW

--- a/.claude/agents/test-coverage-gap.md
+++ b/.claude/agents/test-coverage-gap.md
@@ -1,0 +1,71 @@
+# Test Coverage Gap Analyzer
+
+Identify source files and modules that lack test coverage and prioritize which areas need tests most.
+
+## How to Analyze
+
+### 1. Scan Source Directories
+
+For each directory under `src/`, count:
+- Total `.ts` and `.tsx` source files (excluding `.spec.ts`, `.test.ts`, type definitions `.d.ts`)
+- Total test files (`.spec.ts`, `.test.ts`, `.main.spec.ts`)
+
+### 2. Map Test Coverage
+
+Create a coverage map showing each module's test status:
+
+| Module | Source Files | Test Files | Coverage |
+|--------|-------------|-----------|----------|
+| ui/ | count | count | percentage |
+| servers/ | count | count | percentage |
+| ...etc | | | |
+
+### 3. Prioritize by Risk
+
+Rank untested modules by criticality:
+
+**Critical (user-facing, data-handling)**:
+- `notifications/` - User-facing notification system
+- `outlookCalendar/` - External service integration (EWS)
+- `servers/` - Core multi-server management
+- `downloads/` - File download handling
+- `store/` - Redux state management and IPC sync
+
+**High (core functionality)**:
+- `ipc/` - Inter-process communication
+- `updates/` - Auto-update system
+- `deepLinks/` - Deep link handling
+- `userPresence/` - Presence tracking
+
+**Medium (UI, can be visually verified)**:
+- `ui/` - React components
+- `screenSharing/` - Screen sharing UI
+- `videoCallWindow/` - Video call UI
+
+### 4. Suggest Test Targets
+
+For each untested module, identify the most testable files:
+- Pure functions and utilities
+- Reducers (pure state transformations)
+- Action creators
+- IPC handler logic (separate from Electron APIs)
+
+Skip files that are purely Electron API wiring with no business logic.
+
+## Output Format
+
+```
+## Test Coverage Report
+
+### Summary
+- Total source files: X
+- Total test files: Y
+- Overall coverage: Z%
+
+### Module Breakdown
+[table from step 2]
+
+### Recommended Test Targets (by priority)
+1. [module/file] - [reason it's testable and important]
+2. ...
+```

--- a/.claude/hooks/auto-format.sh
+++ b/.claude/hooks/auto-format.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Auto-format files after Edit/Write using Prettier
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+if [[ "$FILE_PATH" == *.ts || "$FILE_PATH" == *.tsx || "$FILE_PATH" == *.js || "$FILE_PATH" == *.jsx || "$FILE_PATH" == *.json || "$FILE_PATH" == *.css || "$FILE_PATH" == *.md ]]; then
+  npx prettier --write "$FILE_PATH" 2>/dev/null || true
+fi
+
+exit 0

--- a/.claude/hooks/block-sensitive-files.sh
+++ b/.claude/hooks/block-sensitive-files.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Block edits to sensitive files (lock files, env files)
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+BASENAME=$(basename "$FILE_PATH")
+
+case "$BASENAME" in
+  yarn.lock|package-lock.json|pnpm-lock.yaml)
+    echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Lock files should not be edited directly. Run yarn/npm install instead."}}' >&2
+    exit 2
+    ;;
+  .env|.env.local|.env.production)
+    echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Environment files contain secrets and should not be edited by Claude."}}' >&2
+    exit 2
+    ;;
+esac
+
+exit 0

--- a/.claude/hooks/typecheck.sh
+++ b/.claude/hooks/typecheck.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Run TypeScript type-check on edited .ts/.tsx files
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+if [[ "$FILE_PATH" != *.ts && "$FILE_PATH" != *.tsx ]]; then
+  exit 0
+fi
+
+# Run tsc on the whole project (TypeScript doesn't support single-file checking well)
+# Use --pretty false for cleaner output
+cd "$CLAUDE_PROJECT_DIR" 2>/dev/null || exit 0
+npx tsc --noEmit --pretty false 2>&1 | head -20
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,34 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/block-sensitive-files.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/auto-format.sh",
+            "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/typecheck.sh",
+            "timeout": 60,
+            "async": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/electron-build/SKILL.md
+++ b/.claude/skills/electron-build/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: electron-build
+description: Build and test the Electron app with proper worktree isolation
+---
+
+# Electron Build
+
+Build, lint, and test the Rocket.Chat Electron app. Uses git worktrees to avoid disrupting the user's working directory.
+
+## Arguments
+
+- `platform` (optional): Target platform - `mac`, `win`, `linux`, or `all`. Defaults to current platform.
+- `skip-worktree` (optional): If "true", build in the current directory instead of creating a worktree.
+
+## Steps
+
+### 1. Setup
+
+If `skip-worktree` is not "true":
+1. Create a worktree from the current branch:
+   ```bash
+   mkdir -p ../Rocket.Chat.Electron-worktrees
+   git worktree add ../Rocket.Chat.Electron-worktrees/build-$(git branch --show-current) HEAD
+   ```
+2. Change to the worktree directory
+3. Install dependencies: `yarn`
+
+### 2. Lint
+
+```bash
+yarn lint
+```
+
+Fix any lint errors before proceeding.
+
+### 3. Test
+
+```bash
+yarn test
+```
+
+All tests must pass before building.
+
+### 4. Build
+
+Build the app bundle:
+```bash
+yarn build
+```
+
+Then build platform packages if requested:
+
+| Platform | Command |
+|----------|---------|
+| macOS | `yarn build-mac` |
+| Windows | `yarn build-win` (includes `--x64 --ia32 --arm64`) |
+| Linux | `yarn build-linux` |
+
+### 5. Workspace Build
+
+If changes touch `workspaces/desktop-release-action/`:
+```bash
+yarn workspaces:build
+rm -rf workspaces/desktop-release-action/dist/dist
+```
+
+### 6. Cleanup
+
+If a worktree was created:
+```bash
+git worktree remove ../Rocket.Chat.Electron-worktrees/build-$(git branch --show-current)
+```
+
+## Report
+
+After completion, report:
+- Lint status (pass/fail with error count)
+- Test status (pass/fail with test count)
+- Build status and output location

--- a/.claude/skills/i18n-audit/SKILL.md
+++ b/.claude/skills/i18n-audit/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: i18n-audit
+description: Audit translation completeness across all language files
+---
+
+# i18n Translation Audit
+
+Compare all language files against the English reference (`src/i18n/en.i18n.json`) and report translation coverage.
+
+## Arguments
+
+- `language` (optional): Audit a specific language code (e.g., `pt-BR`, `ja`). Defaults to all languages.
+- `verbose` (optional): If "true", list every missing key. Otherwise show summary only.
+
+## Steps
+
+### 1. Load Reference Keys
+
+Read `src/i18n/en.i18n.json` and extract all keys (including nested keys using dot notation, e.g., `dialog.about.title`).
+
+### 2. Scan All Languages
+
+For each `*.i18n.json` file in `src/i18n/` (except `en.i18n.json`):
+1. Extract all keys using the same dot notation
+2. Compare against the English reference
+3. Record:
+   - **Missing keys**: Present in `en` but absent in this language
+   - **Extra keys**: Present in this language but absent in `en` (possibly outdated)
+   - **Total keys**: Count in this language vs English
+
+### 3. Generate Report
+
+Output a summary table:
+
+```
+Language     | Keys | Missing | Extra | Coverage
+-------------|------|---------|-------|--------
+pt-BR        | 142  | 3       | 0     | 97.9%
+ja           | 138  | 7       | 1     | 95.2%
+...
+```
+
+If `verbose` is "true", also list the specific missing and extra keys per language.
+
+### 4. Highlight Critical Gaps
+
+Flag any language below 90% coverage as needing attention.
+
+## Languages
+
+The project has 22 language files:
+ar, de-DE, en (reference), es, fi, fr, hu, it-IT, ja, nb-NO, nn, no, pl, pt-BR, ru, se, sv, tr-TR, uk-UA, zh, zh-CN, zh-TW

--- a/.claude/skills/new-ipc-channel/SKILL.md
+++ b/.claude/skills/new-ipc-channel/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: new-ipc-channel
+description: Scaffold a new IPC channel with proper TypeScript types
+---
+
+# New IPC Channel
+
+Add a new type-safe IPC channel to the Rocket.Chat Electron app. This scaffolds the channel definition, main process handler, and renderer invoke call.
+
+## Arguments (required)
+
+- `name`: Channel name using domain/action format (e.g., `downloads/clear-all`, `notifications/dismiss`)
+- `args`: TypeScript argument types (e.g., `(itemId: string)` or `()` for no args)
+- `return`: TypeScript return type (e.g., `void`, `boolean`, `{ success: boolean }`)
+
+## Steps
+
+### 1. Add Channel Type Definition
+
+Edit `src/ipc/channels.ts` and add the new channel to the `ChannelToArgsMap` type:
+
+```typescript
+type ChannelToArgsMap = {
+  // ... existing channels ...
+  '<name>': (<args>) => <return>;
+};
+```
+
+Add any needed imports at the top of the file if the types reference domain-specific types.
+
+### 2. Add Main Process Handler
+
+Identify the correct main process file based on the channel domain:
+- `downloads/*` → `src/downloads/main.ts`
+- `notifications/*` → `src/notifications/main.ts`
+- `servers/*` → `src/servers/main.ts`
+- `video-call-window/*` → `src/videoCallWindow/main.ts`
+- `outlook-calendar/*` → `src/outlookCalendar/main.ts`
+- `document-viewer/*` → `src/documentViewer/main.ts`
+
+Add the handler using the existing pattern in that file. Look at sibling handlers for the correct pattern - they use `ipcMain.handle` or the project's `handle` wrapper from `src/ipc/main.ts`.
+
+### 3. Add Renderer Invoke (if needed)
+
+If this channel is called from the renderer process, add the invoke call in the appropriate renderer file or in `src/ipc/renderer.ts` following the existing pattern.
+
+### 4. Verify
+
+Run type checking to ensure the new channel compiles:
+```bash
+npx tsc --noEmit
+```
+
+## Pattern Reference
+
+The IPC system uses a centralized type map (`ChannelToArgsMap`) that enforces type safety between main and renderer processes. The `Channel` and `Handler` types are derived from this map:
+
+```typescript
+export type Channel = keyof ChannelToArgsMap;
+export type Handler<N extends Channel> = ChannelToArgsMap[N];
+```
+
+All 71+ existing channels follow the `'domain/action'` naming convention.

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: release-notes
+description: Generate release notes from git history between tags
+---
+
+# Release Notes Generator
+
+Generate categorized release notes from git commit history between two tags or refs.
+
+## Arguments
+
+- `from` (optional): Starting tag/ref. Defaults to the previous tag.
+- `to` (optional): Ending tag/ref. Defaults to HEAD.
+
+## Steps
+
+### 1. Determine Range
+
+If `from` is not provided, find the most recent tag:
+```bash
+git describe --tags --abbrev=0 HEAD~1
+```
+
+If `to` is not provided, use `HEAD`.
+
+### 2. Gather Commits
+
+```bash
+git log --oneline --no-merges <from>..<to>
+```
+
+### 3. Categorize
+
+Parse commit messages using conventional commit prefixes and categorize:
+
+| Prefix | Category |
+|--------|----------|
+| `feat:` | New Features |
+| `fix:` | Bug Fixes |
+| `perf:` | Performance |
+| `refactor:` | Improvements |
+| `chore:` | Maintenance |
+| `docs:` | Documentation |
+| `ci:` | CI/CD |
+| `test:` | Testing |
+
+Commits without conventional prefixes go under "Other Changes".
+
+### 4. Format Output
+
+```markdown
+## What's Changed
+
+### New Features
+- Description of feature (#PR)
+
+### Bug Fixes
+- Description of fix (#PR)
+
+### Improvements
+- Description of improvement (#PR)
+
+### Maintenance
+- Description of chore (#PR)
+```
+
+### 5. Version Context
+
+Detect the version type from `package.json` and note:
+- Alpha releases (`X.Y.Z-alpha.N`): Mark as "Alpha Release - For QA and early testing"
+- Beta releases (`X.Y.Z-beta.N`): Mark as "Beta Release - Pre-release testing"
+- Stable releases (`X.Y.Z`): Mark as "Stable Release"
+
+### 6. Output
+
+Present the formatted release notes to the user for review. Do not create any files unless asked.

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstreamapi/context7-mcp@latest"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds project-level Claude Code configuration with hooks, skills, agents, and shared MCP server config. These automations improve developer workflow when using Claude Code on this repository.

## What's Added

### Hooks (`.claude/hooks/`)

Hooks run automatically during Claude Code sessions:

- **auto-format.sh** — Runs Prettier on every file after Edit/Write operations, keeping formatting consistent without manual intervention
- **block-sensitive-files.sh** — Blocks edits to `yarn.lock`, `package-lock.json`, and `.env` files, preventing accidental modifications to lock files and secrets
- **typecheck.sh** — Runs `tsc --noEmit` asynchronously after TypeScript file edits, catching type errors immediately instead of at lint time

### Skills (`.claude/skills/`)

Skills are reusable workflows invoked with `/skill-name`:

- **`/electron-build`** — Builds and tests the Electron app using git worktrees for isolation. Encapsulates the full workflow: worktree creation, `yarn install`, lint, test, build, platform packaging, and cleanup. Includes workspace build with `dist/dist` cleanup
- **`/release-notes`** — Generates categorized release notes from git commit history between tags. Parses conventional commit prefixes (`feat:`, `fix:`, etc.) into categories and detects alpha/beta/stable version context
- **`/i18n-audit`** — Audits translation completeness across all 22 language files against the English reference. Reports missing keys, extra keys, and coverage percentage per language
- **`/new-ipc-channel`** — Scaffolds a new IPC channel across `channels.ts`, the correct domain `main.ts`, and `renderer.ts` with proper TypeScript types. References the existing 71-channel pattern

### Agents (`.claude/agents/`)

Agents are specialized reviewers that Claude can use during development:

- **cross-platform-validator** — Reviews code for Windows/macOS/Linux compatibility issues: Linux-only APIs without defensive coding (`process.getuid?.() ?? 1000`), hardcoded path separators, platform-specific Electron APIs, and native module dependencies
- **test-coverage-gap** — Analyzes test coverage per module, prioritizes untested areas by risk level (critical: notifications, Outlook Calendar, servers; high: IPC, updates; medium: UI components)
- **i18n-validator** — Validates translation key consistency when i18n files are modified. Checks for missing keys, extra/outdated keys, structural mismatches, and missing interpolation variables

### MCP Config (`.mcp.json`)

- **context7** — Shared MCP server for library documentation lookup (Electron, React, Redux, etc.). Team members using Claude Code get this automatically

### Project Settings (`.claude/settings.json`)

- Configures all hooks above as project-level defaults (applies to all team members using Claude Code)
- `settings.local.json` remains personal/unshared

## Test plan

- [ ] Start a new Claude Code session in the repo and verify hooks activate
- [ ] Edit a `.ts` file and confirm Prettier auto-formats it
- [ ] Attempt to edit `yarn.lock` and confirm it's blocked
- [ ] Run `/i18n-audit` and verify it produces a coverage report
- [ ] Run `/release-notes` and verify it generates categorized notes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for insecure HTTPS connections in Outlook Calendar integration, enabling users to work around SSL certificate validation issues.

* **Improvements**
  * Upgraded Bugsnag error tracking to v8.8.1 with enhanced session management.

* **Chores**
  * Implemented development tooling enhancements including automated code formatting, type checking, and sensitive file protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->