### PR TITLE
Implement invalid server URL dialog for deep link errors

### DIFF
--- a/src/i18n/en.i18n.json
+++ b/src/i18n/en.i18n.json
@@ -42,6 +42,12 @@
       "title": "Invalid Host",
       "message": "The host \"{{- host}}\" could not be validated, so was not added."
     },
+    "invalidServerUrl": {
+      "title": "Invalid Server URL",
+      "message": "Could not connect to server at \"{{- serverUrl}}\"",
+      "defaultReason": "The server URL could not be resolved or is not a valid Rocket.Chat server.",
+      "ok": "OK"
+    },
     "certificateError": {
       "title": "Certificate error",
       "message": "Do you trust certificate from \"{{- issuerName}}\"? Only click 'Yes' if you really trust this certificate. If you are unsure, contact your IT or security team before clicking on 'Yes'.",

--- a/src/ui/main/dialogs.ts
+++ b/src/ui/main/dialogs.ts
@@ -45,13 +45,21 @@ export const askForServerAddition = async (
   return response === 0;
 };
 
-export const warnAboutInvalidServerUrl = (
-  _serverUrl: string,
-  _reason: string,
-  _parentWindow?: BrowserWindow
+export const warnAboutInvalidServerUrl = async (
+  serverUrl: string,
+  reason: string,
+  parentWindow?: BrowserWindow
 ): Promise<void> => {
-  // TODO
-  throw Error('not implemented');
+  parentWindow?.show();
+
+  await dialog.showMessageBox(parentWindow ?? (await getRootWindow()), {
+    type: 'error',
+    title: t('dialog.invalidServerUrl.title'),
+    message: t('dialog.invalidServerUrl.message', { serverUrl }),
+    detail: reason || t('dialog.invalidServerUrl.defaultReason'),
+    buttons: [t('dialog.invalidServerUrl.ok')],
+    defaultId: 0,
+  });
 };
 
 export const enum AskUpdateInstallResponse {

--- a/src/ui/main/dialogs.ts
+++ b/src/ui/main/dialogs.ts
@@ -52,14 +52,29 @@ export const warnAboutInvalidServerUrl = async (
 ): Promise<void> => {
   parentWindow?.show();
 
-  await dialog.showMessageBox(parentWindow ?? (await getRootWindow()), {
-    type: 'error',
+  let window: BrowserWindow | undefined = parentWindow;
+  if (!window) {
+    try {
+      window = await getRootWindow();
+    } catch {
+      // If getRootWindow fails, show parentless dialog
+    }
+  }
+
+  const options = {
+    type: 'error' as const,
     title: t('dialog.invalidServerUrl.title'),
     message: t('dialog.invalidServerUrl.message', { serverUrl }),
     detail: reason || t('dialog.invalidServerUrl.defaultReason'),
     buttons: [t('dialog.invalidServerUrl.ok')],
     defaultId: 0,
-  });
+  };
+
+  if (window) {
+    await dialog.showMessageBox(window, options);
+  } else {
+    await dialog.showMessageBox(options);
+  }
 };
 
 export const enum AskUpdateInstallResponse {


### PR DESCRIPTION
The `warnAboutInvalidServerUrl` function in `src/ui/main/dialogs.ts` was unimplemented and threw a "not implemented" error. This caused the application to crash when users attempted to open deep links with invalid server URLs.

### Solution
Implemented the dialog function to properly handle invalid server URLs from deep links by:
- Displaying an error dialog with the problematic server URL
- Showing the reason for the failure (DNS resolution error, invalid format, etc.)
- Following the existing dialog pattern used throughout the codebase

### Demo Video


https://github.com/user-attachments/assets/49c991db-f465-49d1-bc3a-6366bed65b10



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized strings for an "Invalid Server URL" error (title, message, default reason, OK button).

* **Bug Fixes**
  * Improved error handling when connecting to invalid server URLs with a dedicated error dialog showing a clear title, detailed message, and fallback reason to help users understand connection failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->