### PR TITLE
chore: remove outdated Electron 10 comment

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -96,11 +96,6 @@ const start = async (): Promise<void> => {
 
   // Mark main window as stable - GPU crashes after this won't trigger fallback
   markMainWindowStable();
-
-  // React DevTools is currently incompatible with Electron 10
-  // if (process.env.NODE_ENV === 'development') {
-  //   installDevTools();
-  // }
   watchMachineTheme();
   setupNotifications();
   attentionDrawing.setUp();


### PR DESCRIPTION
## Description
Removes outdated comment referencing Electron 10 compatibility issues with React DevTools.

## Context
- The project upgraded to Electron 40.0.0 in version 4.12.0
- This comment references Electron 10 (30 versions behind)
- The code has been commented out, making it safe to remove



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused development tool configuration code from the initialization process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->