### PR TITLE
fix: prevent microphone indicator on startup by adding setPermissionCheckHandler

### DIFF
--- a/src/ui/main/serverView/index.ts
+++ b/src/ui/main/serverView/index.ts
@@ -367,6 +367,15 @@ export const attachGuestWebContentsEvents = async (): Promise<void> => {
     );
   };
 
+  const handlePermissionCheck: Parameters<
+    Session['setPermissionCheckHandler']
+  >[0] = (_webContents, permission) => {
+    if (permission === 'media') {
+      return true;
+    }
+    return false;
+  };
+
   const handlePermissionRequest: Parameters<
     Session['setPermissionRequestHandler']
   >[0] = async (_webContents, permission, callback, details) => {
@@ -419,6 +428,7 @@ export const attachGuestWebContentsEvents = async (): Promise<void> => {
       rootWindow
     );
 
+    guestWebContents.session.setPermissionCheckHandler(handlePermissionCheck);
     guestWebContents.session.setPermissionRequestHandler(
       handlePermissionRequest
     );


### PR DESCRIPTION
Fixes #3112

## Problem
On Windows, the app triggers the microphone-in-use taskbar indicator 
on startup because the webapp's routine `navigator.permissions.query()` 
calls escalated into OS-level `getMediaAccessStatus('microphone')` calls.

## Fix
Added `setPermissionCheckHandler` in `serverView/index.ts` that returns 
`true` for `'media'` permission checks. This intercepts the webapp's 
startup permission queries before they escalate to OS API calls that 
trigger the mic indicator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission handling for guest webviews with more restrictive access controls to essential permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->