### PR TITLE
Chore: Remove unused isResponseTo helper function

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -176,10 +176,6 @@ export abstract class Service {
   }
 }
 
-// const isResponseTo = <Response extends RootAction>(id: unknown, type: Response['type']) =>
-//   (action: RootAction): action is Response =>
-//     isResponse(action) && action.type === type && action.meta.id === id;
-
 export const request = <
   Request extends RootAction,
   ResponseTypes extends [...RootAction['type'][]],


### PR DESCRIPTION
The `src/store/index.ts` file contains a commented-out `isResponseTo` helper function that is no longer used. This function was replaced by a better implementation in `src/store/fsa.ts` that supports multiple response types.

The commented code has been removed in this PR



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused code to improve codebase maintainability and reduce technical debt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->