### PR TITLE
security(CORE-1122): macOS secure keyboard entry for sensitive inputs

### DIFF
--- a/src/ipc/channels.ts
+++ b/src/ipc/channels.ts
@@ -136,6 +136,7 @@ type ChannelToArgsMap = {
   'screen-picker/source-responded': (sourceId: string | null) => void;
   'screen-picker/screen-recording-is-permission-granted': () => boolean;
   'screen-picker/open-url': (url: string) => void;
+  'secure-keyboard-entry/set': (enabled: boolean) => void;
 };
 
 export type Channel = keyof ChannelToArgsMap;

--- a/src/ipc/channels.ts
+++ b/src/ipc/channels.ts
@@ -141,6 +141,7 @@ type ChannelToArgsMap = {
   'screen-picker/screen-recording-is-permission-granted': () => boolean;
   'screen-picker/open-url': (url: string) => void;
   'telephony/get-diagnostics': () => TelephonyDiagnostics;
+  'secure-keyboard-entry/set': (enabled: boolean) => void;
 };
 
 export type Channel = keyof ChannelToArgsMap;

--- a/src/ui/components/OutlookCredentialsDialog/index.spec.tsx
+++ b/src/ui/components/OutlookCredentialsDialog/index.spec.tsx
@@ -80,8 +80,10 @@ jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (k: string) => k }),
 }));
 
+const mockUseSelector = jest.fn<string, []>(() => 'outlook-credentials');
+
 jest.mock('react-redux', () => ({
-  useSelector: jest.fn(() => 'outlook-credentials'),
+  useSelector: (_selector: unknown) => mockUseSelector(),
   useDispatch: jest.fn(() => jest.fn()),
 }));
 
