### PR TITLE
fix: tests failing in `getOutlookEvents.spec.ts`

### DIFF
--- a/src/outlookCalendar/getOutlookEvents.ts
+++ b/src/outlookCalendar/getOutlookEvents.ts
@@ -102,6 +102,33 @@ const buildEwsPathname = (url: URL): void => {
 };
 
 /**
+ * Converts URL to string, preserving explicit default ports
+ * Uses url.port to detect if a non-default port was explicitly set
+ */
+const buildFinalUrl = (url: URL, originalUrl: string): string => {
+  const baseUrl = url.toString();
+
+  // If URL already has a non-default port, it's preserved by toString()
+  if (url.port) {
+    return baseUrl;
+  }
+
+  // Check if original URL had an explicit default port that was normalized away
+  // Match port in authority section (after //) or at start (for URLs without protocol)
+  const portMatch = originalUrl.match(/(?:\/\/|^)[^/:]+:(\d+)/);
+  if (portMatch) {
+    const explicitPort = portMatch[1];
+    // Only restore if it's a default port that was dropped
+    if ((url.protocol === 'https:' && explicitPort === '443') ||
+        (url.protocol === 'http:' && explicitPort === '80')) {
+      return baseUrl.replace(url.host, `${url.hostname}:${explicitPort}`);
+    }
+  }
+
+  return baseUrl;
+};
+
+/**
  * Sanitizes and constructs a proper Exchange Web Services (EWS) URL
  * Handles various input formats and edge cases to prevent URL construction errors
  *
@@ -156,7 +183,7 @@ export const sanitizeExchangeUrl = (serverUrl: string): string => {
     // Normalize and construct EWS path using URL properties
     buildEwsPathname(url);
 
-    const sanitizedUrl = url.toString();
+    const sanitizedUrl = buildFinalUrl(url, serverUrl);
 
     outlookLog('URL sanitization completed:', {
       input: serverUrl,
@@ -216,16 +243,7 @@ export const sanitizeExchangeUrl = (serverUrl: string): string => {
       // Use the same clean path construction as main logic
       buildEwsPathname(url);
 
-      // Preserve explicit port if it was in the original URL
-      let finalUrl = url.toString();
-      const portMatch = serverUrl.match(/:(\d+)/);
-      if (portMatch && !url.port) {
-        const port = portMatch[1];
-        if ((url.protocol === 'https:' && port === '443') ||
-            (url.protocol === 'http:' && port === '80')) {
-          finalUrl = finalUrl.replace(url.host, `${url.hostname}:${port}`);
-        }
-      }
+      const finalUrl = buildFinalUrl(url, serverUrl);
 
       outlookLog('Fallback URL construction successful:', {
         input: serverUrl,

--- a/src/outlookCalendar/getOutlookEvents.ts
+++ b/src/outlookCalendar/getOutlookEvents.ts
@@ -115,12 +115,15 @@ const buildFinalUrl = (url: URL, originalUrl: string): string => {
 
   // Check if original URL had an explicit default port that was normalized away
   // Match port in authority section (after //) or at start (for URLs without protocol)
-  const portMatch = originalUrl.match(/(?:\/\/|^)[^/:]+:(\d+)/);
+  // Supports both regular hosts and IPv6 addresses in brackets
+  const portMatch = originalUrl.match(/(?:\/\/|^)(?:\[[^\]]+\]|[^/:]+):(\d+)/);
   if (portMatch) {
     const explicitPort = portMatch[1];
     // Only restore if it's a default port that was dropped
-    if ((url.protocol === 'https:' && explicitPort === '443') ||
-        (url.protocol === 'http:' && explicitPort === '80')) {
+    const isDefaultPort =
+      (url.protocol === 'https:' && explicitPort === '443') ||
+      (url.protocol === 'http:' && explicitPort === '80');
+    if (isDefaultPort) {
       return baseUrl.replace(url.host, `${url.hostname}:${explicitPort}`);
     }
   }
@@ -202,9 +205,14 @@ export const sanitizeExchangeUrl = (serverUrl: string): string => {
     const errorMessage = error instanceof Error ? error.message : String(error);
 
     // Re-throw validation errors without attempting fallback, except for cases
-    // where the URL looks like it's missing a protocol (e.g., "domain.com:443")
-    // Match IPv4 addresses or hostnames with dots followed by port (not scheme:port like "ftp:21")
-    if (errorMessage.includes('Invalid protocol') && !serverUrl.match(/^(?:\d{1,3}(?:\.\d{1,3}){3}|[a-z0-9-]+\.[a-z0-9.-]+):\d+/i)) {
+    // where the URL looks like it's missing a protocol (e.g., "domain.com:443", "localhost:443")
+    // Match IPv4 addresses, hostnames (with optional dots), or single-label names with ports
+    const hostnameWithPortPattern =
+      /^(?:\d{1,3}(?:\.\d{1,3}){3}|[a-z0-9-]+(?:\.[a-z0-9.-]+)?):\d+/i;
+    if (
+      errorMessage.includes('Invalid protocol') &&
+      !serverUrl.match(hostnameWithPortPattern)
+    ) {
       throw error;
     }
 
@@ -257,16 +265,24 @@ export const sanitizeExchangeUrl = (serverUrl: string): string => {
 
       return finalUrl;
     } catch (fallbackError) {
-      const fallbackErrorMsg = fallbackError instanceof Error ? fallbackError.message : String(fallbackError);
+      const fallbackErrorMsg =
+        fallbackError instanceof Error
+          ? fallbackError.message
+          : String(fallbackError);
 
       // Re-throw validation errors directly
-      if (fallbackErrorMsg.includes('URL must have a valid hostname') ||
-          fallbackErrorMsg.includes('Invalid protocol')) {
+      if (
+        fallbackErrorMsg.includes('URL must have a valid hostname') ||
+        fallbackErrorMsg.includes('Invalid protocol')
+      ) {
         throw fallbackError;
       }
 
       // Handle "Invalid URL" for empty hostname case (both http:// and https://)
-      if (fallbackErrorMsg.includes('Invalid URL') && fallbackUrl.match(/^https?:\/\/$/)) {
+      if (
+        fallbackErrorMsg.includes('Invalid URL') &&
+        fallbackUrl.match(/^https?:\/\/$/)
+      ) {
         throw new Error('URL must have a valid hostname');
       }
 

--- a/src/outlookCalendar/getOutlookEvents.ts
+++ b/src/outlookCalendar/getOutlookEvents.ts
@@ -203,7 +203,8 @@ export const sanitizeExchangeUrl = (serverUrl: string): string => {
 
     // Re-throw validation errors without attempting fallback, except for cases
     // where the URL looks like it's missing a protocol (e.g., "domain.com:443")
-    if (errorMessage.includes('Invalid protocol') && !serverUrl.match(/^[a-z0-9.-]+:\d+/i)) {
+    // Match IPv4 addresses or hostnames with dots followed by port (not scheme:port like "ftp:21")
+    if (errorMessage.includes('Invalid protocol') && !serverUrl.match(/^(?:\d{1,3}(?:\.\d{1,3}){3}|[a-z0-9-]+\.[a-z0-9.-]+):\d+/i)) {
       throw error;
     }
 
@@ -264,8 +265,8 @@ export const sanitizeExchangeUrl = (serverUrl: string): string => {
         throw fallbackError;
       }
 
-      // Handle "Invalid URL" for empty hostname case
-      if (fallbackErrorMsg.includes('Invalid URL') && fallbackUrl === 'https://') {
+      // Handle "Invalid URL" for empty hostname case (both http:// and https://)
+      if (fallbackErrorMsg.includes('Invalid URL') && fallbackUrl.match(/^https?:\/\/$/)) {
         throw new Error('URL must have a valid hostname');
       }
 

--- a/src/outlookCalendar/getOutlookEvents.ts
+++ b/src/outlookCalendar/getOutlookEvents.ts
@@ -172,10 +172,18 @@ export const sanitizeExchangeUrl = (serverUrl: string): string => {
 
     return sanitizedUrl;
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
+    // Re-throw validation errors without attempting fallback, except for cases
+    // where the URL looks like it's missing a protocol (e.g., "domain.com:443")
+    if (errorMessage.includes('Invalid protocol') && !serverUrl.match(/^[a-z0-9.-]+:\d+/i)) {
+      throw error;
+    }
+
     // Enhanced fallback using URL constructor more intelligently
     outlookWarn('URL parsing failed, attempting fallback method:', {
       originalUrl: serverUrl,
-      error: error instanceof Error ? error.message : String(error),
+      error: errorMessage,
     });
 
     // Try to fix common URL issues
@@ -198,10 +206,26 @@ export const sanitizeExchangeUrl = (serverUrl: string): string => {
         throw new Error('URL must have a valid hostname');
       }
 
+      // Validate protocol
+      if (!['http:', 'https:'].includes(url.protocol)) {
+        throw new Error(
+          `Invalid protocol "${url.protocol}". Only HTTP and HTTPS are supported`
+        );
+      }
+
       // Use the same clean path construction as main logic
       buildEwsPathname(url);
 
-      const finalUrl = url.toString();
+      // Preserve explicit port if it was in the original URL
+      let finalUrl = url.toString();
+      const portMatch = serverUrl.match(/:(\d+)/);
+      if (portMatch && !url.port) {
+        const port = portMatch[1];
+        if ((url.protocol === 'https:' && port === '443') ||
+            (url.protocol === 'http:' && port === '80')) {
+          finalUrl = finalUrl.replace(url.host, `${url.hostname}:${port}`);
+        }
+      }
 
       outlookLog('Fallback URL construction successful:', {
         input: serverUrl,
@@ -214,21 +238,31 @@ export const sanitizeExchangeUrl = (serverUrl: string): string => {
 
       return finalUrl;
     } catch (fallbackError) {
-      const errorMessage = `Failed to create valid Exchange URL from "${serverUrl}". 
-        Original error: ${error instanceof Error ? error.message : String(error)}. 
-        Fallback error: ${fallbackError instanceof Error ? fallbackError.message : String(fallbackError)}. 
+      const fallbackErrorMsg = fallbackError instanceof Error ? fallbackError.message : String(fallbackError);
+
+      // Re-throw validation errors directly
+      if (fallbackErrorMsg.includes('URL must have a valid hostname') ||
+          fallbackErrorMsg.includes('Invalid protocol')) {
+        throw fallbackError;
+      }
+
+      // Handle "Invalid URL" for empty hostname case
+      if (fallbackErrorMsg.includes('Invalid URL') && fallbackUrl === 'https://') {
+        throw new Error('URL must have a valid hostname');
+      }
+
+      const fallbackErrorMessage = `Failed to create valid Exchange URL from "${serverUrl}".
+        Original error: ${errorMessage}.
+        Fallback error: ${fallbackErrorMsg}.
         Please ensure the URL includes a valid protocol (http:// or https://) and hostname.`;
 
       outlookError('URL sanitization failed completely:', {
         input: serverUrl,
-        originalError: error instanceof Error ? error.message : String(error),
-        fallbackError:
-          fallbackError instanceof Error
-            ? fallbackError.message
-            : String(fallbackError),
+        originalError: errorMessage,
+        fallbackError: fallbackErrorMsg,
       });
 
-      throw new Error(errorMessage);
+      throw new Error(fallbackErrorMessage);
     }
   }
 };


### PR DESCRIPTION
When running tests in `getOutlookEvents.spec.ts`, 3 tests were failing. 
Logs,

```
● Exchange URL Sanitization › Fallback for malformed URLs › handles URLs without protocol mail.example.com:443/ews into https://mail.example.com:443/ews/exchange.asmx

    expect(received).toBe(expected) // Object.is equality

    Expected: "https://mail.example.com:443/ews/exchange.asmx"
    Received: "https://mail.example.com/ews/exchange.asmx"

      125 |     ])('handles URLs without protocol %s into %s', (input, expected) => {
      126 |       const result = sanitizeExchangeUrl(input);
    > 127 |       expect(result).toBe(expected);
          |                      ^
      128 |     });
      129 |   });


● Exchange URL Sanitization › URL validation and error handling › Invalid URL structures › throws error for invalid URL invalid://domain.com with message containing Invalid protocol "invalid:". Only HTTP and HTTPS are supported

    expect(received).toThrow(expected)

    Expected pattern: /Invalid protocol "invalid:". Only HTTP and HTTPS are supported/

    Received function did not throw

      190 |         'throws error for invalid URL %s with message containing %s',
      191 |         (input, expectedErrorPart) => {
    > 192 |           expect(() => sanitizeExchangeUrl(input)).toThrow(
          |                                                    ^
      193 |             new RegExp(expectedErrorPart)
      194 |           );
      195 |         }


● Exchange URL Sanitization › URL validation and error handling › Invalid URL structures › throws error for invalid URL https:// with message containing URL must have a valid hostname

    expect(received).toThrow(expected)

    Expected pattern: /URL must have a valid hostname/
    Received message: "Failed to create valid Exchange URL from \"https://\".·
            Original error: TypeError: Invalid URL.·
            Fallback error: TypeError: Invalid URL.·
            Please ensure the URL includes a valid protocol (http:// or https://) and hostname."

          229 |       });
          230 |
        > 231 |       throw new Error(errorMessage);
              |             ^
          232 |     }
          233 |   }
          234 | };

```


### Changes:
- Added protocol validation in fallback path to catch invalid protocols
- Added port preservation logic for explicit default ports (443/https, 80/http)
- Improved error handling to re-throw validation errors from fallback
- Added special case detection for URLs without protocols that include ports (e.g., `domain.com:443`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Outlook calendar integration by preserving explicit default ports during URL handling.
  * Clearer, more informative error messages for protocol and hostname issues, including explicit handling of empty hostnames and invalid protocol cases.
  * Enhanced diagnostics: original and fallback error details are consolidated for clearer reporting while retaining original error information in logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->