### PR TITLE
fix: reject getDisplayMedia calls without user gesture on server view

### DIFF
--- a/src/screenSharing/serverViewScreenSharing.ts
+++ b/src/screenSharing/serverViewScreenSharing.ts
@@ -69,19 +69,23 @@ export const setupServerViewDisplayMedia = (
     const currentProvider = provider;
     try {
       guestWebContents.session.setDisplayMediaRequestHandler(
-        (_request, cb) => {
-          try {
-            currentProvider.handleDisplayMediaRequest(cb);
-          } catch (error) {
-            console.error(
-              'Server view screen sharing: error in handler:',
-              error
-            );
-            cb({ video: false } as any);
-          }
-        },
-        { useSystemPicker: false }
+  (request, cb) => {
+    if (!request.userGesture) {
+      cb({} as any);
+      return;
+    }
+    try {
+      currentProvider.handleDisplayMediaRequest(cb);
+    } catch (error) {
+      console.error(
+        'Server view screen sharing: error in handler:',
+        error
       );
+      cb({ video: false } as any);
+    }
+  },
+  { useSystemPicker: false }
+);
       prewarmDesktopCapturerCache();
     } catch (error) {
       console.error(

--- a/src/screenSharing/serverViewScreenSharing.ts
+++ b/src/screenSharing/serverViewScreenSharing.ts
@@ -69,23 +69,23 @@ export const setupServerViewDisplayMedia = (
     const currentProvider = provider;
     try {
       guestWebContents.session.setDisplayMediaRequestHandler(
-  (request, cb) => {
-    if (!request.userGesture) {
-      cb({} as any);
-      return;
-    }
-    try {
-      currentProvider.handleDisplayMediaRequest(cb);
-    } catch (error) {
-      console.error(
-        'Server view screen sharing: error in handler:',
-        error
+        (request, cb) => {
+          if (!request.userGesture) {
+            cb({} as any);
+            return;
+          }
+          try {
+            currentProvider.handleDisplayMediaRequest(cb);
+          } catch (error) {
+            console.error(
+              'Server view screen sharing: error in handler:',
+              error
+            );
+            cb({ video: false } as any);
+          }
+        },
+        { useSystemPicker: false }
       );
-      cb({ video: false } as any);
-    }
-  },
-  { useSystemPicker: false }
-);
       prewarmDesktopCapturerCache();
     } catch (error) {
       console.error(


### PR DESCRIPTION
Closes #3308

## Problem
Since 4.14.0, the screen share picker opens automatically on every app launch on Linux/Wayland/Flatpak. PR #3266 registered
setDisplayMediaRequestHandler on every server view webview. The Rocket.Chat web app calls getDisplayMedia() at load time as a capability probe, and the newly registered handler catches this and opens the picker unconditionally.

## Fix
Added a userGesture guard inside setupServerViewDisplayMedia() in serverViewScreenSharing.ts. If the request has no user gesture (i.e. triggered automatically by the page), it is silently rejected and the picker is not shown.

## Testing
- Verified the code compiles cleanly
- Verified screen sharing still works when manually triggered on Windows
- Could not reproduce the Linux/Wayland/Flatpak environment locally — please verify on that setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced user-gesture requirement for screen-sharing requests so attempts without explicit user interaction are promptly rejected; failures fall back to disabling video to keep sessions secure.

* **Refactor**
  * Adjusted handler registration formatting for improved consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->