### PR TITLE
feat: add openInBrowser to RocketChatDesktop API

### DIFF
--- a/src/browser/ipc.ts
+++ b/src/browser/ipc.ts
@@ -1,0 +1,16 @@
+import { handle } from '../ipc/main';
+import { openExternal } from '../utils/browserLauncher';
+
+export const startBrowserHandler = (): void => {
+  handle('browser/open-url', async (_event, url) => {
+    try {
+      const parsed = new URL(url);
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        return;
+      }
+      await openExternal(parsed.toString());
+    } catch {
+      // Invalid URL — ignore
+    }
+  });
+};

--- a/src/ipc/channels.ts
+++ b/src/ipc/channels.ts
@@ -74,6 +74,7 @@ type ChannelToArgsMap = {
   'outlook-calendar/has-credentials': () => boolean;
   'outlook-calendar/clear-credentials': () => void;
   'outlook-calendar/set-user-token': (token: string, userId: string) => void;
+  'browser/open-url': (url: string) => void;
   'document-viewer/open-window': (
     url: string,
     format: string,

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import {
   watchAndPersistChanges,
 } from './app/main/data';
 import { setUserDataDirectory } from './app/main/dev';
+import { startBrowserHandler } from './browser/ipc';
 import { setupDeepLinks, processDeepLinksInArgs } from './deepLinks/main';
 import { startDocumentViewerHandler } from './documentViewer/ipc';
 import { setupDownloads } from './downloads/main';
@@ -145,6 +146,7 @@ const start = async (): Promise<void> => {
   handleDesktopCapturerGetSources();
   handleClearCacheDialog();
   startDocumentViewerHandler();
+  startBrowserHandler();
   checkSupportedVersionServers();
 
   await processDeepLinksInArgs();

--- a/src/servers/preload/api.ts
+++ b/src/servers/preload/api.ts
@@ -24,6 +24,7 @@ import {
   getInternalVideoChatWindowEnabled,
   openInternalVideoChatWindow,
 } from './internalVideoChatWindow';
+import { openInBrowser } from './openInBrowser';
 import { reloadServer } from './reloadServer';
 import {
   setBackground,
@@ -47,6 +48,7 @@ type ExtendedIRocketChatDesktop = IRocketChatDesktop & {
     options: CustomNotificationOptions
   ) => Promise<unknown>;
   closeCustomNotification: (id: unknown) => void;
+  openInBrowser: (url: string) => void;
 };
 
 declare global {
@@ -91,5 +93,6 @@ export const RocketChatDesktop: Window['RocketChatDesktop'] = {
   setUserToken,
   setSidebarCustomTheme,
   openDocumentViewer,
+  openInBrowser,
   reloadServer,
 };

--- a/src/servers/preload/openInBrowser.ts
+++ b/src/servers/preload/openInBrowser.ts
@@ -1,0 +1,16 @@
+import { ipcRenderer } from 'electron';
+
+export const openInBrowser = (url: string): void => {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      console.warn(
+        `[RocketChatDesktop.openInBrowser] blocked non-http(s) URL: ${parsed.protocol}`
+      );
+      return;
+    }
+    ipcRenderer.invoke('browser/open-url', parsed.toString());
+  } catch (error) {
+    console.warn('[RocketChatDesktop.openInBrowser] invalid URL:', error);
+  }
+};


### PR DESCRIPTION
## Summary

Adds `openInBrowser(url)` to the `RocketChatDesktop` API injected into server webviews, so the server frontend can request that a URL be opened in the user's native browser instead of inside the Electron shell.

- Expose `window.RocketChatDesktop.openInBrowser(url: string): void` from the servers preload
- Add typed `browser/open-url` IPC channel and main-process handler
- Validate URL in preload and main — http/https only; non-matching schemes (`file:`, `javascript:`, `mailto:`, custom) are rejected
- Route through `utils/browserLauncher.openExternal` so the user's selected-browser setting is honored

## Test plan

- [ ] `yarn lint` clean
- [ ] `npx tsc --noEmit` clean
- [ ] Manual: from an attached server webview devtools, call `window.RocketChatDesktop.openInBrowser('https://example.com')` — opens in default/selected browser
- [ ] Manual: call with `file:///etc/passwd`, `javascript:alert(1)`, `mailto:x@y`, `''` — all rejected, no crash, warning logged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for opening URLs in your default web browser directly from the application. The feature validates URLs for security and only processes HTTP/HTTPS links, with graceful error handling for invalid URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->