@@ -105,10 +107,15 @@ jest.mock('../Dialog', () => {
 
 const originalPlatform = process.platform;
 
-function renderDialog(): { container: HTMLElement; unmount: () => void } {
+function renderDialog(openDialog = 'outlook-credentials'): {
+  container: HTMLElement;
+  unmount: () => void;
+  setOpenDialog: (value: string) => void;
+} {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root = createRoot(container);
+  mockUseSelector.mockReturnValue(openDialog);
   act(() => {
     root.render(React.createElement(OutlookCredentialsDialog));
   });
@@ -117,6 +124,12 @@ function renderDialog(): { container: HTMLElement; unmount: () => void } {
     unmount: () => {
       act(() => root.unmount());
       document.body.removeChild(container);
+    },
+    setOpenDialog: (value: string) => {
+      mockUseSelector.mockReturnValue(value);
+      act(() => {
+        root.render(React.createElement(OutlookCredentialsDialog));
+      });
     },
   };
 }
@@ -132,6 +145,7 @@ function getPasswordInput(container: HTMLElement): HTMLInputElement {
 describe('OutlookCredentialsDialog — secure keyboard entry', () => {
   afterEach(() => {
     jest.clearAllMocks();
+    mockUseSelector.mockReturnValue('outlook-credentials');
     Object.defineProperty(process, 'platform', { value: originalPlatform });
   });
 
@@ -222,6 +236,52 @@ describe('OutlookCredentialsDialog — secure keyboard entry', () => {
       expect(removeSpy).toHaveBeenCalledWith('focus', expect.any(Function));
       removeSpy.mockRestore();
     });
+
+    it('calls secure-keyboard-entry/set false on unmount when password was focused', () => {
+      const { container, unmount } = renderDialog();
+      act(() => {
+        Simulate.focus(getPasswordInput(container));
+      });
+      mockInvoke.mockClear();
+      unmount();
+      expect(mockInvoke).toHaveBeenCalledWith(
+        'secure-keyboard-entry/set',
+        false
+      );
+    });
+
+    it('does NOT call secure-keyboard-entry/set false on unmount when password was never focused', () => {
+      const { unmount } = renderDialog();
+      unmount();
+      expect(mockInvoke).not.toHaveBeenCalledWith(
+        'secure-keyboard-entry/set',
+        false
+      );
+    });
+
+    it('calls secure-keyboard-entry/set false when dialog closes via state change (isVisible flips false)', () => {
+      const { container, setOpenDialog, unmount } = renderDialog();
+      act(() => {
+        Simulate.focus(getPasswordInput(container));
+      });
+      mockInvoke.mockClear();
+      setOpenDialog('some-other-dialog');
+      expect(mockInvoke).toHaveBeenCalledWith(
+        'secure-keyboard-entry/set',
+        false
+      );
+      unmount();
+    });
+
+    it('does NOT call secure-keyboard-entry/set false on dialog close when password was never focused', () => {
+      const { setOpenDialog, unmount } = renderDialog();
+      setOpenDialog('some-other-dialog');
+      expect(mockInvoke).not.toHaveBeenCalledWith(
+        'secure-keyboard-entry/set',
+        false
+      );
+      unmount();
+    });
   });
 
   describe('on linux', () => {
@@ -246,6 +306,27 @@ describe('OutlookCredentialsDialog — secure keyboard entry', () => {
       expect(mockInvoke).not.toHaveBeenCalled();
       unmount();
     });
+
+    it('does not call secure-keyboard-entry/set on unmount', () => {
+      const { container, unmount } = renderDialog();
+      act(() => {
+        Simulate.focus(getPasswordInput(container));
+      });
+      mockInvoke.mockClear();
+      unmount();
+      expect(mockInvoke).not.toHaveBeenCalled();
+    });
+
+    it('does not call secure-keyboard-entry/set on dialog close via state change', () => {
+      const { container, setOpenDialog, unmount } = renderDialog();
+      act(() => {
+        Simulate.focus(getPasswordInput(container));
+      });
+      mockInvoke.mockClear();
+      setOpenDialog('some-other-dialog');
+      expect(mockInvoke).not.toHaveBeenCalled();
+      unmount();
+    });
   });
 
   describe('on win32', () => {
@@ -258,6 +339,27 @@ describe('OutlookCredentialsDialog — secure keyboard entry', () => {
       act(() => {
         Simulate.focus(getPasswordInput(container));
       });
+      expect(mockInvoke).not.toHaveBeenCalled();
+      unmount();
+    });
+
+    it('does not call secure-keyboard-entry/set on unmount', () => {
+      const { container, unmount } = renderDialog();
+      act(() => {
+        Simulate.focus(getPasswordInput(container));
+      });
+      mockInvoke.mockClear();
+      unmount();
+      expect(mockInvoke).not.toHaveBeenCalled();
+    });
+
+    it('does not call secure-keyboard-entry/set on dialog close via state change', () => {
+      const { container, setOpenDialog, unmount } = renderDialog();
+      act(() => {
+        Simulate.focus(getPasswordInput(container));
+      });
+      mockInvoke.mockClear();
+      setOpenDialog('some-other-dialog');
       expect(mockInvoke).not.toHaveBeenCalled();
       unmount();
     });

--- a/src/ui/components/OutlookCredentialsDialog/index.spec.tsx
+++ b/src/ui/components/OutlookCredentialsDialog/index.spec.tsx
@@ -1,0 +1,265 @@
+/**
+ * Renderer spec for OutlookCredentialsDialog secure keyboard entry behaviour.
+ * Uses react-dom/client + act — no @testing-library/react required.
+ */
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { Simulate } from 'react-dom/test-utils';
+
+import { OutlookCredentialsDialog } from './index';
+
+const mockInvoke = jest.fn();
+
+jest.mock('../../../ipc/renderer', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+jest.mock('@rocket.chat/fuselage', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const React = require('react');
+  return {
+    Box: ({
+      children,
+      ...p
+    }: React.PropsWithChildren<Record<string, unknown>>) =>
+      React.createElement('div', p, children),
+    Button: ({
+      children,
+      ...p
+    }: React.PropsWithChildren<Record<string, unknown>>) =>
+      React.createElement('button', p, children),
+    ButtonGroup: ({ children }: React.PropsWithChildren) =>
+      React.createElement('div', null, children),
+    Callout: ({ children }: React.PropsWithChildren) =>
+      React.createElement('div', null, children),
+    CheckBox: React.forwardRef(
+      (p: Record<string, unknown>, ref: React.Ref<HTMLInputElement>) =>
+        React.createElement('input', { type: 'checkbox', ref, ...p })
+    ),
+    Field: ({ children }: React.PropsWithChildren) =>
+      React.createElement('div', null, children),
+    FieldError: ({ children }: React.PropsWithChildren) =>
+      React.createElement('span', null, children),
+    FieldGroup: ({ children }: React.PropsWithChildren) =>
+      React.createElement('div', null, children),
+    FieldLabel: ({
+      children,
+      ...p
+    }: React.PropsWithChildren<Record<string, unknown>>) =>
+      React.createElement('label', p, children),
+    FieldRow: ({ children }: React.PropsWithChildren) =>
+      React.createElement('div', null, children),
+    Label: ({ children }: React.PropsWithChildren) =>
+      React.createElement('label', null, children),
+    Margins: ({ children }: React.PropsWithChildren) =>
+      React.createElement('div', null, children),
+    PasswordInput: React.forwardRef(
+      (
+        { onFocus, onBlur, ...p }: React.InputHTMLAttributes<HTMLInputElement>,
+        ref: React.Ref<HTMLInputElement>
+      ) =>
+        React.createElement('input', {
+          'type': 'password',
+          'data-testid': 'password-input',
+          ref,
+          onFocus,
+          onBlur,
+          ...p,
+        })
+    ),
+    TextInput: React.forwardRef(
+      (
+        p: React.InputHTMLAttributes<HTMLInputElement>,
+        ref: React.Ref<HTMLInputElement>
+      ) => React.createElement('input', { ref, ...p })
+    ),
+  };
+});
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(() => 'outlook-credentials'),
+  useDispatch: jest.fn(() => jest.fn()),
+}));
+
+jest.mock('../../../store', () => ({
+  listen: jest.fn(() => jest.fn()),
+}));
+
+jest.mock('../Dialog', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const React = require('react');
+  return {
+    Dialog: ({
+      children,
+      isVisible,
+    }: React.PropsWithChildren<{ isVisible: boolean }>) =>
+      isVisible
+        ? React.createElement('div', { 'data-testid': 'dialog' }, children)
+        : null,
+  };
+});
+
+const originalPlatform = process.platform;
+
+function renderDialog(): { container: HTMLElement; unmount: () => void } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(React.createElement(OutlookCredentialsDialog));
+  });
+  return {
+    container,
+    unmount: () => {
+      act(() => root.unmount());
+      document.body.removeChild(container);
+    },
+  };
+}
+
+function getPasswordInput(container: HTMLElement): HTMLInputElement {
+  const el = container.querySelector<HTMLInputElement>(
+    '[data-testid="password-input"]'
+  );
+  if (!el) throw new Error('password input not found');
+  return el;
+}
+
+describe('OutlookCredentialsDialog — secure keyboard entry', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  describe('on darwin', () => {
+    beforeEach(() => {
+      Object.defineProperty(process, 'platform', { value: 'darwin' });
+    });
+
+    it('calls secure-keyboard-entry/set true when password field is focused', () => {
+      const { container, unmount } = renderDialog();
+      act(() => {
+        Simulate.focus(getPasswordInput(container));
+      });
+      expect(mockInvoke).toHaveBeenCalledWith(
+        'secure-keyboard-entry/set',
+        true
+      );
+      unmount();
+    });
+
+    it('calls secure-keyboard-entry/set false when password field is blurred', () => {
+      const { container, unmount } = renderDialog();
+      act(() => {
+        Simulate.focus(getPasswordInput(container));
+      });
+      mockInvoke.mockClear();
+      act(() => {
+        Simulate.blur(getPasswordInput(container));
+      });
+      expect(mockInvoke).toHaveBeenCalledWith(
+        'secure-keyboard-entry/set',
+        false
+      );
+      unmount();
+    });
+
+    it('re-enables secure keyboard entry on window focus when password field is active', () => {
+      const { container, unmount } = renderDialog();
+      act(() => {
+        Simulate.focus(getPasswordInput(container));
+      });
+      mockInvoke.mockClear();
+
+      // Simulate OS window regaining focus without DOM focus/blur on the input
+      act(() => {
+        window.dispatchEvent(new Event('focus'));
+      });
+
+      expect(mockInvoke).toHaveBeenCalledWith(
+        'secure-keyboard-entry/set',
+        true
+      );
+      unmount();
+    });
+
+    it('does NOT re-enable secure keyboard entry on window focus when password field was never focused', () => {
+      const { unmount } = renderDialog();
+      act(() => {
+        window.dispatchEvent(new Event('focus'));
+      });
+      expect(mockInvoke).not.toHaveBeenCalledWith(
+        'secure-keyboard-entry/set',
+        true
+      );
+      unmount();
+    });
+
+    it('does NOT re-enable secure keyboard entry on window focus after password field was blurred', () => {
+      const { container, unmount } = renderDialog();
+      act(() => {
+        Simulate.focus(getPasswordInput(container));
+        Simulate.blur(getPasswordInput(container));
+      });
+      mockInvoke.mockClear();
+
+      act(() => {
+        window.dispatchEvent(new Event('focus'));
+      });
+
+      expect(mockInvoke).not.toHaveBeenCalled();
+      unmount();
+    });
+
+    it('removes the window focus listener on unmount', () => {
+      const removeSpy = jest.spyOn(window, 'removeEventListener');
+      const { unmount } = renderDialog();
+      unmount();
+      expect(removeSpy).toHaveBeenCalledWith('focus', expect.any(Function));
+      removeSpy.mockRestore();
+    });
+  });
+
+  describe('on linux', () => {
+    beforeEach(() => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+    });
+
+    it('does not call secure-keyboard-entry/set on password focus', () => {
+      const { container, unmount } = renderDialog();
+      act(() => {
+        Simulate.focus(getPasswordInput(container));
+      });
+      expect(mockInvoke).not.toHaveBeenCalled();
+      unmount();
+    });
+
+    it('does not call secure-keyboard-entry/set on window focus', () => {
+      const { unmount } = renderDialog();
+      act(() => {
+        window.dispatchEvent(new Event('focus'));
+      });
+      expect(mockInvoke).not.toHaveBeenCalled();
+      unmount();
+    });
+  });
+
+  describe('on win32', () => {
+    beforeEach(() => {
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+    });
+
+    it('does not call secure-keyboard-entry/set on password focus', () => {
+      const { container, unmount } = renderDialog();
+      act(() => {
+        Simulate.focus(getPasswordInput(container));
+      });
+      expect(mockInvoke).not.toHaveBeenCalled();
+      unmount();
+    });
+  });
+});

