### PR TITLE
Fallback to default retentionDays when invalid

### DIFF
--- a/src/logging/cleanup.ts
+++ b/src/logging/cleanup.ts
@@ -14,8 +14,10 @@ export const cleanupOldLogs = (
 ): void => {
   try {
     if (!Number.isFinite(retentionDays) || retentionDays <= 0) {
-      console.warn('[logging] Invalid retentionDays; skipping log cleanup');
-      return;
+      console.warn(
+        `    [logging] Invalid retentionDays (${retentionDays}); falling back to default (${DEFAULT_RETENTION_DAYS})`
+      );
+      retentionDays = DEFAULT_RETENTION_DAYS;
     }
 
     const logsPath = app.getPath('logs');


### PR DESCRIPTION
Prevent log cleanup from being skipped when retentionDays is invalid by falling back to the default value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid retention configuration to use default settings instead of stopping the cleanup process, with enhanced error logging for better diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->