### PR TITLE
fix: show invalid server URL dialog

### DIFF
--- a/src/ui/main/dialogs.ts
+++ b/src/ui/main/dialogs.ts
@@ -45,13 +45,19 @@ export const askForServerAddition = async (
   return response === 0;
 };
 
-export const warnAboutInvalidServerUrl = (
-  _serverUrl: string,
-  _reason: string,
-  _parentWindow?: BrowserWindow
+export const warnAboutInvalidServerUrl = async (
+  serverUrl: string,
+  reason: string,
+  parentWindow?: BrowserWindow
 ): Promise<void> => {
-  // TODO
-  throw Error('not implemented');
+  await dialog.showMessageBox(parentWindow ?? (await getRootWindow()), {
+    type: 'error',
+    title: t('dialog.addServerError.title'),
+    message: t('dialog.addServerError.message', { host: serverUrl }),
+    detail: reason || undefined,
+    buttons: [t('dialog.updateInstallLater.ok')],
+    defaultId: 0,
+  });
 };
 
 export const enum AskUpdateInstallResponse {


### PR DESCRIPTION
Implement warnAboutInvalidServerUrl to display an error dialog and surface the validation reason instead of throwing.

- Replaced the placeholder warnAboutInvalidServerUrl implementation in [dialogs.ts]with an Electron dialog.showMessageBox call.
- Wired it to existing i18n strings [dialog.addServerError.] and included the provided validation reason as dialog detail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved error handling for invalid server URLs. Users now receive informative error dialogs with localized messages displaying the problematic host and detailed error information to help diagnose connection issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->