### PR TITLE
fix: Log viewer Windows compatibility and Outlook logging in production

### DIFF
--- a/src/logViewerWindow/ipc.ts
+++ b/src/logViewerWindow/ipc.ts
@@ -43,7 +43,7 @@ const validateLogFilePath = (
   return { valid: true };
 };
 
-const LOG_ENTRY_REGEX = /^\[([^\]]+)\] \[([^\]]+)\]/;
+const LOG_ENTRY_REGEX = /^\[([^\]]+)\]\s+\[([^\]]+)\]/;
 
 const getLastNEntries = (
   content: string,
@@ -53,7 +53,7 @@ const getLastNEntries = (
     return { content: '', totalEntries: 0 };
   }
 
-  const lines = content.split('\n');
+  const lines = content.split(/\r?\n/);
   const entryStartIndices: number[] = [];
 
   lines.forEach((line, index) => {

--- a/src/logViewerWindow/logViewerWindow.tsx
+++ b/src/logViewerWindow/logViewerWindow.tsx
@@ -37,7 +37,7 @@ import {
   parseLogLevel,
 } from './types';
 
-const LOG_LINE_REGEX = /^\[([^\]]+)\] \[([^\]]+)\]\s*(.*)$/;
+const LOG_LINE_REGEX = /^\[([^\]]+)\]\s+\[([^\]]+)\]\s*(.*)$/;
 const CONTEXT_REGEX = /^(\[[^\]]+\](?:\s*\[[^\]]+\])*)\s*(.*)$/;
 
 const formatFileSize = (bytes: number): string => {
@@ -172,7 +172,7 @@ function LogViewerWindow() {
     if (!logText || logText.trim() === '') {
       return [];
     }
-    const lines = logText.split('\n').filter((line: string) => line.trim());
+    const lines = logText.split(/\r?\n/).filter((line: string) => line.trim());
     const entries: LogEntryType[] = [];
     let currentEntry: LogEntryType | null = null;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -144,7 +144,7 @@ const start = async (): Promise<void> => {
 
   await processDeepLinksInArgs();
 
-  console.log('Application initialization completed successfully');
+  console.info('Application initialization completed successfully');
 };
 
 start().catch((error) => {

--- a/src/outlookCalendar/logger.ts
+++ b/src/outlookCalendar/logger.ts
@@ -39,13 +39,13 @@ export const setupOutlookLogger = (): void => {
 
 export const outlookLog = (...args: unknown[]): void => {
   if (global.isVerboseOutlookLoggingEnabled) {
-    console.log(prefix, ...args);
+    console.info(prefix, ...args);
   }
 };
 
 export const outlookDebug = (...args: unknown[]): void => {
   if (global.isVerboseOutlookLoggingEnabled) {
-    console.debug(prefix, ...args);
+    console.info(prefix, ...args);
   }
 };
 
@@ -71,6 +71,6 @@ export const outlookError = (message: unknown, ...details: unknown[]): void => {
 
 export const outlookEventDetail = (...args: unknown[]): void => {
   if (global.isDetailedEventsLoggingEnabled) {
-    console.debug(eventDetailPrefix, ...args);
+    console.info(eventDetailPrefix, ...args);
   }
 };

--- a/src/outlookCalendar/preload.ts
+++ b/src/outlookCalendar/preload.ts
@@ -5,7 +5,7 @@ import type { OutlookEventsResponse } from './type';
 export const getOutlookEvents = async (
   date: Date
 ): Promise<OutlookEventsResponse> => {
-  console.log(
+  console.info(
     '[OutlookCalendar] Preload: Getting Outlook events for date:',
     date.toISOString()
   );
@@ -15,7 +15,7 @@ export const getOutlookEvents = async (
       'outlook-calendar/get-events',
       date
     );
-    console.log(
+    console.info(
       '[OutlookCalendar] Preload: Successfully got Outlook events response:',
       response
     );
@@ -31,7 +31,7 @@ export const getOutlookEvents = async (
 };
 
 export const setOutlookExchangeUrl = (url: string, userId: string): void => {
-  console.log('[OutlookCalendar] Preload: Setting Exchange URL:', {
+  console.info('[OutlookCalendar] Preload: Setting Exchange URL:', {
     url,
     userId,
   });
@@ -39,7 +39,7 @@ export const setOutlookExchangeUrl = (url: string, userId: string): void => {
   ipcRenderer
     .invoke('outlook-calendar/set-exchange-url', url, userId)
     .then(() => {
-      console.log('[OutlookCalendar] Preload: Successfully set Exchange URL');
+      console.info('[OutlookCalendar] Preload: Successfully set Exchange URL');
     })
     .catch((error: unknown) => {
       const errorMessage =
@@ -53,13 +53,16 @@ export const setOutlookExchangeUrl = (url: string, userId: string): void => {
 };
 
 export const hasOutlookCredentials = async (): Promise<boolean> => {
-  console.log(
+  console.info(
     '[OutlookCalendar] Preload: Checking if Outlook credentials exist'
   );
 
   try {
     const result = await ipcRenderer.invoke('outlook-calendar/has-credentials');
-    console.log('[OutlookCalendar] Preload: Credentials check result:', result);
+    console.info(
+      '[OutlookCalendar] Preload: Credentials check result:',
+      result
+    );
     return result;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
@@ -72,12 +75,12 @@ export const hasOutlookCredentials = async (): Promise<boolean> => {
 };
 
 export const clearOutlookCredentials = (): void => {
-  console.log('[OutlookCalendar] Preload: Clearing Outlook credentials');
+  console.info('[OutlookCalendar] Preload: Clearing Outlook credentials');
 
   ipcRenderer
     .invoke('outlook-calendar/clear-credentials')
     .then(() => {
-      console.log(
+      console.info(
         '[OutlookCalendar] Preload: Successfully cleared credentials'
       );
     })
@@ -92,7 +95,7 @@ export const clearOutlookCredentials = (): void => {
 };
 
 export const setUserToken = (token: string, userId: string): void => {
-  console.log(
+  console.info(
     '[OutlookCalendar] Preload: Setting user token for userId:',
     userId
   );
@@ -100,7 +103,7 @@ export const setUserToken = (token: string, userId: string): void => {
   ipcRenderer
     .invoke('outlook-calendar/set-user-token', token, userId)
     .then(() => {
-      console.log('[OutlookCalendar] Preload: Successfully set user token');
+      console.info('[OutlookCalendar] Preload: Successfully set user token');
     })
     .catch((error: unknown) => {
       const errorMessage =


### PR DESCRIPTION
## Summary

- **Fix log viewer showing nothing on Windows machines**: Log files generated on Windows use `\r\n` line endings. The log parser split on `\n` leaving `\r` at the end of lines, and since JavaScript regex `.` does not match `\r`, the parsing regex failed on every single line resulting in an empty log viewer.
- **Fix regex for variable whitespace**: The `electron-log` format template adds a space after `[{level}]` and `formatLogContext` also starts with `[`, creating a double space between brackets. Changed regex from literal single space to `\s+`.
- **Fix Outlook verbose logs not appearing in production**: `outlookLog` (84 calls) and `outlookDebug` used `console.log`/`console.debug` which map to `log.debug` in the logging infrastructure. In production, the file transport threshold is `info`, so all verbose Outlook logs were silently dropped. Changed to `console.info` so they reach the log file when the user enables verbose logging.

## Files changed

- `src/logViewerWindow/ipc.ts` — CRLF split + regex fix for entry counting
- `src/logViewerWindow/logViewerWindow.tsx` — CRLF split + regex fix for log parsing
- `src/outlookCalendar/logger.ts` — `outlookLog`, `outlookDebug`, `outlookEventDetail` → `console.info`

## Test plan

- [x] Lint passes
- [x] All 213 tests pass
- [x] Verified regex matches all 1157 lines from a real Windows-generated log file
- [ ] Verify log viewer displays entries when opening a Windows `.log` file
- [ ] Verify Outlook verbose logs appear in `main.log` on a production build with verbose toggle enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log parsing to accept variable whitespace between timestamp/level segments.
  * Enhanced log file handling to correctly split both LF and CRLF line endings.

* **Chores**
  * Standardized logging calls to use info-level output for clearer, more consistent messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->