### PR TITLE
chore: update Electron from 40.0.0 to 40.8.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "chokidar": "~3.5.3",
     "conventional-changelog-cli": "~4.1.0",
     "convert-svg-to-png": "~0.6.4",
-    "electron": "40.0.0",
+    "electron": "40.8.5",
     "electron-builder": "26.0.3",
     "electron-devtools-installer": "^3.2.0",
     "electron-notarize": "^1.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8619,16 +8619,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:40.0.0":
-  version: 40.0.0
-  resolution: "electron@npm:40.0.0"
+"electron@npm:40.8.5":
+  version: 40.8.5
+  resolution: "electron@npm:40.8.5"
   dependencies:
     "@electron/get": "npm:^2.0.0"
     "@types/node": "npm:^24.9.0"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10/ac4896cb44dacddd68b89b2a04fbc0834234c2dc40a1630bd1ed5ff05972d6a4712baab5e2101c1cc08a1589b5381b4058b14a25d5bd0f2804f8f7fc056efd5c
+  checksum: 10/13782668afa2ba8404e129eb3c67269d52f009734d0e100193fc382d98efc51b79d2afce3dc1c7a091e74f6028b10f9fe0cf1a32330af873d4df5ee9a83e93c2
   languageName: node
   linkType: hard
 
@@ -15036,7 +15036,7 @@ __metadata:
     convert-svg-to-png: "npm:~0.6.4"
     detect-browsers: "npm:~6.1.0"
     dompurify: "npm:~3.3.3"
-    electron: "npm:40.0.0"
+    electron: "npm:40.8.5"
     electron-builder: "npm:26.0.3"
     electron-devtools-installer: "npm:^3.2.0"
     electron-dl: "npm:4.0.0"


### PR DESCRIPTION
## Summary
- Updates Electron from 40.0.0 to 40.8.5 (latest in the 40.x series)
- Chromium updated from 144.0.7559.68 to 144.0.7559.236
- Node.js updated from 24.11.0 to 24.14.0
- No breaking changes — all 40.x releases are backwards-compatible patch/minor updates

## Notable fixes included
- Fixed `clipboard.readImage()` crash with malformed image data
- Fixed Windows notification icons failing due to invalid filename characters
- Fixed macOS `safeStorage` keychain migration issues
- Fixed Windows shutdown crash with hidden titlebar
- Fixed macOS frameless window resize in MAS builds
- Fixed Linux menu bar hiding after `setFullScreen(false)`
- Fixed `desktopCapturer` CoreAudio Tap API for macOS audio capture
- Fixed offscreen rendering screen info and media queries

## Test plan
- [x] TypeScript compilation passes (`tsc --noEmit`)
- [x] ESLint passes (no errors)
- [x] All 213 tests pass across 17 suites
- [ ] Manual smoke test on macOS
- [ ] CI build verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Electron runtime dependency to version 40.8.5, incorporating bug fixes, stability improvements, and security updates to the application's build environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->