### PR TITLE
feat(image-gallery): add mouse wheel / trackpad zoom support

### DIFF
--- a/src/preload.ts
+++ b/src/preload.ts
@@ -10,8 +10,8 @@ import { setServerUrl } from './servers/preload/urls';
 import { createRendererReduxStore, listen } from './store';
 import { WEBVIEW_DID_NAVIGATE } from './ui/actions';
 import { debounce } from './ui/main/debounce';
-import { listenToMessageBoxEvents } from './ui/preload/messageBox';
 import { setupImageGalleryZoom } from './ui/preload/imageGallery';
+import { listenToMessageBoxEvents } from './ui/preload/messageBox';
 import { handleTrafficLightsSpacing } from './ui/preload/sidebar';
 import { whenReady } from './whenReady';
 

--- a/src/ui/preload/imageGallery.ts
+++ b/src/ui/preload/imageGallery.ts
@@ -1,4 +1,3 @@
-
 export const setupImageGalleryZoom = (): void => {
   let lastZoomTime = 0;
   const ZOOM_COOLDOWN = 200; // more = less zoom speed


### PR DESCRIPTION
### What this PR does
Adds mouse wheel / trackpad scroll support for zooming images in the image gallery.

### Why
Currently, users can only zoom images using explicit zoom buttons.
Adding scroll-based zoom improves usability and matches common image viewer behavior.

### How it works
- Listens for `wheel` events when the cursor is over an image
- Accumulates scroll delta before triggering zoom to prevent excessive zoom speed
- Reuses existing zoom-in / zoom-out controls
- Prevents default scrolling only when zoom is handled

### UX improvements
- Smooth and controlled zoom speed
- Works with mouse wheel and trackpad
- Does not interfere with slide navigation
- No breaking changes to existing controls

### Screenshots / video
(optional – add if you want)

### Testing
- [x] Tested zoom-in with scroll up
- [x] Tested zoom-out with scroll down
- [x] Verified zoom buttons still work
- [x] No impact on non-image scrolling

### Related issue
Closes #3194


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mouse wheel zooming now available for image galleries with automatic zoom-in/out based on scroll direction and built-in cooldown protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->