### PR TITLE
feat: support afp:// links and open them with system handler

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,12 @@
-import { app } from 'electron';
-import electronDl from 'electron-dl';
+import { app, shell } from 'electron';
 
-import { performElectronStartup, setupApp } from './app/main/app';
+import {
+  performElectronStartup,
+  setupApp,
+  initializeScreenCaptureFallbackState,
+  setupGpuCrashHandler,
+  markMainWindowStable,
+} from './app/main/app';
 import {
   mergePersistableValues,
   watchAndPersistChanges,
@@ -10,12 +15,26 @@ import { setUserDataDirectory } from './app/main/dev';
 import { setupDeepLinks, processDeepLinksInArgs } from './deepLinks/main';
 import { startDocumentViewerHandler } from './documentViewer/ipc';
 import { setupDownloads } from './downloads/main';
+import { setupElectronDlWithTracking } from './downloads/main/setup';
 import { setupMainErrorHandling } from './errors';
 import i18n from './i18n/main';
+import { handle } from './ipc/main';
 import { handleJitsiDesktopCapturerGetSources } from './jitsi/ipc';
+import { startLogViewerWindowHandler } from './logViewerWindow/ipc';
+import {
+  logger,
+  setupWebContentsLogging,
+  cleanupOldLogs,
+  setupDebugLoggingWatch,
+} from './logging';
 import { setupNavigation } from './navigation/main';
+import attentionDrawing from './notifications/attentionDrawing';
 import { setupNotifications } from './notifications/main';
-import { startOutlookCalendarUrlHandler } from './outlookCalendar/ipc';
+import {
+  startOutlookCalendarUrlHandler,
+  stopOutlookCalendarSync,
+} from './outlookCalendar/ipc';
+import { setupOutlookLogger } from './outlookCalendar/logger';
 import { setupScreenSharing } from './screenSharing/main';
 import { handleClearCacheDialog } from './servers/cache';
 import { setupServers } from './servers/main';
@@ -36,21 +55,39 @@ import touchBar from './ui/main/touchBar';
 import trayIcon from './ui/main/trayIcon';
 import { setupUpdates } from './updates/main';
 import { setupPowerMonitor } from './userPresence/main';
+import { openExternal } from './utils/browserLauncher';
 import {
   handleDesktopCapturerGetSources,
   startVideoCallWindowHandler,
+  cleanupVideoCallResources,
 } from './videoCallWindow/ipc';
-
-electronDl({ saveAs: true });
 
 const start = async (): Promise<void> => {
   setUserDataDirectory();
 
+  logger.info('Starting Rocket.Chat Desktop application');
+
+  setupWebContentsLogging();
+
   performElectronStartup();
+
+  // Set up GPU crash handler BEFORE whenReady to catch early GPU failures
+  setupGpuCrashHandler();
 
   await app.whenReady();
 
+  cleanupOldLogs();
+
   createMainReduxStore();
+
+  setupOutlookLogger();
+  setupDebugLoggingWatch();
+
+  // Initialize screen capture fallback state after store is available
+  initializeScreenCaptureFallbackState();
+
+  // Set up electron-dl with our download tracking callbacks
+  setupElectronDlWithTracking();
 
   const localStorage = await exportLocalStorage();
   await mergePersistableValues(localStorage);
@@ -68,14 +105,14 @@ const start = async (): Promise<void> => {
   attachGuestWebContentsEvents();
   await showRootWindow();
 
-  // React DevTools is currently incompatible with Electron 10
-  // if (process.env.NODE_ENV === 'development') {
-  //   installDevTools();
-  // }
+  // Mark main window as stable - GPU crashes after this won't trigger fallback
+  markMainWindowStable();
   watchMachineTheme();
   setupNotifications();
+  attentionDrawing.setUp();
   setupScreenSharing();
   startVideoCallWindowHandler();
+  startLogViewerWindowHandler();
 
   await setupSpellChecking();
 
@@ -96,6 +133,9 @@ const start = async (): Promise<void> => {
     menuBar.tearDown();
     touchBar.tearDown();
     trayIcon.tearDown();
+    attentionDrawing.tearDown();
+    stopOutlookCalendarSync();
+    cleanupVideoCallResources();
   });
 
   watchAndPersistChanges();
@@ -105,7 +145,37 @@ const start = async (): Promise<void> => {
   startDocumentViewerHandler();
   checkSupportedVersionServers();
 
+  handle('open-external', async (_webContents, rawUrl) => {
+    let url: URL;
+
+    try {
+      url = new URL(rawUrl);
+    } catch {
+      console.warn('Blocked malformed external URL');
+      return;
+    }
+
+    const { isProtocolAllowed } = await import('./navigation/main');
+
+    if (!(await isProtocolAllowed(url.toString()))) {
+      console.warn('Blocked external URL with disallowed protocol');
+      return;
+    }
+
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      await openExternal(url.toString());
+      return;
+    }
+
+    await shell.openExternal(url.toString());
+  });
+
   await processDeepLinksInArgs();
+
+  console.info('Application initialization completed successfully');
 };
 
-start();
+start().catch((error) => {
+  logger.error('Failed to start application', error);
+  app.exit(1);
+});

--- a/src/ui/main/rootWindow.ts
+++ b/src/ui/main/rootWindow.ts
@@ -10,6 +10,7 @@ import {
   APP_MAIN_WINDOW_TITLE_SET,
 } from '../../app/actions';
 import { setupRootWindowReload } from '../../app/main/dev';
+import { getPersistedValues } from '../../app/main/persistence';
 import { select, watch, listen, dispatchLocal, dispatch } from '../../store';
 import type { RootState } from '../../store/rootReducer';
 import { ROOT_WINDOW_STATE_CHANGED, WEBVIEW_FOCUS_REQUESTED } from '../actions';
@@ -43,30 +44,74 @@ const selectRootWindowState = ({ rootWindowState }: RootState): WindowState =>
 
 let _rootWindow: BrowserWindow;
 let tempWindow: BrowserWindow;
+let crashHandlerRegistered = false;
 
 export const getRootWindow = (): Promise<BrowserWindow> =>
   new Promise((resolve, reject) => {
     setTimeout(() => {
-      _rootWindow ? resolve(_rootWindow) : reject(new Error());
+      if (!_rootWindow) {
+        reject(new Error('Root window not initialized'));
+        return;
+      }
+      if (_rootWindow.isDestroyed()) {
+        reject(new Error('Root window has been destroyed'));
+        return;
+      }
+      resolve(_rootWindow);
     }, 300);
   });
 
 const platformTitleBarStyle =
   process.platform === 'darwin' ? 'hidden' : 'default';
 
+const isMac = process.platform === 'darwin';
+const getEnableVibrancy = (): boolean => {
+  if (!isMac) {
+    return false;
+  }
+  try {
+    const persistedValues: { isTransparentWindowEnabled?: boolean } =
+      getPersistedValues();
+    return persistedValues?.isTransparentWindowEnabled === true;
+  } catch (error) {
+    return false;
+  }
+};
+
 export const createRootWindow = (): void => {
+  const enableVibrancy = getEnableVibrancy();
   _rootWindow = new BrowserWindow({
     width: 1000,
     height: 600,
     minWidth: 400,
     minHeight: 400,
     titleBarStyle: platformTitleBarStyle,
-    backgroundColor: '#2f343d',
+    backgroundColor: enableVibrancy ? '#00000000' : '#2f343d',
     show: false,
     webPreferences,
+    ...(enableVibrancy
+      ? {
+          transparent: true,
+          vibrancy: 'sidebar',
+          visualEffectState: 'active',
+        }
+      : {}),
   });
 
-  _rootWindow.addListener('close', (event) => {
+  // Block navigation to smb:// protocol
+  _rootWindow.webContents.on('will-navigate', (event, url) => {
+    if (typeof url === 'string' && url.toLowerCase().startsWith('smb://')) {
+      event.preventDefault();
+    }
+  });
+  _rootWindow.webContents.setWindowOpenHandler(({ url }: { url: string }) => {
+    if (url.toLowerCase().startsWith('smb://')) {
+      return { action: 'deny' };
+    }
+    return { action: 'allow' };
+  });
+
+  _rootWindow.addListener('close', (event: any) => {
     event.preventDefault();
   });
 
@@ -175,41 +220,58 @@ const fetchRootWindowState = async (): Promise<
 };
 
 export const setupRootWindow = (): void => {
+  const safeWindowOperation = async <T>(
+    operation: (window: BrowserWindow) => Promise<T> | T,
+    operationName: string
+  ): Promise<T | void> => {
+    try {
+      const window = await getRootWindow();
+      if (window.isDestroyed()) {
+        return;
+      }
+      return await operation(window);
+    } catch (error) {
+      if (process.env.NODE_ENV === 'development') {
+        console.warn(`${operationName} skipped:`, error);
+      }
+    }
+  };
+
   const unsubscribers = [
     watch(selectGlobalBadgeCount, async (globalBadgeCount) => {
-      const browserWindow = await getRootWindow();
-
-      if (browserWindow.isFocused() || globalBadgeCount === 0) {
-        return;
-      }
-
-      const { isShowWindowOnUnreadChangedEnabled, isFlashFrameEnabled } =
-        select(
-          ({ isShowWindowOnUnreadChangedEnabled, isFlashFrameEnabled }) => ({
-            isShowWindowOnUnreadChangedEnabled,
-            isFlashFrameEnabled,
-          })
-        );
-
-      if (isShowWindowOnUnreadChangedEnabled && !browserWindow.isVisible()) {
-        const isMinimized = browserWindow.isMinimized();
-        const isMaximized = browserWindow.isMaximized();
-
-        browserWindow.showInactive();
-
-        if (isMinimized) {
-          browserWindow.minimize();
+      await safeWindowOperation(async (browserWindow) => {
+        if (browserWindow.isFocused() || globalBadgeCount === 0) {
+          return;
         }
 
-        if (isMaximized) {
-          browserWindow.maximize();
-        }
-        return;
-      }
+        const { isShowWindowOnUnreadChangedEnabled, isFlashFrameEnabled } =
+          select(
+            ({ isShowWindowOnUnreadChangedEnabled, isFlashFrameEnabled }) => ({
+              isShowWindowOnUnreadChangedEnabled,
+              isFlashFrameEnabled,
+            })
+          );
 
-      if (isFlashFrameEnabled && process.platform !== 'darwin') {
-        browserWindow.flashFrame(true);
-      }
+        if (isShowWindowOnUnreadChangedEnabled && !browserWindow.isVisible()) {
+          const isMinimized = browserWindow.isMinimized();
+          const isMaximized = browserWindow.isMaximized();
+
+          browserWindow.showInactive();
+
+          if (isMinimized) {
+            browserWindow.minimize();
+          }
+
+          if (isMaximized) {
+            browserWindow.maximize();
+          }
+          return;
+        }
+
+        if (isFlashFrameEnabled && process.platform !== 'darwin') {
+          browserWindow.flashFrame(true);
+        }
+      }, 'Badge count update');
     }),
     watch(
       ({ currentView, servers }) => {
@@ -220,26 +282,35 @@ export const setupRootWindow = (): void => {
         return currentServer?.pageTitle || currentServer?.title || app.name;
       },
       async (windowTitle) => {
-        const browserWindow = await getRootWindow();
-        browserWindow.setTitle(windowTitle);
-        dispatch({
-          type: APP_MAIN_WINDOW_TITLE_SET,
-          payload: windowTitle,
-        });
+        await safeWindowOperation((browserWindow) => {
+          browserWindow.setTitle(windowTitle);
+          dispatch({
+            type: APP_MAIN_WINDOW_TITLE_SET,
+            payload: windowTitle,
+          });
+        }, 'Window title update');
       }
     ),
     listen(WEBVIEW_FOCUS_REQUESTED, async () => {
-      const rootWindow = await getRootWindow();
-      rootWindow.focus();
-      rootWindow.show();
+      await safeWindowOperation((rootWindow) => {
+        rootWindow.focus();
+        rootWindow.show();
+      }, 'Webview focus request');
     }),
   ];
 
   const fetchAndDispatchWindowState = debounce(async (): Promise<void> => {
-    dispatchLocal({
-      type: ROOT_WINDOW_STATE_CHANGED,
-      payload: await fetchRootWindowState(),
-    });
+    try {
+      const state = await fetchRootWindowState();
+      dispatchLocal({
+        type: ROOT_WINDOW_STATE_CHANGED,
+        payload: state,
+      });
+    } catch (error) {
+      if (process.env.NODE_ENV === 'development') {
+        console.warn('Failed to fetch window state:', error);
+      }
+    }
   }, 1000);
 
   getRootWindow().then((rootWindow) => {
@@ -260,40 +331,79 @@ export const setupRootWindow = (): void => {
       rootWindow.flashFrame(false);
     });
 
-    rootWindow.addListener('close', async () => {
-      if (rootWindow?.isFullScreen()) {
-        await new Promise<void>((resolve) =>
-          rootWindow.once('leave-full-screen', () => resolve())
-        );
-        rootWindow.setFullScreen(false);
+    rootWindow.addListener('close', async (event) => {
+      try {
+        if (rootWindow.isDestroyed()) {
+          return;
+        }
+
+        if (rootWindow.isFullScreen()) {
+          await new Promise<void>((resolve) =>
+            rootWindow.once('leave-full-screen', () => resolve())
+          );
+          rootWindow.setFullScreen(false);
+        }
+
+        if (process.platform !== 'linux' && !rootWindow.isDestroyed()) {
+          rootWindow.blur();
+        }
+
+        let isTrayIconEnabled: boolean;
+        let isMinimizeOnCloseEnabled: boolean;
+
+        try {
+          isTrayIconEnabled = select(
+            ({ isTrayIconEnabled }) => isTrayIconEnabled ?? true
+          );
+          isMinimizeOnCloseEnabled = select(
+            ({ isMinimizeOnCloseEnabled }) => isMinimizeOnCloseEnabled ?? true
+          );
+        } catch (error) {
+          console.warn(
+            'Failed to access application state during close:',
+            error
+          );
+          isTrayIconEnabled = true;
+          isMinimizeOnCloseEnabled = true;
+        }
+
+        if (process.platform === 'darwin' || isTrayIconEnabled) {
+          if (!rootWindow.isDestroyed()) {
+            rootWindow.hide();
+          }
+          return;
+        }
+
+        if (process.platform === 'win32' && isMinimizeOnCloseEnabled) {
+          if (!rootWindow.isDestroyed()) {
+            rootWindow.minimize();
+          }
+          return;
+        }
+
+        // Prevent race condition: window destruction during app.quit()
+        event.preventDefault();
+        app.quit();
+      } catch (error) {
+        console.error('Error in close event handler:', error);
+        event.preventDefault();
+        app.quit();
       }
-
-      if (process.platform !== 'linux') rootWindow.blur();
-
-      const isTrayIconEnabled = select(
-        ({ isTrayIconEnabled }) => isTrayIconEnabled ?? true
-      );
-
-      if (process.platform === 'darwin' || isTrayIconEnabled) {
-        rootWindow.hide();
-        return;
-      }
-
-      const isMinimizeOnCloseEnabled = select(
-        ({ isMinimizeOnCloseEnabled }) => isMinimizeOnCloseEnabled ?? true
-      );
-
-      if (process.platform === 'win32' && isMinimizeOnCloseEnabled) {
-        rootWindow.minimize();
-        return;
-      }
-
-      app.quit();
     });
 
     unsubscribers.push(() => {
-      rootWindow.removeAllListeners();
-      rootWindow.close();
+      try {
+        if (rootWindow && !rootWindow.isDestroyed()) {
+          rootWindow.removeAllListeners();
+          setImmediate(() => {
+            if (rootWindow && !rootWindow.isDestroyed()) {
+              rootWindow.close();
+            }
+          });
+        }
+      } catch (error) {
+        console.error('Error during root window cleanup:', error);
+      }
     });
   });
 
@@ -305,100 +415,138 @@ export const setupRootWindow = (): void => {
 
     unsubscribers.push(
       watch(selectRootWindowIcon, async ({ globalBadge, rootWindowIcon }) => {
-        const browserWindow = await getRootWindow();
+        await safeWindowOperation(async (browserWindow) => {
+          if (!rootWindowIcon) {
+            browserWindow.setIcon(
+              nativeImage.createFromPath(
+                getTrayIconPath({
+                  platform: process.platform,
+                  badge: globalBadge,
+                })
+              )
+            );
+            return;
+          }
 
-        if (!rootWindowIcon) {
-          browserWindow.setIcon(
-            nativeImage.createFromPath(
-              getTrayIconPath({
-                platform: process.platform,
-                badge: globalBadge,
-              })
-            )
-          );
-          return;
-        }
+          const icon = nativeImage.createEmpty();
+          const { scaleFactor } = screen.getPrimaryDisplay();
 
-        const icon = nativeImage.createEmpty();
-        const { scaleFactor } = screen.getPrimaryDisplay();
-
-        if (process.platform === 'linux') {
-          rootWindowIcon.icon.forEach((representation) => {
-            icon.addRepresentation({
-              ...representation,
-              scaleFactor,
-            });
-          });
-        }
-
-        if (process.platform === 'win32') {
-          for (const representation of rootWindowIcon.icon) {
-            icon.addRepresentation({
-              ...representation,
-              scaleFactor: representation.width ?? 0 / 32,
+          if (process.platform === 'linux') {
+            rootWindowIcon.icon.forEach((representation) => {
+              icon.addRepresentation({
+                ...representation,
+                scaleFactor,
+              });
             });
           }
-        }
 
-        browserWindow.setIcon(icon);
-
-        if (process.platform === 'win32') {
-          let overlayIcon: NativeImage | null = null;
-          const overlayDescription: string =
-            (typeof globalBadge === 'number' &&
-              i18next.t('unreadMention', {
-                appName: app.name,
-                count: globalBadge,
-              })) ||
-            (globalBadge === '•' &&
-              i18next.t('unreadMessage', { appName: app.name })) ||
-            i18next.t('noUnreadMessage', { appName: app.name });
-          if (rootWindowIcon.overlay) {
-            overlayIcon = nativeImage.createEmpty();
-
-            for (const representation of rootWindowIcon.overlay) {
-              overlayIcon.addRepresentation({
+          if (process.platform === 'win32') {
+            for (const representation of rootWindowIcon.icon) {
+              icon.addRepresentation({
                 ...representation,
-                scaleFactor: 1,
+                scaleFactor: Math.max((representation.width ?? 0) / 32, 1),
               });
             }
           }
 
-          const isTrayIconEnabled = select(
-            ({ isTrayIconEnabled }) => isTrayIconEnabled ?? true
-          );
+          browserWindow.setIcon(icon);
 
-          if (!isTrayIconEnabled) {
-            const t = i18next.t.bind(i18next);
-            const translate = `taskbar.${overlayDescription}`;
-            const taskbarTitle =
-              globalBadge !== undefined
-                ? `(${globalBadge}) ${t(translate)}`
-                : t(translate);
+          if (process.platform === 'win32') {
+            let overlayIcon: NativeImage | null = null;
+            const overlayDescription: string =
+              (typeof globalBadge === 'number' &&
+                i18next.t('unreadMention', {
+                  appName: app.name,
+                  count: globalBadge,
+                })) ||
+              (globalBadge === '•' &&
+                i18next.t('unreadMessage', { appName: app.name })) ||
+              i18next.t('noUnreadMessage', { appName: app.name });
+            if (rootWindowIcon.overlay) {
+              overlayIcon = nativeImage.createEmpty();
 
-            browserWindow.setTitle(taskbarTitle);
+              for (const representation of rootWindowIcon.overlay) {
+                overlayIcon.addRepresentation({
+                  ...representation,
+                  scaleFactor: 1,
+                });
+              }
+            }
+
+            const isTrayIconEnabled = select(
+              ({ isTrayIconEnabled }) => isTrayIconEnabled ?? true
+            );
+
+            if (!isTrayIconEnabled) {
+              const t = i18next.t.bind(i18next);
+              const translate = `taskbar.${overlayDescription}`;
+              const taskbarTitle =
+                globalBadge !== undefined
+                  ? `(${globalBadge}) ${t(translate)}`
+                  : t(translate);
+
+              browserWindow.setTitle(taskbarTitle);
+            }
+            browserWindow.setOverlayIcon(overlayIcon, overlayDescription);
           }
-          browserWindow.setOverlayIcon(overlayIcon, overlayDescription);
-        }
+        }, 'Window icon update');
       }),
       watch(
         ({ isMenuBarEnabled }) => isMenuBarEnabled,
         async (isMenuBarEnabled) => {
-          const browserWindow = await getRootWindow();
-          browserWindow.autoHideMenuBar = !isMenuBarEnabled;
-          browserWindow.setMenuBarVisibility(isMenuBarEnabled);
+          await safeWindowOperation((browserWindow) => {
+            browserWindow.autoHideMenuBar = !isMenuBarEnabled;
+            browserWindow.setMenuBarVisibility(isMenuBarEnabled);
+          }, 'Menu bar visibility update');
         }
       )
     );
   }
 
   app.addListener('before-quit', () => {
-    unsubscribers.forEach((unsubscriber) => unsubscriber());
+    unsubscribers.forEach((unsubscriber) => {
+      try {
+        unsubscriber();
+      } catch (error) {
+        console.warn('Unsubscriber error during quit:', error);
+      }
+    });
   });
 };
 
 export const showRootWindow = async (): Promise<void> => {
   const browserWindow = await getRootWindow();
+
+  // Handle renderer process crashes
+  if (!crashHandlerRegistered) {
+    crashHandlerRegistered = true;
+
+    browserWindow.webContents.on(
+      'render-process-gone',
+      async (_event, details) => {
+        console.error('Renderer process crashed:', details.reason);
+        try {
+          const { session } = browserWindow.webContents;
+          await session.clearCache();
+          await session.clearStorageData({
+            storages: [
+              'cookies',
+              'indexdb',
+              'filesystem',
+              'shadercache',
+              'websql',
+              'serviceworkers',
+              'cachestorage',
+            ],
+          });
+          console.log('Cache cleared. Reloading window...');
+          browserWindow.reload();
+        } catch (error) {
+          console.error('Failed to recover from crash:', error);
+        }
+      }
+    );
+  }
 
   browserWindow.loadFile(path.join(app.getAppPath(), 'app/index.html'));
 
@@ -420,6 +568,7 @@ export const showRootWindow = async (): Promise<void> => {
       }
 
       setupRootWindow();
+
       resolve();
     });
   });


### PR DESCRIPTION
Adds support for afp:// links in the Rocket.Chat desktop client.

Previously AFP links were opened in the browser.
With this change, AFP links are opened using the system handler (e.g., Finder on macOS).

Fixes issue where AFP file paths could not be opened directly from chat messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added crash recovery that clears caches and reloads when needed
  * Added GPU crash protection
  * Added screen capture fallback handling
  * Added window attention features

* **Improvements**
  * Enhanced window stability and state persistence on macOS
  * Improved window lifecycle management and error handling
  * Better URL validation and protocol enforcement

* **Platform Support**
  * Added ARM64 support for Windows builds
  * Enabled Snap package support
  * Removed Flatpak from Linux builds

* **Localization**
  * Updated Hungarian translations with new menu items and dialog strings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
fix issue #438 