### PR TITLE
fix: handle unhandled promise rejections in auto-updater

### DIFF
--- a/src/updates/main.ts
+++ b/src/updates/main.ts
@@ -349,9 +349,8 @@ export const setupUpdates = async (): Promise<void> => {
   listen(UPDATES_CHECK_FOR_UPDATES_REQUESTED, async () => {
     try {
       isUserInitiatedCheck = true;
-      setTimeout(() => {
-        autoUpdater.checkForUpdates();
-      }, 100);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      await autoUpdater.checkForUpdates();
     } catch (error) {
       error instanceof Error &&
         dispatch({
@@ -377,7 +376,7 @@ export const setupUpdates = async (): Promise<void> => {
     await warnAboutUpdateDownload();
 
     try {
-      autoUpdater.downloadUpdate();
+      await autoUpdater.downloadUpdate();
     } catch (error) {
       error instanceof Error &&
         dispatch({


### PR DESCRIPTION
## Summary

- Fix unhandled promise rejection (`ERR_UPDATER_NO_PUBLISHED_VERSIONS`) that crashes the app when the GitHub releases feed is unreachable for some users
- Properly `await` the `checkForUpdates()` promise in user-initiated checks — it was previously fire-and-forget inside a `setTimeout` callback, escaping the try-catch
- Properly `await` the `downloadUpdate()` promise so its try-catch also works

## Context

Some users report an unhandled promise rejection when checking for updates. The same version works for others — the releases exist on GitHub, but the affected machines can't reach the Atom feed (likely network/proxy/rate-limiting). The startup check (`await autoUpdater.checkForUpdates()`) handled this correctly, but the user-initiated check and download path did not.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `yarn lint` passes
- [x] `yarn test` — 213/213 tests pass
- [ ] Manual: verify no crash when GitHub releases are unreachable
- [ ] Manual: verify normal update flow still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved update system reliability by ensuring update checks and downloads are properly synchronized with enhanced error handling to report issues to users more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->