### PR TITLE
fix: Add safe guards to prevent The application GUI just crashed

### DIFF
--- a/src/servers/preload/internalVideoChatWindow.ts
+++ b/src/servers/preload/internalVideoChatWindow.ts
@@ -1,12 +1,12 @@
 import { ipcRenderer } from 'electron';
 
-import { select } from '../../store';
+import { safeSelect } from '../../store';
 import { openExternal } from '../../utils/browserLauncher';
 
 export const getInternalVideoChatWindowEnabled = (): boolean =>
-  select(
+  safeSelect(
     ({ isInternalVideoChatWindowEnabled }) => isInternalVideoChatWindowEnabled
-  );
+  ) ?? false;
 
 export type videoCallWindowOptions = {
   providerName?: string | undefined;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -66,6 +66,11 @@ type Selector<T> = (state: RootState) => T;
 export const select = <T>(selector: Selector<T>): T =>
   selector(reduxStore.getState());
 
+export const safeSelect = <T>(selector: Selector<T>): T | undefined => {
+  if (!reduxStore) return undefined;
+  return selector(reduxStore.getState());
+};
+
 export const watch = <T>(
   selector: Selector<T>,
   watcher: (curr: T, prev: T | undefined) => void


### PR DESCRIPTION
# Improved Startup Stability: Safer Handling of Early API Calls

## Summary

During investigation of a crash reported on macOS 26.x (Tahoe), we identified that the app's store could be accessed before it finished initializing — for example, when the server page loads faster than the app's internal setup completes. This PR adds defensive guards so these early calls are handled safely instead of throwing an error.

## What's New

### Improved

- **Startup stability**: The app no longer crashes if the server page calls desktop APIs (title updates, user presence, notifications) before the app's internal state has finished initializing. Those calls are now safely ignored and retried naturally by the webapp when it's ready.

https://rocketchat.atlassian.net/browse/SUP-978


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added defensive checks to dispatch, state access, observation, and request flows so actions gracefully no-op when the app store isn't initialized, preventing runtime errors and improving stability.

* **Refactor**
  * Simplified how the internal video chat window state is read, optimizing retrieval logic without changing its public behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->