### PR TITLE
fix: hide keyboard shortcut from sidebar tooltip when no shortcut is assigned

### DIFF
--- a/src/ui/components/SideBar/ServerButton.tsx
+++ b/src/ui/components/SideBar/ServerButton.tsx
@@ -143,7 +143,7 @@ const ServerButton = ({
   };
 
   const tooltipContent = `
-  ${title} (${process.platform === 'darwin' ? '⌘' : '^'}+${shortcutNumber})
+  ${title}${shortcutNumber ? ` (${process.platform === 'darwin' ? '⌘' : '^'}+${shortcutNumber})` : ''}
   ${
     hasUnreadMessages
       ? `

--- a/src/ui/components/SideBar/index.tsx
+++ b/src/ui/components/SideBar/index.tsx
@@ -103,7 +103,7 @@ export const SideBar = () => {
                     : server.title ?? server.url
                 }
                 shortcutNumber={
-                  typeof order === 'number' && order <= 9
+                  typeof order === 'number' && order < 9
                     ? String(order + 1)
                     : null
                 }


### PR DESCRIPTION
## What does this PR do?
Fixes the sidebar server tooltip showing `(^+null)` or `(^+10)` 
for servers beyond the 9th position.

Fixes #3244

## Root Cause
Two bugs were found in `src/ui/components/SideBar/`:

**Bug 1:  Off-by-one in `index.tsx`:**
The condition `order <= 9` was incorrectly assigning `shortcutNumber = "10"` 
to the 10th server, even though `Ctrl+10` shortcut does not exist.

**Bug 2: No null check in `ServerButton.tsx`:**
The tooltip always interpolated `shortcutNumber` even when it was `null`, 
causing JavaScript to silently convert `null` to the string `"null"`.

## Changes
- `index.tsx` → changed `order <= 9` to `order < 9`
- `ServerButton.tsx` → conditionally render shortcut only when `shortcutNumber` is not null

## Before & After

| Server | Before | After |
|--------|--------|-------|
| Server 1-9 | `Name (^+1)` to `Name (^+9)` ✅ | `Name (^+1)` to `Name (^+9)` ✅ |
| Server 10 | `Name (^+10)` ❌ | `Name` ✅ |
| Server 11+ | `Name (^+null)` ❌ | `Name` ✅ |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tooltip now displays correctly by only showing keyboard shortcuts when available
  * Keyboard shortcuts assigned to first nine servers only

<!-- end of auto-generated comment: release notes by coderabbit.ai -->