### PR TITLE
chore: pin github actions to SHA hashes

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -28,17 +28,17 @@ jobs:
         run: git config --global core.autocrlf false
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
 
       - name: Setup Node 24.11.1
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24.11.1'
 
       - name: Setup node_modules cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
@@ -67,13 +67,13 @@ jobs:
 
       - name: Setup gcloud (Windows)
         if: ${{ matrix.os == 'windows-latest' }}
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
         with:
           version: '>=536.0.0'
 
       - name: Authenticate to Google Cloud (Windows)
         if: ${{ matrix.os == 'windows-latest' }}
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
         with:
           credentials_json: ${{ secrets.GCP_SA_JSON }}
 

--- a/.github/workflows/powershell-lint.yml
+++ b/.github/workflows/powershell-lint.yml
@@ -26,7 +26,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       
       - name: Install PSScriptAnalyzer
         shell: pwsh

--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -36,17 +36,17 @@ jobs:
         run: git config --global core.autocrlf false
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Setup Node 24.11.1
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24.11.1'
 
       - name: Setup node_modules cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
@@ -77,7 +77,7 @@ jobs:
 
       - name: Cache Google Cloud KMS CNG provider (Windows)
         if: ${{ matrix.os == 'windows-latest' }}
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: cache-kms-cng
         with:
           path: build/installers/google-cloud-kms-cng-provider.msi
@@ -255,13 +255,13 @@ jobs:
 
       - name: Setup gcloud (Windows)
         if: ${{ matrix.os == 'windows-latest' }}
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
         with:
           version: '>=536.0.0'
 
       - name: Authenticate to Google Cloud (Windows)
         if: ${{ matrix.os == 'windows-latest' }}
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
         with:
           credentials_json: ${{ secrets.GCP_SA_JSON }}
 
@@ -555,7 +555,7 @@ jobs:
 
       - name: Publish to Snap Store (Edge)
         if: ${{ matrix.build-target == 'linux' }}
-        uses: snapcore/action-publish@v1
+        uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1.2.0
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         with:
@@ -613,7 +613,7 @@ jobs:
       # Get Artifact URLs using actions/github-script (only specified file extensions)
       - name: Get Artifact URLs
         id: get-artifact-urls
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             const fs = require('fs');
@@ -632,7 +632,7 @@ jobs:
 
       - name: Post PR Comment with the Artifact links
         if: steps.get-artifact-urls.outputs.artifact_urls != ''
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           header: ${{ runner.os }}-installer

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -26,13 +26,13 @@ jobs:
       - name: Disable git core.autocrlf
         run: git config --global core.autocrlf false
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup Node 24.11.1
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24.11.1'
       - name: Setup node_modules cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
<!--
INSTRUCTION: Your Pull Request name should start with one of the following
prefixes:

- "feat:" for new features;
- "fix:" for bug fixes.
-->

# Proposed changes
This PR replaces mutable tag references with immutable commit SHA pins for all third-party GitHub Actions, as part of a supply chain security hardening effort.

Each workflow file now references the exact commit SHA of the desired action version instead of a floating tag. This guarantees that the same code is always executed regardless of whether the version tag is moved or the action's repository is modified after pinning.
<!-- Inform the issue number that this PR closes, or remove the line below -->

# Issues
[SB-958](https://rocketchat.atlassian.net/browse/SB-958)

<!-- Tell us more about your PR with screen shots if you can -->


[SB-958]: https://rocketchat.atlassian.net/browse/SB-958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions to use pinned commit versions across build and validation workflows for improved stability and security in CI/CD processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->