### PR TITLE
fix: prevent HTML entity encoding in interpolated values

### DIFF
--- a/src/i18n/common.ts
+++ b/src/i18n/common.ts
@@ -103,6 +103,7 @@ const formatDuration = (duration: number): string => {
 };
 
 export const interpolation: InitOptions['interpolation'] = {
+  escapeValue: false,
   format: (value, format, lng) => {
     if (value instanceof Date && !Number.isNaN(value.getTime())) {
       return new Intl.DateTimeFormat(lng).format(value);


### PR DESCRIPTION
**Summary**

- Fixed expiration date in Server Info displaying HTML entities (e.g., 4&#x2F;16&#x2F;2026) instead of properly formatted dates (e.g., 4/16/2026)
- Added escapeValue: false to the i18next interpolation config in src/i18n/common.ts

**Root Cause**

i18next's default escapeValue is true, which HTML-encodes interpolated values to prevent XSS. The / character in locale-formatted dates was being escaped to &#x2F;. Since this is a React app (which already handles XSS protection via JSX), escaping is unnecessary and is the https://react.i18next.com/latest/i18next-instance.

**Steps to Reproduce**

1. Open the Rocket.Chat Desktop App
2. Right-click on a server in the left sidebar
3. Click Server Info
4. Check the Expiration field

[CORE-1935]

[CORE-1935]: https://rocketchat.atlassian.net/browse/CORE-1935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translation interpolation so special characters and formatted content render correctly (disables automatic escaping), preventing double-escaped or HTML-encoded text in UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->