### PR TITLE
fix(video-call): Black Screen doesn't appear when Video call ends

### DIFF
--- a/src/videoCallWindow/ipc.ts
+++ b/src/videoCallWindow/ipc.ts
@@ -683,15 +683,6 @@ export const startVideoCallWindowHandler = (): void => {
         transparent: false,
         skipTaskbar: false,
       });
-
-      videoCallWindow.webContents.on(
-        'will-navigate',
-        (event: Event, url: string) => {
-          if (url.toLowerCase().startsWith('smb://')) {
-            event.preventDefault();
-          }
-        }
-      );
       videoCallWindow.webContents.setWindowOpenHandler(
         ({ url }: { url: string }) => {
           if (url.toLowerCase().startsWith('smb://')) {
@@ -908,30 +899,28 @@ export const startVideoCallWindowHandler = (): void => {
         url
       );
 
-      webContents.setWindowOpenHandler(({ url }: { url: string }) => {
-        console.log('Video call window - new window requested:', url);
-
-        if (url.toLowerCase().startsWith('smb://')) {
-          return { action: 'deny' };
-        }
-
-        if (url.startsWith('http://') || url.startsWith('https://')) {
-          openExternal(url);
-          return { action: 'deny' };
-        }
-
-        return { action: 'allow' };
-      });
-
-      webContents.on('will-navigate', (event: any, url: string) => {
+      webContents.on('will-navigate', (event: Event, url: string) => {
         console.log('Video call window will-navigate:', url);
 
-        // Check for close pages and handle them specially to prevent crashes
-        if (url.includes('/close.html') || url.includes('/close2.html')) {
+        // Block smb protocol
+        if (url.toLowerCase().startsWith('smb://')) {
+          event.preventDefault();
+          return;
+        }
+
+        // Close window immediately when call ends
+        if (url.includes('/static/close')) {
           console.log(
-            'Video call window: Navigation to close page detected, will handle gracefully'
+            'Video call ended — closing video call window immediately'
           );
-          // Don't prevent navigation, but note it for safer handling
+
+          event.preventDefault();
+
+          if (videoCallWindow && !videoCallWindow.isDestroyed()) {
+            videoCallWindow.close();
+          }
+
+          return;
         }
 
         try {
@@ -946,6 +935,7 @@ export const startVideoCallWindowHandler = (): void => {
               'External protocol detected in video call window:',
               parsedUrl.protocol
             );
+
             event.preventDefault();
 
             isProtocolAllowed(url).then((allowed) => {


### PR DESCRIPTION
Closes #3234

## Description

After ending a Jitsi video call in the Rocket.Chat Electron desktop app, the video call window does not close immediately. Instead, the window navigates to a Jitsi `/static/close*.html` page, which results in a blank/black screen being displayed before the window closes.

This creates a confusing user experience because the call appears to still be active even though it has already ended.

## Solution

Intercept navigation to Jitsi `/static/close` pages and close the Electron `videoCallWindow` immediately instead of allowing the navigation.

## Changes

- Detect navigation to `/static/close`
- Prevent the navigation
- Close the video call window immediately when the call ends

## Testing

1. Start a video call
2. Join the call using the Electron desktop app
3. Click **End Call**
4. Verify that the video call window closes immediately without showing a blank/black screen
<img width="1517" height="823" alt="Screenshot 2026-03-05 103426" src="https://github.com/user-attachments/assets/ed8d90eb-bf67-4c2e-9afe-fb2491371e2c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced video call window navigation stability and improved protocol handling
  * Improved cleanup procedures and lifecycle management when closing video call windows
  * Better safeguards against unexpected navigation events and protocol mishandling during active video calls
  * Refined protocol-blocking mechanisms to prevent unintended navigation attempts
  * Strengthened error prevention in video call window operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->