--- a/src/ui/components/OutlookCredentialsDialog/index.tsx
+++ b/src/ui/components/OutlookCredentialsDialog/index.tsx
@@ -21,6 +21,7 @@ import { useTranslation } from 'react-i18next';
 import { useSelector, useDispatch } from 'react-redux';
 import type { Dispatch } from 'redux';
 
+import { invoke } from '../../../ipc/renderer';
 import {
   OUTLOOK_CALENDAR_ASK_CREDENTIALS,
   OUTLOOK_CALENDAR_DIALOG_DISMISSED,
@@ -153,7 +154,11 @@ export const OutlookCredentialsDialog = () => {
           <Field>
             <Label>{t('Password')}</Label>
             <FieldRow>
-              <PasswordInput {...register('password', { required: true })} />
+              <PasswordInput
+                {...register('password', { required: true })}
+                onFocus={() => invoke('secure-keyboard-entry/set', true)}
+                onBlur={() => invoke('secure-keyboard-entry/set', false)}
+              />
             </FieldRow>
             {errors.password && (
               <FieldError>

--- a/src/ui/components/OutlookCredentialsDialog/index.tsx
+++ b/src/ui/components/OutlookCredentialsDialog/index.tsx
@@ -156,8 +156,14 @@ export const OutlookCredentialsDialog = () => {
             <FieldRow>
               <PasswordInput
                 {...register('password', { required: true })}
-                onFocus={() => invoke('secure-keyboard-entry/set', true)}
-                onBlur={() => invoke('secure-keyboard-entry/set', false)}
+                onFocus={() =>
+                  process.platform === 'darwin' &&
+                  invoke('secure-keyboard-entry/set', true)
+                }
+                onBlur={() =>
+                  process.platform === 'darwin' &&
+                  invoke('secure-keyboard-entry/set', false)
+                }
               />
             </FieldRow>
             {errors.password && (

--- a/src/ui/components/OutlookCredentialsDialog/index.tsx
+++ b/src/ui/components/OutlookCredentialsDialog/index.tsx
@@ -197,17 +197,19 @@ export const OutlookCredentialsDialog = () => {
             <Label>{t('Password')}</Label>
             <FieldRow>
               <PasswordInput
-                {...register('password', { required: true })}
+                {...register('password', {
+                  required: true,
+                  onBlur: () => {
+                    if (process.platform === 'darwin') {
+                      passwordFieldActiveRef.current = false;
+                      invoke('secure-keyboard-entry/set', false);
+                    }
+                  },
+                })}
                 onFocus={() => {
                   if (process.platform === 'darwin') {
                     passwordFieldActiveRef.current = true;
                     invoke('secure-keyboard-entry/set', true);
-                  }
-                }}
-                onBlur={() => {
-                  if (process.platform === 'darwin') {
-                    passwordFieldActiveRef.current = false;
-                    invoke('secure-keyboard-entry/set', false);
                   }
                 }}
               />

--- a/src/ui/components/OutlookCredentialsDialog/index.tsx
+++ b/src/ui/components/OutlookCredentialsDialog/index.tsx
@@ -104,6 +104,32 @@ export const OutlookCredentialsDialog = () => {
   }, [isVisible]);
 
   useEffect(() => {
+    if (isVisible) {
+      return;
+    }
+    if (process.platform !== 'darwin') {
+      return;
+    }
+    if (passwordFieldActiveRef.current) {
+      passwordFieldActiveRef.current = false;
+      invoke('secure-keyboard-entry/set', false);
+    }
+  }, [isVisible]);
+
+  useEffect(
+    () => () => {
+      if (process.platform !== 'darwin') {
+        return;
+      }
+      if (passwordFieldActiveRef.current) {
+        passwordFieldActiveRef.current = false;
+        invoke('secure-keyboard-entry/set', false);
+      }
+    },
+    []
+  );
+
+  useEffect(() => {
     if (process.platform !== 'darwin') {
       return undefined;
     }

--- a/src/ui/components/OutlookCredentialsDialog/index.tsx
+++ b/src/ui/components/OutlookCredentialsDialog/index.tsx
@@ -47,6 +47,7 @@ export const OutlookCredentialsDialog = () => {
   const dispatch = useDispatch<Dispatch<RootAction>>();
 
   const requestIdRef = useRef<unknown>();
+  const passwordFieldActiveRef = useRef(false);
 
   const [server, setServer] = useState<Server | undefined>();
   const [userId, setUserId] = useState<string>('');
@@ -102,6 +103,21 @@ export const OutlookCredentialsDialog = () => {
     window.focus();
   }, [isVisible]);
 
+  useEffect(() => {
+    if (process.platform !== 'darwin') {
+      return undefined;
+    }
+
+    const handleWindowFocus = (): void => {
+      if (passwordFieldActiveRef.current) {
+        invoke('secure-keyboard-entry/set', true);
+      }
+    };
+
+    window.addEventListener('focus', handleWindowFocus);
+    return () => window.removeEventListener('focus', handleWindowFocus);
+  }, []);
+
   const handleAuth = async ({
     login,
     password,
@@ -156,14 +172,18 @@ export const OutlookCredentialsDialog = () => {
             <FieldRow>
               <PasswordInput
                 {...register('password', { required: true })}
-                onFocus={() =>
-                  process.platform === 'darwin' &&
-                  invoke('secure-keyboard-entry/set', true)
-                }
-                onBlur={() =>
-                  process.platform === 'darwin' &&
-                  invoke('secure-keyboard-entry/set', false)
-                }
+                onFocus={() => {
+                  if (process.platform === 'darwin') {
+                    passwordFieldActiveRef.current = true;
+                    invoke('secure-keyboard-entry/set', true);
+                  }
+                }}
+                onBlur={() => {
+                  if (process.platform === 'darwin') {
+                    passwordFieldActiveRef.current = false;
+                    invoke('secure-keyboard-entry/set', false);
+                  }
+                }}
               />
             </FieldRow>
             {errors.password && (

--- a/src/ui/components/OutlookCredentialsDialog/secureKeyboardEntry.spec.tsx
+++ b/src/ui/components/OutlookCredentialsDialog/secureKeyboardEntry.spec.tsx
@@ -80,8 +80,10 @@ jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (k: string) => k }),
 }));
 
+const mockUseSelector = jest.fn<string, []>(() => 'outlook-credentials');
+
 jest.mock('react-redux', () => ({
-  useSelector: jest.fn(() => 'outlook-credentials'),
+  useSelector: (_selector: unknown) => mockUseSelector(),
   useDispatch: jest.fn(() => jest.fn()),
 }));
 
@@ -105,10 +107,15 @@ jest.mock('../Dialog', () => {
 
 const originalPlatform = process.platform;
 
-function renderDialog(): { container: HTMLElement; unmount: () => void } {
+function renderDialog(openDialog = 'outlook-credentials'): {
+  container: HTMLElement;
+  unmount: () => void;
+  setOpenDialog: (value: string) => void;
+} {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root = createRoot(container);
+  mockUseSelector.mockReturnValue(openDialog);
   act(() => {
     root.render(React.createElement(OutlookCredentialsDialog));
   });
@@ -117,6 +124,12 @@ function renderDialog(): { container: HTMLElement; unmount: () => void } {
     unmount: () => {
       act(() => root.unmount());
       document.body.removeChild(container);
+    },
+    setOpenDialog: (value: string) => {
+      mockUseSelector.mockReturnValue(value);
+      act(() => {
+        root.render(React.createElement(OutlookCredentialsDialog));
+      });
     },
   };
 }
@@ -132,6 +145,7 @@ function getPasswordInput(container: HTMLElement): HTMLInputElement {
 describe('OutlookCredentialsDialog — secure keyboard entry', () => {
   afterEach(() => {
     jest.clearAllMocks();
+    mockUseSelector.mockReturnValue('outlook-credentials');
     Object.defineProperty(process, 'platform', { value: originalPlatform });
   });
 
@@ -222,6 +236,52 @@ describe('OutlookCredentialsDialog — secure keyboard entry', () => {
       expect(removeSpy).toHaveBeenCalledWith('focus', expect.any(Function));
       removeSpy.mockRestore();
     });
+
+    it('calls secure-keyboard-entry/set false on unmount when password was focused', () => {
+      const { container, unmount } = renderDialog();
+      act(() => {
+        Simulate.focus(getPasswordInput(container));
+      });
+      mockInvoke.mockClear();
+      unmount();
+      expect(mockInvoke).toHaveBeenCalledWith(
+        'secure-keyboard-entry/set',
+        false
+      );
+    });
+
+    it('does NOT call secure-keyboard-entry/set false on unmount when password was never focused', () => {
+      const { unmount } = renderDialog();
+      unmount();
+      expect(mockInvoke).not.toHaveBeenCalledWith(
+        'secure-keyboard-entry/set',
+        false
+      );
+    });
+
+    it('calls secure-keyboard-entry/set false when dialog closes via state change (isVisible flips false)', () => {
+      const { container, setOpenDialog, unmount } = renderDialog();
+      act(() => {
+        Simulate.focus(getPasswordInput(container));
+      });
+      mockInvoke.mockClear();
+      setOpenDialog('some-other-dialog');
+      expect(mockInvoke).toHaveBeenCalledWith(
+        'secure-keyboard-entry/set',
+        false
+      );
+      unmount();
+    });
+
+    it('does NOT call secure-keyboard-entry/set false on dialog close when password was never focused', () => {
+      const { setOpenDialog, unmount } = renderDialog();
+      setOpenDialog('some-other-dialog');
+      expect(mockInvoke).not.toHaveBeenCalledWith(
+        'secure-keyboard-entry/set',
+        false
+      );
+      unmount();
+    });
   });
 
   describe('on linux', () => {
@@ -243,6 +303,27 @@ describe('OutlookCredentialsDialog — secure keyboard entry', () => {
       act(() => {
         window.dispatchEvent(new Event('focus'));
       });
+      expect(mockInvoke).not.toHaveBeenCalled();
+      unmount();
+    });
+
+    it('does not call secure-keyboard-entry/set on unmount', () => {
+      const { container, unmount } = renderDialog();
+      act(() => {
+        Simulate.focus(getPasswordInput(container));
+      });
+      mockInvoke.mockClear();
+      unmount();
+      expect(mockInvoke).not.toHaveBeenCalled();
+    });
+
+    it('does not call secure-keyboard-entry/set on dialog close via state change', () => {
+      const { container, setOpenDialog, unmount } = renderDialog();
+      act(() => {
+        Simulate.focus(getPasswordInput(container));
+      });
+      mockInvoke.mockClear();
+      setOpenDialog('some-other-dialog');
       expect(mockInvoke).not.toHaveBeenCalled();
       unmount();
     });

--- a/src/ui/components/OutlookCredentialsDialog/secureKeyboardEntry.spec.tsx
+++ b/src/ui/components/OutlookCredentialsDialog/secureKeyboardEntry.spec.tsx
@@ -1,0 +1,265 @@
+/**
+ * Renderer spec for OutlookCredentialsDialog secure keyboard entry behaviour.
+ * Uses react-dom/client + act — no @testing-library/react required.
+ */
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { Simulate } from 'react-dom/test-utils';
+
+import { OutlookCredentialsDialog } from './index';
+
+const mockInvoke = jest.fn();
+
+jest.mock('../../../ipc/renderer', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+jest.mock('@rocket.chat/fuselage', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const React = require('react');
+  return {
+    Box: ({
+      children,
+      ...p
+    }: React.PropsWithChildren<Record<string, unknown>>) =>
+      React.createElement('div', p, children),
+    Button: ({
+      children,
+      ...p
+    }: React.PropsWithChildren<Record<string, unknown>>) =>
+      React.createElement('button', p, children),
+    ButtonGroup: ({ children }: React.PropsWithChildren) =>
+      React.createElement('div', null, children),
+    Callout: ({ children }: React.PropsWithChildren) =>
+      React.createElement('div', null, children),
+    CheckBox: React.forwardRef(
+      (p: Record<string, unknown>, ref: React.Ref<HTMLInputElement>) =>
+        React.createElement('input', { type: 'checkbox', ref, ...p })
+    ),
+    Field: ({ children }: React.PropsWithChildren) =>
+      React.createElement('div', null, children),
+    FieldError: ({ children }: React.PropsWithChildren) =>
+      React.createElement('span', null, children),
+    FieldGroup: ({ children }: React.PropsWithChildren) =>
+      React.createElement('div', null, children),
+    FieldLabel: ({
+      children,
+      ...p
+    }: React.PropsWithChildren<Record<string, unknown>>) =>
+      React.createElement('label', p, children),
+    FieldRow: ({ children }: React.PropsWithChildren) =>
+      React.createElement('div', null, children),
+    Label: ({ children }: React.PropsWithChildren) =>
+      React.createElement('label', null, children),
+    Margins: ({ children }: React.PropsWithChildren) =>
+      React.createElement('div', null, children),
+    PasswordInput: React.forwardRef(
+      (
+        { onFocus, onBlur, ...p }: React.InputHTMLAttributes<HTMLInputElement>,
+        ref: React.Ref<HTMLInputElement>
+      ) =>
+        React.createElement('input', {
+          'type': 'password',
+          'data-testid': 'password-input',
+          ref,
+          onFocus,
+          onBlur,
+          ...p,
+        })
+    ),
+    TextInput: React.forwardRef(
+      (
+        p: React.InputHTMLAttributes<HTMLInputElement>,
+        ref: React.Ref<HTMLInputElement>
+      ) => React.createElement('input', { ref, ...p })
+    ),
+  };
+});
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(() => 'outlook-credentials'),
+  useDispatch: jest.fn(() => jest.fn()),
+}));
+
+jest.mock('../../../store', () => ({
+  listen: jest.fn(() => jest.fn()),
+}));
+
+jest.mock('../Dialog', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const React = require('react');
+  return {
+    Dialog: ({
+      children,
+      isVisible,
+    }: React.PropsWithChildren<{ isVisible: boolean }>) =>
+      isVisible
+        ? React.createElement('div', { 'data-testid': 'dialog' }, children)
+        : null,
+  };
+});
+
+const originalPlatform = process.platform;
+
+function renderDialog(): { container: HTMLElement; unmount: () => void } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(React.createElement(OutlookCredentialsDialog));
+  });
+  return {
+    container,
+    unmount: () => {
+      act(() => root.unmount());
+      document.body.removeChild(container);
+    },
+  };
+}
+
+function getPasswordInput(container: HTMLElement): HTMLInputElement {
+  const el = container.querySelector<HTMLInputElement>(
+    '[data-testid="password-input"]'
+  );
+  if (!el) throw new Error('password input not found');
+  return el;
+}
+
+describe('OutlookCredentialsDialog — secure keyboard entry', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  describe('on darwin', () => {
+    beforeEach(() => {
+      Object.defineProperty(process, 'platform', { value: 'darwin' });
+    });
+
+    it('calls secure-keyboard-entry/set true when password field is focused', () => {
+      const { container, unmount } = renderDialog();
+      act(() => {
+        Simulate.focus(getPasswordInput(container));
+      });
+      expect(mockInvoke).toHaveBeenCalledWith(
+        'secure-keyboard-entry/set',
+        true
+      );
+      unmount();
+    });
+
+    it('calls secure-keyboard-entry/set false when password field is blurred', () => {
+      const { container, unmount } = renderDialog();
+      act(() => {
+        Simulate.focus(getPasswordInput(container));
+      });
+      mockInvoke.mockClear();
+      act(() => {
+        Simulate.blur(getPasswordInput(container));
+      });
+      expect(mockInvoke).toHaveBeenCalledWith(
+        'secure-keyboard-entry/set',
+        false
+      );
+      unmount();
+    });
+
+    it('re-enables secure keyboard entry on window focus when password field is active', () => {
+      const { container, unmount } = renderDialog();
+      act(() => {
+        Simulate.focus(getPasswordInput(container));
+      });
+      mockInvoke.mockClear();
+
+      // Simulate OS window regaining focus without DOM focus/blur on the input
+      act(() => {
+        window.dispatchEvent(new Event('focus'));
+      });
+
+      expect(mockInvoke).toHaveBeenCalledWith(
+        'secure-keyboard-entry/set',
+        true
+      );
+      unmount();
+    });
+
+    it('does NOT re-enable secure keyboard entry on window focus when password field was never focused', () => {
+      const { unmount } = renderDialog();
+      act(() => {
+        window.dispatchEvent(new Event('focus'));
+      });
+      expect(mockInvoke).not.toHaveBeenCalledWith(
+        'secure-keyboard-entry/set',
+        true
+      );
+      unmount();
+    });
+
+    it('does NOT re-enable secure keyboard entry on window focus after password field was blurred', () => {
+      const { container, unmount } = renderDialog();
+      act(() => {
+        Simulate.focus(getPasswordInput(container));
+        Simulate.blur(getPasswordInput(container));
+      });
+      mockInvoke.mockClear();
+
+      act(() => {
+        window.dispatchEvent(new Event('focus'));
+      });
+
+      expect(mockInvoke).not.toHaveBeenCalled();
+      unmount();
+    });
+
+    it('removes the window focus listener on unmount', () => {
+      const removeSpy = jest.spyOn(window, 'removeEventListener');
+      const { unmount } = renderDialog();
+      unmount();
+      expect(removeSpy).toHaveBeenCalledWith('focus', expect.any(Function));
+      removeSpy.mockRestore();
+    });
+  });
+
+  describe('on linux', () => {
+    beforeEach(() => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+    });
+
+    it('does not call secure-keyboard-entry/set on password focus', () => {
+      const { container, unmount } = renderDialog();
+      act(() => {
+        Simulate.focus(getPasswordInput(container));
+      });
+      expect(mockInvoke).not.toHaveBeenCalled();
+      unmount();
+    });
+
+    it('does not call secure-keyboard-entry/set on window focus', () => {
+      const { unmount } = renderDialog();
+      act(() => {
+        window.dispatchEvent(new Event('focus'));
+      });
+      expect(mockInvoke).not.toHaveBeenCalled();
+      unmount();
+    });
+  });
+
+  describe('on win32', () => {
+    beforeEach(() => {
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+    });
+
+    it('does not call secure-keyboard-entry/set on password focus', () => {
+      const { container, unmount } = renderDialog();
+      act(() => {
+        Simulate.focus(getPasswordInput(container));
+      });
+      expect(mockInvoke).not.toHaveBeenCalled();
+      unmount();
+    });
+  });
+});

--- a/src/ui/main/rootWindow.spec.ts
+++ b/src/ui/main/rootWindow.spec.ts
@@ -6,6 +6,7 @@ jest.mock('electron', () => ({
     quit: jest.fn(),
     addListener: jest.fn(),
     name: 'Test App',
+    setSecureKeyboardEntryEnabled: jest.fn(),
   },
   BrowserWindow: jest.fn(),
   nativeImage: {
@@ -36,6 +37,10 @@ jest.mock('../../app/main/dev', () => ({
 
 jest.mock('./icons', () => ({
   getTrayIconPath: jest.fn(),
+}));
+
+jest.mock('./secureKeyboardEntry', () => ({
+  setupSecureKeyboardEntry: jest.fn(() => () => undefined),
 }));
 
 describe('rootWindow close event handler', () => {

--- a/src/ui/main/rootWindow.spec.ts
+++ b/src/ui/main/rootWindow.spec.ts
@@ -41,7 +41,7 @@ jest.mock('./icons', () => ({
 }));
 
 jest.mock('./secureKeyboardEntry', () => ({
-  setupSecureKeyboardEntry: jest.fn(() => () => undefined),
+  setupSecureKeyboardEntry: jest.fn(() => jest.fn()),
 }));
 
 describe('rootWindow close event handler', () => {

--- a/src/ui/main/rootWindow.spec.ts
+++ b/src/ui/main/rootWindow.spec.ts
@@ -6,6 +6,7 @@ jest.mock('electron', () => ({
     quit: jest.fn(),
     addListener: jest.fn(),
     name: 'Test App',
+    setSecureKeyboardEntryEnabled: jest.fn(),
   },
   BrowserWindow: jest.fn(),
   nativeImage: {
@@ -37,6 +38,10 @@ jest.mock('../../app/main/dev', () => ({
 
 jest.mock('./icons', () => ({
   getTrayIconPath: jest.fn(),
+}));
+
+jest.mock('./secureKeyboardEntry', () => ({
+  setupSecureKeyboardEntry: jest.fn(() => () => undefined),
 }));
 
 describe('rootWindow close event handler', () => {

--- a/src/ui/main/rootWindow.ts
+++ b/src/ui/main/rootWindow.ts
@@ -30,6 +30,7 @@ import type { WindowState } from '../common';
 import { selectGlobalBadge, selectGlobalBadgeCount } from '../selectors';
 import { debounce } from './debounce';
 import { getTrayIconPath } from './icons';
+import { setupSecureKeyboardEntry } from './secureKeyboardEntry';
 
 const webPreferences: WebPreferences = {
   nodeIntegration: true,
@@ -248,6 +249,8 @@ export const setupRootWindow = (): void => {
     }
   };
 
+  const removeSecureKeyboardHandler = setupSecureKeyboardEntry();
+
   const unsubscribers = [
     watch(selectGlobalBadgeCount, async (globalBadgeCount) => {
       await safeWindowOperation(async (browserWindow) => {
@@ -342,7 +345,17 @@ export const setupRootWindow = (): void => {
       rootWindow.flashFrame(false);
     });
 
+    if (process.platform === 'darwin') {
+      rootWindow.addListener('blur', () => {
+        app.setSecureKeyboardEntryEnabled(false);
+      });
+    }
+
     rootWindow.addListener('close', async (event) => {
+      if (process.platform === 'darwin') {
+        app.setSecureKeyboardEntryEnabled(false);
+      }
+
       try {
         if (rootWindow.isDestroyed()) {
           return;
@@ -515,6 +528,7 @@ export const setupRootWindow = (): void => {
   }
 
   app.addListener('before-quit', () => {
+    removeSecureKeyboardHandler();
     unsubscribers.forEach((unsubscriber) => {
       try {
         unsubscriber();

--- a/src/ui/main/rootWindow.ts
+++ b/src/ui/main/rootWindow.ts
@@ -30,6 +30,7 @@ import type { WindowState } from '../common';
 import { selectGlobalBadge, selectGlobalBadgeCount } from '../selectors';
 import { debounce } from './debounce';
 import { getTrayIconPath } from './icons';
+import { setupSecureKeyboardEntry } from './secureKeyboardEntry';
 
 const webPreferences: WebPreferences = {
   nodeIntegration: true,
@@ -256,6 +257,8 @@ export const setupRootWindow = (): void => {
     }
   };
 
+  const removeSecureKeyboardHandler = setupSecureKeyboardEntry();
+
   const unsubscribers = [
     watch(selectGlobalBadgeCount, async (globalBadgeCount) => {
       await safeWindowOperation(async (browserWindow) => {
@@ -350,7 +353,17 @@ export const setupRootWindow = (): void => {
       rootWindow.flashFrame(false);
     });
 
+    if (process.platform === 'darwin') {
+      rootWindow.addListener('blur', () => {
+        app.setSecureKeyboardEntryEnabled(false);
+      });
+    }
+
     rootWindow.addListener('close', async (event) => {
+      if (process.platform === 'darwin') {
+        app.setSecureKeyboardEntryEnabled(false);
+      }
+
       try {
         if (rootWindow.isDestroyed()) {
           return;
@@ -523,6 +536,7 @@ export const setupRootWindow = (): void => {
   }
 
   app.addListener('before-quit', () => {
+    removeSecureKeyboardHandler();
     unsubscribers.forEach((unsubscriber) => {
       try {
         unsubscriber();

--- a/src/ui/main/secureKeyboardEntry.main.spec.ts
+++ b/src/ui/main/secureKeyboardEntry.main.spec.ts
@@ -1,0 +1,96 @@
+import { app, ipcMain } from 'electron';
+
+import { setupSecureKeyboardEntry } from './secureKeyboardEntry';
+
+jest.mock('electron', () => ({
+  app: {
+    setSecureKeyboardEntryEnabled: jest.fn(),
+  },
+  ipcMain: {
+    handle: jest.fn(),
+    removeHandler: jest.fn(),
+  },
+}));
+
+describe('setupSecureKeyboardEntry', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  describe('on darwin', () => {
+    beforeEach(() => {
+      Object.defineProperty(process, 'platform', { value: 'darwin' });
+    });
+
+    it('registers the secure-keyboard-entry/set IPC handler', () => {
+      setupSecureKeyboardEntry();
+      expect(ipcMain.handle).toHaveBeenCalledWith(
+        'secure-keyboard-entry/set',
+        expect.any(Function)
+      );
+    });
+
+    it('calls app.setSecureKeyboardEntryEnabled(true) when handler invoked with true', async () => {
+      setupSecureKeyboardEntry();
+      const handler = (ipcMain.handle as jest.Mock).mock.calls[0][1];
+      await handler({ sender: {} }, true);
+      expect(app.setSecureKeyboardEntryEnabled).toHaveBeenCalledWith(true);
+    });
+
+    it('calls app.setSecureKeyboardEntryEnabled(false) when handler invoked with false', async () => {
+      setupSecureKeyboardEntry();
+      const handler = (ipcMain.handle as jest.Mock).mock.calls[0][1];
+      await handler({ sender: {} }, false);
+      expect(app.setSecureKeyboardEntryEnabled).toHaveBeenCalledWith(false);
+    });
+
+    it('returns a cleanup function that removes the IPC handler', () => {
+      const remove = setupSecureKeyboardEntry();
+      remove();
+      expect(ipcMain.removeHandler).toHaveBeenCalledWith(
+        'secure-keyboard-entry/set'
+      );
+    });
+  });
+
+  describe('on linux', () => {
+    beforeEach(() => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+    });
+
+    it('does not register any IPC handler', () => {
+      setupSecureKeyboardEntry();
+      expect(ipcMain.handle).not.toHaveBeenCalled();
+    });
+
+    it('does not call app.setSecureKeyboardEntryEnabled', () => {
+      setupSecureKeyboardEntry();
+      expect(app.setSecureKeyboardEntryEnabled).not.toHaveBeenCalled();
+    });
+
+    it('returns a no-op cleanup function', () => {
+      const remove = setupSecureKeyboardEntry();
+      expect(() => remove()).not.toThrow();
+      expect(ipcMain.removeHandler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('on win32', () => {
+    beforeEach(() => {
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+    });
+
+    it('does not register any IPC handler', () => {
+      setupSecureKeyboardEntry();
+      expect(ipcMain.handle).not.toHaveBeenCalled();
+    });
+
+    it('does not call app.setSecureKeyboardEntryEnabled', () => {
+      setupSecureKeyboardEntry();
+      expect(app.setSecureKeyboardEntryEnabled).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/ui/main/secureKeyboardEntry.ts
+++ b/src/ui/main/secureKeyboardEntry.ts
@@ -1,0 +1,18 @@
+import { app } from 'electron';
+
+import { handle } from '../../ipc/main';
+
+export const setupSecureKeyboardEntry = (): (() => void) => {
+  if (process.platform !== 'darwin') {
+    return () => undefined;
+  }
+
+  const removeHandler = handle(
+    'secure-keyboard-entry/set',
+    async (_, enabled) => {
+      app.setSecureKeyboardEntryEnabled(enabled);
+    }
+  );
+
+  return removeHandler;
+};


### PR DESCRIPTION
## What changed

- Added `secure-keyboard-entry/set` IPC channel (`src/ipc/channels.ts`) with payload `boolean`.
- New `src/ui/main/secureKeyboardEntry.ts`: registers an `ipcMain.handle` for that channel on macOS only, calling `app.setSecureKeyboardEntryEnabled(value)`. No-op on linux/win32.
- `src/ui/main/rootWindow.ts`: wires `setupSecureKeyboardEntry()` into `setupRootWindow()`; adds a `blur` listener and a reset at the top of the `close` handler (both darwin-gated) to force secure entry off when the window loses focus or closes, preventing a stuck-on state.
- `src/ui/components/OutlookCredentialsDialog/index.tsx`: the password field's `onFocus` invokes `secure-keyboard-entry/set` with `true`; `onBlur` invokes it with `false`.

## Why

Q4-2022 security audit (CORE-1122) identified that the app does not protect credential entry with macOS Secure Keyboard Entry. Apple's guidance is to enable it only while a sensitive field is focused and disable it immediately after — leaving it globally enabled interferes with input methods and accessibility tools.

## Known limitation

Server-side login (the Rocket.Chat login form) runs inside a webview. Injecting JS into third-party webviews to hook focus/blur is out of scope for this ticket and will be addressed in a follow-up ticket.

## Test plan

- [x] `yarn lint` — passes
- [x] `npx tsc --noEmit` — clean
- [x] `yarn test --testPathPattern="secureKeyboardEntry"` — 9/9 tests pass
  - darwin: handler registered, `setSecureKeyboardEntryEnabled(true/false)` called, cleanup removes handler
  - linux: no handler registered, API not called, cleanup is no-op
  - win32: no handler registered, API not called

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added macOS secure keyboard entry support for password fields in the credentials dialog and app window lifecycle.
  * Secure keyboard entry now turns on when entering a password field and turns off when focus is lost, the dialog closes, or the app window shuts down.

* **Tests**
  * Added coverage for platform-specific behavior, including macOS, Linux, and Windows.
  * Expanded UI and main-process tests to verify focus, blur, cleanup, and window events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->