### PR TITLE
fix: don't reload external pages Closes #3299

### DIFF
--- a/src/injected.ts
+++ b/src/injected.ts
@@ -43,6 +43,18 @@ const start = async () => {
       console.error(
         `[Rocket.Chat Desktop] Maximum retry time (${MAX_RETRY_TIME}ms) reached. window.require is still not available.`
       );
+
+      // Only trigger a force reload if the page appears to be a RocketChat
+      // instance. A missing `__meteor_runtime_config__` global indicates we
+      // are on an external page (e.g. a SAML/SSO IdP), where a force reload
+      // would interrupt the authentication flow.
+      if (typeof window.__meteor_runtime_config__ === 'undefined') {
+        console.log(
+          '[Rocket.Chat Desktop] External page detected (no Meteor runtime). Skipping force reload.'
+        );
+        return;
+      }
+          
       console.log(
         '[Rocket.Chat Desktop] Triggering force reload with cache clear to recover...'
       );


### PR DESCRIPTION
Fixes #3299 

On external pages (e.g. SAML/SSO), where window.require is not available, injected.ts fired a force-reload, this fix will avoid that


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced external page detection: The system now identifies non-Meteor pages during recovery operations and handles them gracefully without forcing unnecessary reloads, improving stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->