### PR TITLE
Chore: Remove Unused 6.0.0 Version Check Commented Code

### DIFF
--- a/src/injected.ts
+++ b/src/injected.ts
@@ -121,16 +121,12 @@ const start = async () => {
     : 'meteor/konecty:user-presence';
 
   const settingsModulePath = (() => {
-    // if (versionIsGreaterOrEqualsTo(serverInfo.version, '6.0.0'))
-    //   return '/app/settings/client';
     if (versionIsGreaterOrEqualsTo(serverInfo.version, '5.0.0'))
       return '/app/settings/client/index.ts';
     return '/app/settings';
   })();
 
   const utilsModulePath = (() => {
-    // if (versionIsGreaterOrEqualsTo(serverInfo.version, '6.0.0'))
-    //   return '/app/utils/client';
     if (versionIsGreaterOrEqualsTo(serverInfo.version, '5.0.0'))
       return '/app/utils/client/index.ts';
     return '/app/utils';


### PR DESCRIPTION
The `injected.ts` file contains commented-out version checks for Rocket.Chat 6.0.0 that suggest different module paths would be used. 

The commented code is removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined module loading logic with simplified version-based path selection for settings and utility modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->