### PR TITLE
fix: allow skipped updates to appear on manual check for updates

### DIFF
--- a/src/updates/main.ts
+++ b/src/updates/main.ts
@@ -162,6 +162,8 @@ const loadConfiguration = async (): Promise<UpdateConfiguration> => {
   );
 };
 
+let isUserInitiatedCheck = false;
+
 export const setupUpdates = async (): Promise<void> => {
   // This is necessary to make the updater work in development mode
   if (process.env.NODE_ENV === 'development') {
@@ -244,7 +246,7 @@ export const setupUpdates = async (): Promise<void> => {
     const skippedUpdateVersion = select(
       ({ skippedUpdateVersion }) => skippedUpdateVersion
     );
-    if (skippedUpdateVersion === version) {
+    if (!isUserInitiatedCheck && skippedUpdateVersion === version) {
       dispatch({ type: UPDATES_NEW_VERSION_NOT_AVAILABLE });
       return;
     }
@@ -329,6 +331,7 @@ export const setupUpdates = async (): Promise<void> => {
 
   if (doCheckForUpdatesOnStartup) {
     try {
+      isUserInitiatedCheck = false;
       await autoUpdater.checkForUpdates();
     } catch (error) {
       error instanceof Error &&
@@ -345,6 +348,7 @@ export const setupUpdates = async (): Promise<void> => {
 
   listen(UPDATES_CHECK_FOR_UPDATES_REQUESTED, async () => {
     try {
+      isUserInitiatedCheck = true;
       setTimeout(() => {
         autoUpdater.checkForUpdates();
       }, 100);


### PR DESCRIPTION
## Summary

Fixes the update skip behavior so that manually checking for updates (About → Check for Updates) shows all available versions, including previously skipped ones. The skip preference now only suppresses automatic startup checks.

**Jira:** https://rocketchat.atlassian.net/browse/CORE-1389

## Changes

- Add `isUserInitiatedCheck` flag to distinguish manual vs automatic update checks
- Only honor `skippedUpdateVersion` during automatic (startup) checks
- User-initiated checks bypass the skip filter, matching OS-level update behavior (macOS/Windows)

## Test plan

- [ ] Skip a version via the update notification dialog
- [ ] Restart the app — verify the skipped version does **not** appear on automatic startup check
- [ ] Open About → Check for Updates — verify the skipped version **does** appear
- [ ] Verify non-skipped versions continue to appear on both automatic and manual checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined update notification behavior for previously skipped versions when performing manual update checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->