### PR TITLE
fix: only show notification when renotify is enabled in main process

### DIFF
--- a/src/notifications/main.ts
+++ b/src/notifications/main.ts
@@ -204,7 +204,9 @@ const updateNotification = async (
     }
   }
 
-  notification.show();
+  if (_renotify) {
+    notification.show();
+  }
 
   if (changedToVoice) {
     attentionDrawing.drawAttention(id);


### PR DESCRIPTION
fix #3301 

From previous commit i can see there is this variable "_renotify" got removed 
just re added that 
this should fix the issue 

Tests:
Lint
Manual Test of fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification behavior to only re-display when explicitly requested, preventing unnecessary re-triggers during routine updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->