### PR TITLE
fix(a11y): add missing aria-label to sidebar add workspace button

### DIFF
--- a/src/ui/components/SideBar/index.tsx
+++ b/src/ui/components/SideBar/index.tsx
@@ -137,6 +137,7 @@ export const SideBar = () => {
               title={t('sidebar.tooltips.addWorkspace', {
                 shortcut: process.platform === 'darwin' ? '⌘' : '^',
               })}
+              aria-label={t('sidebar.tooltips.addWorkspace')}
             ></IconButton>
           )}
         </ButtonGroup>


### PR DESCRIPTION
Closes N/A

## Description

This PR fixes an accessibility issue in the sidebar where the "Add Workspace" button was missing an `aria-label`.

Although a `title` attribute was present, screen readers require an explicit `aria-label` to properly describe the button's purpose.

## Changes

- Added `aria-label` to the sidebar "Add Workspace" button using the existing translation key

## Impact

- Improves accessibility for screen reader users
- Resolves console warning related to missing accessible label
- No functional changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Enhanced the "add workspace" button with improved screen reader support for better accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->