### PR TITLE
fix: enable PDF rendering in desktop viewer

### DIFF
--- a/src/ui/main/serverView/index.ts
+++ b/src/ui/main/serverView/index.ts
@@ -210,6 +210,7 @@ export const attachGuestWebContentsEvents = async (): Promise<void> => {
     webPreferences.webSecurity = true;
     webPreferences.contextIsolation = true;
     webPreferences.sandbox = false;
+    webPreferences.plugins = true;
   };
 
   const handleDidAttachWebview = (
@@ -250,6 +251,7 @@ export const attachGuestWebContentsEvents = async (): Promise<void> => {
                 webPreferences: {
                   preload: path.join(app.getAppPath(), 'app/preload.js'),
                   sandbox: false,
+                  plugins: true,
                 },
               }
             : {}),


### PR DESCRIPTION
Fixes #3255

PDF files opened in the desktop viewer were displayed as raw text instead of rendering properly.

Cause:
Electron requires `webPreferences.plugins = true` to enable the built-in Chromium PDF viewer.

Solution:
Enabled `plugins: true` in the webview configuration so PDFs render correctly inside the desktop viewer.

This matches the behavior seen in the browser version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugins are now enabled for webviews and video call windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->