### PR TITLE
fix: add missing aria-labels for accessibility in UpdateDialog and DownloadsManagerView

### DIFF
--- a/src/ui/components/DownloadsManagerView/DownloadItem.tsx
+++ b/src/ui/components/DownloadsManagerView/DownloadItem.tsx
@@ -182,51 +182,51 @@ const DownloadItem = ({
           </Box>
           <Box display='flex' fontScale='c1'>
             {expired && (
-              <ActionButton onClick={handleRemove}>
+              <ActionButton onClick={handleRemove} aria-label={t('downloads.item.remove')}>
                 {t('downloads.item.remove')}
               </ActionButton>
             )}
             {!expired && (
-              <ActionButton onClick={handleCopyLink}>
+              <ActionButton onClick={handleCopyLink} aria-label={t('downloads.item.copyLink')}>
                 {t('downloads.item.copyLink')}
               </ActionButton>
             )}
             {state === 'progressing' && (
               <>
-                <ActionButton onClick={handlePause}>
+                <ActionButton onClick={handlePause}  aria-label={t('downloads.item.pause')}>
                   {t('downloads.item.pause')}
                 </ActionButton>
-                <ActionButton onClick={handleCancel}>
+                <ActionButton onClick={handleCancel} aria-label={t('downloads.item.cancel')}>
                   {t('downloads.item.cancel')}
                 </ActionButton>
               </>
             )}
             {state === 'paused' && (
               <>
-                <ActionButton onClick={handleResume}>
+                <ActionButton onClick={handleResume} aria-label={t('downloads.item.resume')}>
                   {t('downloads.item.resume')}
                 </ActionButton>
-                <ActionButton onClick={handleCancel}>
+                <ActionButton onClick={handleCancel} aria-label={t('downloads.item.cancel')}>
                   {t('downloads.item.cancel')}
                 </ActionButton>
               </>
             )}
             {state === 'completed' && (
               <>
-                <ActionButton onClick={handleShowInFolder}>
+                <ActionButton onClick={handleShowInFolder}  aria-label={t('downloads.item.showInFolder')}>
                   {t('downloads.item.showInFolder')}
                 </ActionButton>
-                <ActionButton onClick={handleRemove}>
+                <ActionButton onClick={handleRemove} aria-label={t('downloads.item.remove')}>
                   {t('downloads.item.remove')}
                 </ActionButton>
               </>
             )}
             {errored && (
               <>
-                <ActionButton onClick={handleRetry}>
+                <ActionButton onClick={handleRetry} aria-label={t('downloads.item.retry')}>
                   {t('downloads.item.retry')}
                 </ActionButton>
-                <ActionButton onClick={handleRemove}>
+                <ActionButton onClick={handleRemove} aria-label={t('downloads.item.remove')}>
                   {t('downloads.item.remove')}
                 </ActionButton>
               </>

--- a/src/ui/components/UpdateDialog/index.tsx
+++ b/src/ui/components/UpdateDialog/index.tsx
@@ -89,10 +89,10 @@ export const UpdateDialog = () => {
       </Box>
 
       <ButtonGroup>
-        <Button type='button' onClick={handleSkipButtonClick}>
+        <Button type='button' onClick={handleSkipButtonClick} aria-label={t('dialog.update.skip')} >
           {t('dialog.update.skip')}
         </Button>
-        <Button type='button' onClick={handleRemindLaterButtonClick}>
+        <Button type='button' onClick={handleRemindLaterButtonClick} aria-label={t('dialog.update.remindLater')} >
           {t('dialog.update.remindLater')}
         </Button>
         <Button
@@ -100,6 +100,7 @@ export const UpdateDialog = () => {
           type='button'
           primary
           onClick={handleInstallButtonClick}
+           aria-label={t('dialog.update.install')}
         >
           {t('dialog.update.install')}
         </Button>


### PR DESCRIPTION
Closes #3226

## What does this PR do?
Adds missing aria-label attributes to buttons in UpdateDialog 
and ActionButtons in DownloadsManagerView.

## Why is this needed?
Running the app in development mode showed multiple accessibility 
warnings in the console:
"If you do not provide a visible label, you must specify an 
aria-label or aria-labelledby attribute"

This affects screen reader users who rely on aria-labels 
to understand button actions.

## Files Changed
- src/ui/components/UpdateDialog/index.tsx
- src/ui/components/DownloadsManagerView/DownloadItem.tsx

## Testing
Warnings no longer appear after running yarn start 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility for screen reader users by adding descriptive labels to all buttons in the download manager and system update dialogs. This enhancement ensures users relying on assistive technology receive clear, contextual descriptions when interacting with important download management and update control features throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->