### PR TITLE
fix: always show PDF viewer toolbar with back button

### DIFF
--- a/src/ui/components/ServersView/DocumentViewer.tsx
+++ b/src/ui/components/ServersView/DocumentViewer.tsx
@@ -70,21 +70,22 @@ const DocumentViewer = ({
         bg='tint'
         width='100%'
         height='100%'
-        position='absolute'
-        content='center'
-        alignItems='center'
+        display='flex'
+        flexDirection='column'
       >
         <Box
-          content='center'
-          alignItems='center'
           display='flex'
+          alignItems='center'
           color='default'
+          pbe='x8'
+          pbs='x8'
+          pis='x8'
         >
           <IconButton icon='arrow-back' onClick={closeDocumentViewer} mi='x8' />
           <h2>PDF Viewer</h2>
         </Box>
 
-        <Box>
+        <Box position='relative' flexGrow={1}>
           <Box
             display='flex'
             justifyContent='center'
@@ -101,9 +102,10 @@ const DocumentViewer = ({
             src={documentUrl}
             style={{
               width: '100%',
+              height: '100%',
               position: 'absolute',
               left: 0,
-              top: 50,
+              top: 0,
               right: 0,
               bottom: 0,
             }}

--- a/src/ui/components/ServersView/styles.tsx
+++ b/src/ui/components/ServersView/styles.tsx
@@ -23,6 +23,12 @@ type DocumentViewerWrapperProps = {
 };
 
 export const DocumentViewerWrapper = styled.section<DocumentViewerWrapperProps>`
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+
   ${({ isVisible }) => css`
     display: ${isVisible ? 'flex' : 'none'};
   `};


### PR DESCRIPTION
## Summary

Fixes [CORE-1241](https://rocketchat.atlassian.net/browse/CORE-1241) — PDF viewer always shows the Back button toolbar.

When opening a PDF from a channel's Files tab, the PDF viewer toolbar (with the Back button) was not visible, leaving the user stuck with no way to navigate back.

## Changes

- Add absolute positioning to `DocumentViewerWrapper` so it properly fills the parent container
- Change `DocumentViewer` layout from absolute-positioned to column flex, ensuring the toolbar stacks above the PDF content
- Set the content area to `flexGrow: 1` with relative positioning so the webview fills the remaining space

## Test plan

- [ ] Open a channel > Files tab > select a PDF — verify the Back button toolbar is visible
- [ ] Open a PDF directly from a conversation message — verify the Back button toolbar is still visible
- [ ] Click the Back button — verify it closes the PDF viewer and returns to the channel
- [ ] Test with sidebar visible and sidebar hidden — toolbar should show in both cases

[CORE-1241]: https://rocketchat.atlassian.net/browse/CORE-1241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Restructured document viewer layout to use flexbox architecture for improved responsiveness and flexible content sizing.
  * Refined container positioning and overlay styling for enhanced visual display behavior and rendering.
  * Optimized header styling with improved padding and alignment for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->