### PR TITLE
fix: guard against invalid download percentage

### DIFF
--- a/src/ui/components/DownloadsManagerView/DownloadItem.tsx
+++ b/src/ui/components/DownloadsManagerView/DownloadItem.tsx
@@ -108,12 +108,12 @@ const DownloadItem = ({
   const errored = state === 'interrupted' || state === 'cancelled';
   const expired = state === 'expired';
   const percentage = useMemo(() => {
-  if (!receivedBytes || !totalBytes) {
-    return 0;
-  }
+    if (!receivedBytes || !totalBytes) {
+      return 0;
+    }
 
-  return Math.floor((receivedBytes / totalBytes) * 100);
-}, [receivedBytes, totalBytes]);
+    return Math.min(100, Math.floor((receivedBytes / totalBytes) * 100));
+  }, [receivedBytes, totalBytes]);
   return (
     <Box
       width='100%'

--- a/src/ui/components/DownloadsManagerView/DownloadItem.tsx
+++ b/src/ui/components/DownloadsManagerView/DownloadItem.tsx
@@ -107,11 +107,13 @@ const DownloadItem = ({
 
   const errored = state === 'interrupted' || state === 'cancelled';
   const expired = state === 'expired';
-  const percentage = useMemo(
-    () => Math.floor((receivedBytes / totalBytes) * 100),
-    [receivedBytes, totalBytes]
-  );
+  const percentage = useMemo(() => {
+  if (!receivedBytes || !totalBytes) {
+    return 0;
+  }
 
+  return Math.floor((receivedBytes / totalBytes) * 100);
+}, [receivedBytes, totalBytes]);
   return (
     <Box
       width='100%'

--- a/src/ui/components/Modal/ModalBackdrop.tsx
+++ b/src/ui/components/Modal/ModalBackdrop.tsx
@@ -8,6 +8,8 @@ const useEscapeKey = (onDismiss: (() => void) | undefined): void => {
       if (e.key !== 'Escape') {
         return;
       }
+
+      e.stopPropagation();
       onDismiss?.();
     };
 
@@ -24,7 +26,9 @@ const isAtBackdropChildren = (
   ref: RefObject<HTMLElement>
 ): boolean => {
   const backdrop = ref.current;
-  return backdrop?.contains(e.target as Node) ?? false;
+  const { parentElement } = e.target as HTMLElement;
+
+  return (Boolean(parentElement) && backdrop?.contains(parentElement)) ?? false;
 };
 
 const useOutsideClick = (
@@ -89,6 +93,7 @@ const ModalBackdrop = ({
   return (
     <Box
       ref={ref}
+      children={children}
       className='rcx-modal__backdrop'
       position='fixed'
       zIndex={9999}
@@ -97,9 +102,7 @@ const ModalBackdrop = ({
       flexDirection='column'
       onMouseDown={onMouseDown}
       onMouseUp={onMouseUp}
-    >
-      {children}
-    </Box>
+    />
   );
 };
 

--- a/src/ui/components/Modal/ModalBackdrop.tsx
+++ b/src/ui/components/Modal/ModalBackdrop.tsx
@@ -8,8 +8,6 @@ const useEscapeKey = (onDismiss: (() => void) | undefined): void => {
       if (e.key !== 'Escape') {
         return;
       }
-
-      e.stopPropagation();
       onDismiss?.();
     };
 
@@ -26,9 +24,7 @@ const isAtBackdropChildren = (
   ref: RefObject<HTMLElement>
 ): boolean => {
   const backdrop = ref.current;
-  const { parentElement } = e.target as HTMLElement;
-
-  return (Boolean(parentElement) && backdrop?.contains(parentElement)) ?? false;
+  return backdrop?.contains(e.target as Node) ?? false;
 };
 
 const useOutsideClick = (
@@ -93,7 +89,6 @@ const ModalBackdrop = ({
   return (
     <Box
       ref={ref}
-      children={children}
       className='rcx-modal__backdrop'
       position='fixed'
       zIndex={9999}
@@ -102,7 +97,9 @@ const ModalBackdrop = ({
       flexDirection='column'
       onMouseDown={onMouseDown}
       onMouseUp={onMouseUp}
-    />
+    >
+      {children}
+    </Box>
   );
 };
 


### PR DESCRIPTION
Prevents NaN/Infinity values in ProgressBar when receivedBytes or totalBytes are undefined or zero.
Tested locally in development mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed download progress calculation to handle missing or zero byte values, preventing invalid/NaN displays.
  * Progress is now safely computed and capped at 100%, ensuring consistent indicators in Downloads.
  * Modal dismissal improved: Escape key reliably closes modals.
  * Backdrop containment and click/dismiss detection refined to improve modal focus and interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->