### PR TITLE
Fix: Removed a trailing comma that can cause potential JSON parsing issues

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,5 @@
     "resolveJsonModule": true,
     "skipLibCheck": true
   },
-  "include": ["src"],
+  "include": ["src"]
 }


### PR DESCRIPTION
Removed a trailing comma that can cause potential JSON parsing issues. 

This fixes an invalid syntax error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**No user-facing changes in this update.** Internal configuration adjustments were made with no impact on functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->