### PR TITLE
fix(macos): sync nativeTheme.themeSource with user preference

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -103,7 +103,7 @@ const start = async (): Promise<void> => {
   //   installDevTools();
   // }
   watchMachineTheme();
-  syncNativeThemeSource();
+  const unsubscribeNativeThemeSource = syncNativeThemeSource();
   setupNotifications();
   attentionDrawing.setUp();
   setupScreenSharing();
@@ -131,6 +131,7 @@ const start = async (): Promise<void> => {
     trayIcon.tearDown();
     attentionDrawing.tearDown();
     cleanupVideoCallResources();
+    unsubscribeNativeThemeSource();
   });
 
   watchAndPersistChanges();

--- a/src/ui/main/rootWindow.ts
+++ b/src/ui/main/rootWindow.ts
@@ -90,10 +90,10 @@ export const createRootWindow = (): void => {
     webPreferences,
     ...(enableVibrancy
       ? {
-          transparent: true,
-          vibrancy: 'sidebar',
-          visualEffectState: 'active',
-        }
+        transparent: true,
+        vibrancy: 'sidebar',
+        visualEffectState: 'active',
+      }
       : {}),
   });
 
@@ -557,12 +557,8 @@ const dispatchMachineTheme = (): void => {
   });
 };
 
-export const syncNativeThemeSource = (): void => {
-  const updateThemeSource = () => {
-    const userThemePreference = select(
-      ({ userThemePreference }: RootState) => userThemePreference
-    );
-
+export const syncNativeThemeSource = (): (() => void) => {
+  const updateThemeSource = (userThemePreference: RootState['userThemePreference']) => {
     // Set nativeTheme.themeSource to ensure window borders follow app theme
     // instead of OS theme (critical for macOS per-application theme override)
     switch (userThemePreference) {
@@ -580,14 +576,11 @@ export const syncNativeThemeSource = (): void => {
     }
   };
 
-  // Initial sync
-  updateThemeSource();
-
   // Watch for changes to user theme preference
-  watch(
+  return watch(
     ({ userThemePreference }: RootState) => userThemePreference,
-    () => {
-      updateThemeSource();
+    (userThemePreference) => {
+      updateThemeSource(userThemePreference);
     }
   );
 };


### PR DESCRIPTION
Fixes #38589

The macOS client was displaying window borders that followed the OS theme instead of respecting per-application theme overrides set in Accessibility & appearance settings.

This was caused by only reading nativeTheme.shouldUseDarkColors (which reflects OS theme) without setting nativeTheme.themeSource (which controls the application's theme override).

Changes:
- Added syncNativeThemeSource() function in rootWindow.ts to watch user theme preference and update nativeTheme.themeSource accordingly
- Integrated the sync function into main.ts initialization flow
- Window borders now follow app theme preference (Auto/Light/Dark) instead of always following OS theme

## How to test
1. On macOS, set system appearance to Light
2. Open Rocket.Chat
3. Go to Accessibility & Appearance
4. Set theme to Dark
5. Verify window borders follow the app theme


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App now actively syncs its theme preference with the operating system and updates immediately when preference changes.
* **Bug Fixes**
  * Ensures theme synchronization is reliably cleaned up on exit to prevent lingering background listeners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->