### PR TITLE
security(CORE-1129): validate ipcMain senders against allowlist

### DIFF
--- a/src/ipc/main/validateSender.spec.ts
+++ b/src/ipc/main/validateSender.spec.ts
@@ -197,6 +197,19 @@ describe('isTrustedSender — main-window', () => {
     const other = makeWebContents({ id: 99, type: 'window' });
     expect(isTrustedSender(other, allow)).toBe(false);
   });
+
+  it('rejects a server webview whose hostWebContents is the main window (CORE-1129)', () => {
+    // A malicious server webview is hosted by the main window and must NOT be
+    // allowed to impersonate the main-window sender class.
+    const serverWebview = makeWebContents({
+      id: 62,
+      type: 'webview',
+      url: 'https://chat.example.com/some/path',
+      hostWebContents: mainWindowWc,
+    });
+    mockSelect.mockReturnValue([{ url: 'https://chat.example.com/' }]);
+    expect(isTrustedSender(serverWebview, allow)).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/ipc/main/validateSender.spec.ts
+++ b/src/ipc/main/validateSender.spec.ts
@@ -235,6 +235,90 @@ describe('isTrustedSender — log-viewer-window/get-server-tag allowlist', () =>
 });
 
 // ---------------------------------------------------------------------------
+// screen-sharing-source-responded: once-vs-on listener robustness
+//
+// Verifies that an untrusted sender firing the channel does NOT consume the
+// listener, so the legitimate picker reply is still handled correctly.
+// ---------------------------------------------------------------------------
+
+describe('ipcMain.on + removeListener pattern for picker response', () => {
+  // Minimal ipcMain double that tracks listeners and lets tests fire them.
+  const makeIpcMainDouble = () => {
+    const listeners: Map<string, ((...args: unknown[]) => void)[]> = new Map();
+    return {
+      on(channel: string, fn: (...args: unknown[]) => void) {
+        const existing = listeners.get(channel) ?? [];
+        listeners.set(channel, [...existing, fn]);
+      },
+      removeListener(channel: string, fn: (...args: unknown[]) => void) {
+        const existing = listeners.get(channel) ?? [];
+        listeners.set(
+          channel,
+          existing.filter((l) => l !== fn)
+        );
+      },
+      emit(channel: string, ...args: unknown[]) {
+        const fns = listeners.get(channel) ?? [];
+        // snapshot so removeListener inside handler doesn't skip entries
+        [...fns].forEach((fn) => fn(...args));
+      },
+      listenerCount(channel: string) {
+        return (listeners.get(channel) ?? []).length;
+      },
+    };
+  };
+
+  it('untrusted sender does not consume the listener', () => {
+    const ipcDouble = makeIpcMainDouble();
+    const channel = 'video-call-window/screen-sharing-source-responded';
+
+    const received: Array<string | null> = [];
+
+    // Simulate the on+removeListener pattern from the fixed code
+    const handler = (...args: unknown[]) => {
+      const event = args[0] as { trusted: boolean };
+      const sourceId = args[1] as string | null;
+      if (!event.trusted) return; // keep listening
+      ipcDouble.removeListener(channel, handler);
+      received.push(sourceId);
+    };
+    ipcDouble.on(channel, handler);
+
+    // Untrusted sender fires first — must not consume handler
+    ipcDouble.emit(channel, { trusted: false }, null);
+    expect(ipcDouble.listenerCount(channel)).toBe(1);
+    expect(received).toHaveLength(0);
+
+    // Trusted sender fires — handler runs and self-removes
+    ipcDouble.emit(channel, { trusted: true }, 'screen:1');
+    expect(received).toEqual(['screen:1']);
+    expect(ipcDouble.listenerCount(channel)).toBe(0);
+  });
+
+  it('trusted sender consumes the listener and invokes handler exactly once', () => {
+    const ipcDouble = makeIpcMainDouble();
+    const channel = 'video-call-window/screen-sharing-source-responded';
+    const received: Array<string | null> = [];
+
+    const handler = (...args: unknown[]) => {
+      const event = args[0] as { trusted: boolean };
+      const sourceId = args[1] as string | null;
+      if (!event.trusted) return;
+      ipcDouble.removeListener(channel, handler);
+      received.push(sourceId);
+    };
+    ipcDouble.on(channel, handler);
+
+    ipcDouble.emit(channel, { trusted: true }, 'screen:2');
+    // Second trusted emit should be a no-op (listener already removed)
+    ipcDouble.emit(channel, { trusted: true }, 'screen:3');
+
+    expect(received).toEqual(['screen:2']);
+    expect(ipcDouble.listenerCount(channel)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // multi-class allow list
 // ---------------------------------------------------------------------------
 

--- a/src/ipc/main/validateSender.spec.ts
+++ b/src/ipc/main/validateSender.spec.ts
@@ -1,0 +1,201 @@
+import type { WebContents } from 'electron';
+
+import { select } from '../../store';
+import {
+  isTrustedSender,
+  registerWindowGetter,
+  type SenderClass,
+} from '../validateSender';
+
+// jest.mock is hoisted by babel-jest so the mock is in place before imports run.
+jest.mock('../../store', () => ({
+  select: jest.fn(),
+}));
+
+const mockSelect = select as jest.MockedFunction<typeof select>;
+
+const makeWebContents = (
+  overrides: Partial<{
+    id: number;
+    type: string;
+    url: string;
+    destroyed: boolean;
+    hostWebContents: WebContents | undefined;
+  }> = {}
+): WebContents => {
+  const wc = {
+    id: overrides.id ?? 1,
+    getType: jest.fn(() => overrides.type ?? 'window'),
+    getURL: jest.fn(() => overrides.url ?? 'file:///app/index.html'),
+    isDestroyed: jest.fn(() => overrides.destroyed ?? false),
+    hostWebContents: overrides.hostWebContents,
+  } as unknown as WebContents;
+  return wc;
+};
+
+beforeEach(() => {
+  jest.resetModules();
+  mockSelect.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// server-webview
+// ---------------------------------------------------------------------------
+
+describe('isTrustedSender — server-webview', () => {
+  const allow: SenderClass[] = ['server-webview'];
+
+  it('accepts a webview whose origin matches a configured server', () => {
+    const sender = makeWebContents({
+      type: 'webview',
+      url: 'https://chat.example.com/some/path',
+    });
+    mockSelect.mockReturnValue([{ url: 'https://chat.example.com/' }]);
+
+    expect(isTrustedSender(sender, allow)).toBe(true);
+  });
+
+  it('rejects a webview whose origin does not match any server', () => {
+    const sender = makeWebContents({
+      type: 'webview',
+      url: 'https://evil.example.com/',
+    });
+    mockSelect.mockReturnValue([{ url: 'https://chat.example.com/' }]);
+
+    expect(isTrustedSender(sender, allow)).toBe(false);
+  });
+
+  it('rejects a non-webview (window type) even if URL matches a server', () => {
+    const sender = makeWebContents({
+      type: 'window',
+      url: 'https://chat.example.com/',
+    });
+    mockSelect.mockReturnValue([{ url: 'https://chat.example.com/' }]);
+
+    expect(isTrustedSender(sender, allow)).toBe(false);
+  });
+
+  it('rejects when server list is empty', () => {
+    const sender = makeWebContents({
+      type: 'webview',
+      url: 'https://chat.example.com/',
+    });
+    mockSelect.mockReturnValue([]);
+
+    expect(isTrustedSender(sender, allow)).toBe(false);
+  });
+
+  it('rejects when sender URL is not a valid URL', () => {
+    const sender = makeWebContents({ type: 'webview', url: 'not-a-url' });
+    mockSelect.mockReturnValue([{ url: 'https://chat.example.com/' }]);
+
+    expect(isTrustedSender(sender, allow)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// log-viewer (local window class)
+// ---------------------------------------------------------------------------
+
+describe('isTrustedSender — log-viewer', () => {
+  const allow: SenderClass[] = ['log-viewer'];
+
+  const logViewerWc = makeWebContents({ id: 10, type: 'window' });
+
+  beforeEach(() => {
+    registerWindowGetter('log-viewer', () => logViewerWc);
+  });
+
+  it('accepts the exact log viewer WebContents', () => {
+    expect(isTrustedSender(logViewerWc, allow)).toBe(true);
+  });
+
+  it('rejects a different WebContents with the same type', () => {
+    const other = makeWebContents({ id: 99, type: 'window' });
+    expect(isTrustedSender(other, allow)).toBe(false);
+  });
+
+  it('rejects when getter returns null (window not open)', () => {
+    registerWindowGetter('log-viewer', () => null);
+    const sender = makeWebContents({ id: 10, type: 'window' });
+    expect(isTrustedSender(sender, allow)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// video-call (local window class — direct sender + hosted webview)
+// ---------------------------------------------------------------------------
+
+describe('isTrustedSender — video-call', () => {
+  const allow: SenderClass[] = ['video-call'];
+
+  const videoCallWc = makeWebContents({ id: 20, type: 'window' });
+
+  beforeEach(() => {
+    registerWindowGetter('video-call', () => videoCallWc);
+  });
+
+  it('accepts the video call window WebContents directly', () => {
+    expect(isTrustedSender(videoCallWc, allow)).toBe(true);
+  });
+
+  it('accepts a webview whose hostWebContents is the video call window', () => {
+    const hostedWebview = makeWebContents({
+      id: 21,
+      type: 'webview',
+      url: 'https://jitsi.example.com/',
+      hostWebContents: videoCallWc,
+    });
+    expect(isTrustedSender(hostedWebview, allow)).toBe(true);
+  });
+
+  it('rejects a webview hosted by a different window', () => {
+    const otherWc = makeWebContents({ id: 30, type: 'window' });
+    const hostedWebview = makeWebContents({
+      id: 31,
+      type: 'webview',
+      url: 'https://jitsi.example.com/',
+      hostWebContents: otherWc,
+    });
+    expect(isTrustedSender(hostedWebview, allow)).toBe(false);
+  });
+
+  it('rejects an unrelated sender', () => {
+    const other = makeWebContents({ id: 99, type: 'window' });
+    expect(isTrustedSender(other, allow)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// multi-class allow list
+// ---------------------------------------------------------------------------
+
+describe('isTrustedSender — multi-class allow list', () => {
+  const videoCallWc = makeWebContents({ id: 40, type: 'window' });
+
+  beforeEach(() => {
+    registerWindowGetter('video-call', () => videoCallWc);
+  });
+
+  it('accepts if any class in the allow list matches', () => {
+    const serverWebview = makeWebContents({
+      id: 50,
+      type: 'webview',
+      url: 'https://chat.example.com/',
+    });
+    mockSelect.mockReturnValue([{ url: 'https://chat.example.com/' }]);
+
+    expect(
+      isTrustedSender(serverWebview, ['video-call', 'server-webview'])
+    ).toBe(true);
+  });
+
+  it('rejects if no class in the allow list matches', () => {
+    const stranger = makeWebContents({ id: 99, type: 'window' });
+    mockSelect.mockReturnValue([]);
+
+    expect(isTrustedSender(stranger, ['video-call', 'server-webview'])).toBe(
+      false
+    );
+  });
+});

--- a/src/ipc/main/validateSender.spec.ts
+++ b/src/ipc/main/validateSender.spec.ts
@@ -167,6 +167,74 @@ describe('isTrustedSender — video-call', () => {
 });
 
 // ---------------------------------------------------------------------------
+// main-window (local window class — used by refresh-supported-versions)
+// ---------------------------------------------------------------------------
+
+describe('isTrustedSender — main-window', () => {
+  const allow: SenderClass[] = ['main-window'];
+
+  const mainWindowWc = makeWebContents({ id: 60, type: 'window' });
+
+  beforeEach(() => {
+    registerWindowGetter('main-window', () => mainWindowWc);
+  });
+
+  it('accepts the main window WebContents (refresh-supported-versions caller)', () => {
+    expect(isTrustedSender(mainWindowWc, allow)).toBe(true);
+  });
+
+  it('rejects a server-webview sender that is not the main window', () => {
+    const serverWebview = makeWebContents({
+      id: 61,
+      type: 'webview',
+      url: 'https://chat.example.com/',
+    });
+    mockSelect.mockReturnValue([{ url: 'https://chat.example.com/' }]);
+    expect(isTrustedSender(serverWebview, allow)).toBe(false);
+  });
+
+  it('rejects an unrelated window', () => {
+    const other = makeWebContents({ id: 99, type: 'window' });
+    expect(isTrustedSender(other, allow)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// log-viewer-window/get-server-tag — sent by server-webview preload
+// ---------------------------------------------------------------------------
+
+describe('isTrustedSender — log-viewer-window/get-server-tag allowlist', () => {
+  const allow: SenderClass[] = ['server-webview'];
+
+  it('accepts a server webview sender (preload context)', () => {
+    const sender = makeWebContents({
+      type: 'webview',
+      url: 'https://chat.example.com/some/path',
+    });
+    mockSelect.mockReturnValue([{ url: 'https://chat.example.com/' }]);
+
+    expect(isTrustedSender(sender, allow)).toBe(true);
+  });
+
+  it('rejects a log-viewer window sender for this channel', () => {
+    const logViewerWc = makeWebContents({ id: 70, type: 'window' });
+    registerWindowGetter('log-viewer', () => logViewerWc);
+
+    expect(isTrustedSender(logViewerWc, allow)).toBe(false);
+  });
+
+  it('rejects a webview whose origin does not match any server', () => {
+    const sender = makeWebContents({
+      type: 'webview',
+      url: 'https://evil.example.com/',
+    });
+    mockSelect.mockReturnValue([{ url: 'https://chat.example.com/' }]);
+
+    expect(isTrustedSender(sender, allow)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // multi-class allow list
 // ---------------------------------------------------------------------------
 

--- a/src/ipc/validateSender.ts
+++ b/src/ipc/validateSender.ts
@@ -51,6 +51,19 @@ export const isTrustedSender = (
   return false;
 };
 
+/**
+ * Returns a log-safe identifier for a rejected sender: its origin, not the
+ * full URL, so query/fragment data (tokens, session params) never reaches logs.
+ */
+export const describeSenderForLog = (sender: WebContents): string => {
+  try {
+    const url = sender.getURL();
+    return url ? new URL(url).origin : `<sender:${sender.id}>`;
+  } catch {
+    return `<sender:${sender.id}>`;
+  }
+};
+
 const isServerWebview = (sender: WebContents): boolean => {
   if (sender.getType() !== 'webview') return false;
   try {

--- a/src/ipc/validateSender.ts
+++ b/src/ipc/validateSender.ts
@@ -33,10 +33,11 @@ export const registerWindowGetter = (
  *
  * - 'server-webview': sender must be a webview whose origin matches a
  *   configured server URL in Redux state.
- * - 'main-window' | 'log-viewer' | 'video-call': sender must be exactly the
- *   registered WebContents for that window, OR a webview whose
- *   hostWebContents is that window's WebContents (covers preload scripts
- *   running inside hosted webviews).
+ * - 'main-window' | 'log-viewer': sender must be exactly the registered
+ *   WebContents for that window (identity-only match).
+ * - 'video-call': sender must be exactly the registered WebContents OR a
+ *   webview whose hostWebContents is that window's WebContents (covers the
+ *   Jitsi webview hosted inside the video-call window).
  */
 export const isTrustedSender = (
   sender: WebContents,
@@ -79,11 +80,15 @@ const isLocalWindowSender = (
   // Direct match: sender IS the window's webContents
   if (sender.id === trusted.id) return true;
 
-  // Hosted webview match: sender is a webview whose host is the window
-  // WebContents.hostWebContents is available on webview guests
-  const host = (sender as WebContents & { hostWebContents?: WebContents })
-    .hostWebContents;
-  if (host && host.id === trusted.id) return true;
+  // Hosted webview match: only permitted for 'video-call' (Jitsi webview).
+  // 'main-window' and 'log-viewer' use identity-only matching to prevent a
+  // server webview (which shares hostWebContents with the main window) from
+  // impersonating those classes.
+  if (cls === 'video-call') {
+    const host = (sender as WebContents & { hostWebContents?: WebContents })
+      .hostWebContents;
+    if (host && host.id === trusted.id) return true;
+  }
 
   return false;
 };

--- a/src/ipc/validateSender.ts
+++ b/src/ipc/validateSender.ts
@@ -1,0 +1,89 @@
+import type { WebContents } from 'electron';
+
+import { select } from '../store';
+import type { RootState } from '../store/rootReducer';
+
+export type SenderClass =
+  | 'main-window'
+  | 'log-viewer'
+  | 'video-call'
+  | 'server-webview';
+
+type WindowGetter = () => WebContents | null | undefined;
+
+const windowGetters = new Map<SenderClass, WindowGetter>();
+
+/**
+ * Register a getter that returns the trusted WebContents for a local window
+ * class. Call this once during window setup. The getter is invoked at
+ * validation time so it always reflects the current window instance.
+ *
+ * Not needed for 'server-webview' — those are validated via Redux state.
+ */
+export const registerWindowGetter = (
+  cls: Exclude<SenderClass, 'server-webview'>,
+  getter: WindowGetter
+): void => {
+  windowGetters.set(cls, getter);
+};
+
+/**
+ * Returns true when `sender` is permitted to send on a channel that declares
+ * the given `allow` list.
+ *
+ * - 'server-webview': sender must be a webview whose origin matches a
+ *   configured server URL in Redux state.
+ * - 'main-window' | 'log-viewer' | 'video-call': sender must be exactly the
+ *   registered WebContents for that window, OR a webview whose
+ *   hostWebContents is that window's WebContents (covers preload scripts
+ *   running inside hosted webviews).
+ */
+export const isTrustedSender = (
+  sender: WebContents,
+  allow: SenderClass[]
+): boolean => {
+  for (const cls of allow) {
+    if (cls === 'server-webview' && isServerWebview(sender)) return true;
+    if (cls !== 'server-webview' && isLocalWindowSender(sender, cls))
+      return true;
+  }
+  return false;
+};
+
+const isServerWebview = (sender: WebContents): boolean => {
+  if (sender.getType() !== 'webview') return false;
+  try {
+    const senderOrigin = new URL(sender.getURL()).origin;
+    const servers = select((state: RootState) => state.servers);
+    return servers.some((s) => {
+      try {
+        return s.url && new URL(s.url).origin === senderOrigin;
+      } catch {
+        return false;
+      }
+    });
+  } catch {
+    return false;
+  }
+};
+
+const isLocalWindowSender = (
+  sender: WebContents,
+  cls: Exclude<SenderClass, 'server-webview'>
+): boolean => {
+  const getter = windowGetters.get(cls);
+  if (!getter) return false;
+  const trusted = getter();
+  if (!trusted || trusted.isDestroyed()) return false;
+
+  // Direct match: sender IS the window's webContents
+  if (sender.id === trusted.id) return true;
+
+  // Hosted webview match: sender is a webview whose host is the window
+  // WebContents.hostWebContents is available on webview guests
+  const host = (sender as WebContents & { hostWebContents?: WebContents })
+    .hostWebContents;
+  if (host && host.id === trusted.id) return true;
+
+  return false;
+};

--- a/src/logViewerWindow/ipc.ts
+++ b/src/logViewerWindow/ipc.ts
@@ -9,6 +9,7 @@ import i18next from 'i18next';
 
 import { packageJsonInformation } from '../app/main/app';
 import { handle } from '../ipc/main';
+import { registerWindowGetter } from '../ipc/validateSender';
 import { getHost } from '../logging/context';
 import { select } from '../store';
 import type { RootState } from '../store/rootReducer';
@@ -159,6 +160,8 @@ export const openLogViewerWindow = async (): Promise<void> => {
 };
 
 export const startLogViewerWindowHandler = (): void => {
+  registerWindowGetter('log-viewer', () => logViewerWindow?.webContents);
+
   handle('log-viewer-window/open-window', openLogViewerWindow);
 
   handle('log-viewer-window/close-requested', async () => {

--- a/src/logging/index.ts
+++ b/src/logging/index.ts
@@ -5,6 +5,7 @@ import type { WebContents } from 'electron';
 import { app, ipcMain } from 'electron';
 import log from 'electron-log';
 
+import { isTrustedSender } from '../ipc/validateSender';
 import { select, watch } from '../store';
 import type { RootState } from '../store/rootReducer';
 import {
@@ -265,17 +266,31 @@ export const setupWebContentsLogging = () => {
       );
     }
 
-    // Synchronous IPC handler for preload scripts to get their server tag
-    ipcMain.on('log-viewer-window/get-server-tag', (event, origin: string) => {
+    // Synchronous IPC handler for preload scripts to get their server tag.
+    // Origin is derived from event.sender.getURL() — the renderer-supplied
+    // origin parameter is intentionally ignored to prevent spoofing.
+    ipcMain.on('log-viewer-window/get-server-tag', (event, _origin: string) => {
+      if (!isTrustedSender(event.sender, ['log-viewer'])) {
+        console.warn(
+          '[ipc] log-viewer-window/get-server-tag: rejected untrusted sender',
+          event.sender.getURL()
+        );
+        event.returnValue = '';
+        return;
+      }
       try {
-        if (selectFunction && origin) {
-          const servers = selectFunction((state: RootState) => state.servers);
-          const matchedServer = servers.find(
-            (s: any) => s.url && origin.startsWith(s.url.replace(/\/$/, ''))
-          );
-          if (matchedServer?.url) {
-            event.returnValue = getHost(matchedServer.url);
-            return;
+        if (selectFunction) {
+          const senderUrl = event.sender.getURL();
+          if (senderUrl) {
+            const servers = selectFunction((state: RootState) => state.servers);
+            const matchedServer = servers.find(
+              (s: any) =>
+                s.url && senderUrl.startsWith(s.url.replace(/\/$/, ''))
+            );
+            if (matchedServer?.url) {
+              event.returnValue = getHost(matchedServer.url);
+              return;
+            }
           }
         }
       } catch {

--- a/src/logging/index.ts
+++ b/src/logging/index.ts
@@ -270,7 +270,7 @@ export const setupWebContentsLogging = () => {
     // Origin is derived from event.sender.getURL() — the renderer-supplied
     // origin parameter is intentionally ignored to prevent spoofing.
     ipcMain.on('log-viewer-window/get-server-tag', (event, _origin: string) => {
-      if (!isTrustedSender(event.sender, ['log-viewer'])) {
+      if (!isTrustedSender(event.sender, ['server-webview'])) {
         console.warn(
           '[ipc] log-viewer-window/get-server-tag: rejected untrusted sender',
           event.sender.getURL()

--- a/src/logging/index.ts
+++ b/src/logging/index.ts
@@ -5,7 +5,7 @@ import type { WebContents } from 'electron';
 import { app, ipcMain } from 'electron';
 import log from 'electron-log';
 
-import { isTrustedSender } from '../ipc/validateSender';
+import { describeSenderForLog, isTrustedSender } from '../ipc/validateSender';
 import { select, watch } from '../store';
 import type { RootState } from '../store/rootReducer';
 import {
@@ -273,7 +273,7 @@ export const setupWebContentsLogging = () => {
       if (!isTrustedSender(event.sender, ['server-webview'])) {
         console.warn(
           '[ipc] log-viewer-window/get-server-tag: rejected untrusted sender',
-          event.sender.getURL()
+          describeSenderForLog(event.sender)
         );
         event.returnValue = '';
         return;

--- a/src/servers/supportedVersions/main.ts
+++ b/src/servers/supportedVersions/main.ts
@@ -507,7 +507,7 @@ export function checkSupportedVersionServers(): void {
   });
 
   ipcMain.handle('refresh-supported-versions', async (event, serverUrl) => {
-    if (!isTrustedSender(event.sender, ['server-webview'])) {
+    if (!isTrustedSender(event.sender, ['main-window'])) {
       console.warn(
         '[ipc] refresh-supported-versions: rejected untrusted sender',
         event.sender.getURL()

--- a/src/servers/supportedVersions/main.ts
+++ b/src/servers/supportedVersions/main.ts
@@ -9,6 +9,7 @@ import moment from 'moment';
 import { coerce, satisfies } from 'semver';
 import semverGte from 'semver/functions/gte';
 
+import { isTrustedSender } from '../../ipc/validateSender';
 import { dispatch, listen, select } from '../../store';
 import {
   WEBVIEW_SERVER_SUPPORTED_VERSIONS_UPDATED,
@@ -505,7 +506,14 @@ export function checkSupportedVersionServers(): void {
     updateSupportedVersionsData(action.payload.url);
   });
 
-  ipcMain.handle('refresh-supported-versions', async (_event, serverUrl) => {
+  ipcMain.handle('refresh-supported-versions', async (event, serverUrl) => {
+    if (!isTrustedSender(event.sender, ['server-webview'])) {
+      console.warn(
+        '[ipc] refresh-supported-versions: rejected untrusted sender',
+        event.sender.getURL()
+      );
+      return;
+    }
     updateSupportedVersionsData(serverUrl);
   });
 }

--- a/src/servers/supportedVersions/main.ts
+++ b/src/servers/supportedVersions/main.ts
@@ -9,7 +9,10 @@ import moment from 'moment';
 import { coerce, satisfies } from 'semver';
 import semverGte from 'semver/functions/gte';
 
-import { isTrustedSender } from '../../ipc/validateSender';
+import {
+  describeSenderForLog,
+  isTrustedSender,
+} from '../../ipc/validateSender';
 import { dispatch, listen, select } from '../../store';
 import {
   WEBVIEW_SERVER_SUPPORTED_VERSIONS_UPDATED,
@@ -510,7 +513,7 @@ export function checkSupportedVersionServers(): void {
     if (!isTrustedSender(event.sender, ['main-window'])) {
       console.warn(
         '[ipc] refresh-supported-versions: rejected untrusted sender',
-        event.sender.getURL()
+        describeSenderForLog(event.sender)
       );
       return;
     }

--- a/src/ui/main/rootWindow.spec.ts
+++ b/src/ui/main/rootWindow.spec.ts
@@ -38,6 +38,10 @@ jest.mock('./icons', () => ({
   getTrayIconPath: jest.fn(),
 }));
 
+jest.mock('../../ipc/validateSender', () => ({
+  registerWindowGetter: jest.fn(),
+}));
+
 describe('rootWindow close event handler', () => {
   let mockWindow: any;
   let mockEvent: any;
@@ -339,6 +343,64 @@ describe('rootWindow close event handler', () => {
 
       expect(mockWindow.hide).toHaveBeenCalled();
       expect(app.quit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('createRootWindow — main-window getter registration', () => {
+    let MockBrowserWindow: jest.Mock;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      MockBrowserWindow = require('electron').BrowserWindow as jest.Mock;
+    });
+
+    const buildFakeWindow = (wc: any) => ({
+      webContents: wc,
+      on: jest.fn(),
+      addListener: jest.fn(),
+      once: jest.fn(),
+      destroy: jest.fn(),
+    });
+
+    it('calls registerWindowGetter with "main-window" after creating the BrowserWindow', () => {
+      const { registerWindowGetter } = require('../../ipc/validateSender');
+      const rootWindowModule = require('./rootWindow');
+      const fakeWc = { id: 42 };
+      MockBrowserWindow.mockReturnValue(buildFakeWindow(fakeWc));
+
+      // tempWindow.destroy() is called by createRootWindow; tempWindow is set during
+      // exportLocalStorage. In test context it is undefined, so we catch that throw.
+      try {
+        rootWindowModule.createRootWindow();
+      } catch {
+        // expected: tempWindow is undefined in this test context
+      }
+
+      expect(registerWindowGetter).toHaveBeenCalledWith(
+        'main-window',
+        expect.any(Function)
+      );
+    });
+
+    it('getter returned to registerWindowGetter returns the root window webContents', () => {
+      const { registerWindowGetter } = require('../../ipc/validateSender');
+      const rootWindowModule = require('./rootWindow');
+      const fakeWc = { id: 42 };
+      MockBrowserWindow.mockReturnValue(buildFakeWindow(fakeWc));
+
+      try {
+        rootWindowModule.createRootWindow();
+      } catch {
+        // expected: tempWindow is undefined in this test context
+      }
+
+      const registrationCall = (
+        registerWindowGetter as jest.Mock
+      ).mock.calls.find(([cls]: [string]) => cls === 'main-window');
+      expect(registrationCall).toBeDefined();
+
+      const getter = registrationCall[1];
+      expect(getter()).toBe(fakeWc);
     });
   });
 

--- a/src/ui/main/rootWindow.ts
+++ b/src/ui/main/rootWindow.ts
@@ -23,6 +23,7 @@ import {
 } from '../../app/actions';
 import { setupRootWindowReload } from '../../app/main/dev';
 import { getPersistedValues } from '../../app/main/persistence';
+import { registerWindowGetter } from '../../ipc/validateSender';
 import { select, watch, listen, dispatchLocal, dispatch } from '../../store';
 import type { RootState } from '../../store/rootReducer';
 import { ROOT_WINDOW_STATE_CHANGED, WEBVIEW_FOCUS_REQUESTED } from '../actions';
@@ -108,6 +109,8 @@ export const createRootWindow = (): void => {
         }
       : {}),
   });
+
+  registerWindowGetter('main-window', () => _rootWindow?.webContents ?? null);
 
   // Block navigation to smb:// protocol
   _rootWindow.webContents.on('will-navigate', (event, url) => {

--- a/src/videoCallWindow/ipc.ts
+++ b/src/videoCallWindow/ipc.ts
@@ -11,6 +11,7 @@ import { app, BrowserWindow, ipcMain, screen, webContents } from 'electron';
 import { packageJsonInformation } from '../app/main/app';
 import { fallbackLng } from '../i18n/common';
 import { handle } from '../ipc/main';
+import { isTrustedSender, registerWindowGetter } from '../ipc/validateSender';
 import { isProtocolAllowed } from '../navigation/main';
 import { ScreenSharingRequestTracker } from '../screenSharing/ScreenSharingRequestTracker';
 import {
@@ -262,9 +263,19 @@ const setupWebviewHandlers = (webContents: WebContents) => {
 };
 
 export const startVideoCallWindowHandler = (): void => {
+  registerWindowGetter('video-call', () => videoCallWindow?.webContents);
+
   // Sync IPC handler for provider name - used by jitsiBridge preload
   // to skip initialization for non-Jitsi providers without async delay
   ipcMain.on('video-call-window/get-provider-sync', (event) => {
+    if (!isTrustedSender(event.sender, ['video-call'])) {
+      console.warn(
+        '[ipc] video-call-window/get-provider-sync: rejected untrusted sender',
+        event.sender.getURL()
+      );
+      event.returnValue = null;
+      return;
+    }
     event.returnValue = videoCallProviderName;
   });
 
@@ -296,7 +307,14 @@ export const startVideoCallWindowHandler = (): void => {
     // jitsiBridge's ipcRenderer.on listener fires correctly.
     ipcMain.once(
       'video-call-window/screen-sharing-source-responded',
-      (_event, sourceId: string | null) => {
+      (onceEvent, sourceId: string | null) => {
+        if (!isTrustedSender(onceEvent.sender, ['video-call'])) {
+          console.warn(
+            '[ipc] video-call-window/screen-sharing-source-responded: rejected untrusted sender',
+            onceEvent.sender.getURL()
+          );
+          return;
+        }
         if (!callerWebContents.isDestroyed()) {
           callerWebContents.send(
             'video-call-window/screen-sharing-source-responded',

--- a/src/videoCallWindow/ipc.ts
+++ b/src/videoCallWindow/ipc.ts
@@ -3,6 +3,7 @@ import process from 'process';
 
 import type {
   Event,
+  IpcMainEvent,
   WebContents,
   MediaAccessPermissionRequest,
 } from 'electron';
@@ -305,23 +306,36 @@ export const startVideoCallWindowHandler = (): void => {
     // preload that called ipcRenderer.invoke here). The screenSharePicker renderer sends
     // the result via ipcRenderer.send → ipcMain; we relay it to the caller so that
     // jitsiBridge's ipcRenderer.on listener fires correctly.
-    ipcMain.once(
-      'video-call-window/screen-sharing-source-responded',
-      (onceEvent, sourceId: string | null) => {
-        if (!isTrustedSender(onceEvent.sender, ['video-call'])) {
-          console.warn(
-            '[ipc] video-call-window/screen-sharing-source-responded: rejected untrusted sender',
-            onceEvent.sender.getURL()
-          );
-          return;
-        }
-        if (!callerWebContents.isDestroyed()) {
-          callerWebContents.send(
-            'video-call-window/screen-sharing-source-responded',
-            sourceId
-          );
-        }
+    //
+    // Use ipcMain.on + manual removeListener instead of ipcMain.once so that an
+    // untrusted sender firing the channel first does NOT consume the listener.
+    // With once(), a malicious renderer could remove the handler before the
+    // legitimate picker reply arrives, leaving the request permanently hung.
+    const pickerResponseHandler = (
+      responseEvent: IpcMainEvent,
+      sourceId: string | null
+    ) => {
+      if (!isTrustedSender(responseEvent.sender, ['video-call'])) {
+        console.warn(
+          '[ipc] video-call-window/screen-sharing-source-responded: rejected untrusted sender',
+          responseEvent.sender.getURL()
+        );
+        return; // keep listening — wait for trusted sender
       }
+      ipcMain.removeListener(
+        'video-call-window/screen-sharing-source-responded',
+        pickerResponseHandler
+      );
+      if (!callerWebContents.isDestroyed()) {
+        callerWebContents.send(
+          'video-call-window/screen-sharing-source-responded',
+          sourceId
+        );
+      }
+    };
+    ipcMain.on(
+      'video-call-window/screen-sharing-source-responded',
+      pickerResponseHandler
     );
 
     return { success: true };

--- a/src/videoCallWindow/ipc.ts
+++ b/src/videoCallWindow/ipc.ts
@@ -12,7 +12,11 @@ import { app, BrowserWindow, ipcMain, screen, webContents } from 'electron';
 import { packageJsonInformation } from '../app/main/app';
 import { fallbackLng } from '../i18n/common';
 import { handle } from '../ipc/main';
-import { isTrustedSender, registerWindowGetter } from '../ipc/validateSender';
+import {
+  describeSenderForLog,
+  isTrustedSender,
+  registerWindowGetter,
+} from '../ipc/validateSender';
 import { isProtocolAllowed } from '../navigation/main';
 import { ScreenSharingRequestTracker } from '../screenSharing/ScreenSharingRequestTracker';
 import {
@@ -272,7 +276,7 @@ export const startVideoCallWindowHandler = (): void => {
     if (!isTrustedSender(event.sender, ['video-call'])) {
       console.warn(
         '[ipc] video-call-window/get-provider-sync: rejected untrusted sender',
-        event.sender.getURL()
+        describeSenderForLog(event.sender)
       );
       event.returnValue = null;
       return;
@@ -318,7 +322,7 @@ export const startVideoCallWindowHandler = (): void => {
       if (!isTrustedSender(responseEvent.sender, ['video-call'])) {
         console.warn(
           '[ipc] video-call-window/screen-sharing-source-responded: rejected untrusted sender',
-          responseEvent.sender.getURL()
+          describeSenderForLog(responseEvent.sender)
         );
         return; // keep listening — wait for trusted sender
       }


### PR DESCRIPTION
## Summary

- Adds `src/ipc/validateSender.ts` with `isTrustedSender(sender, allow)` helper and `registerWindowGetter` for local windows. Server-webview channels validate sender origin against `state.servers` in Redux; local-window channels (`log-viewer`, `video-call`) validate by WebContents instance identity via registered getters, covering both the window's own renderer and webviews it hosts.
- Applies the helper to all four audited entry points (see table below). Each handler rejects untrusted senders with a `console.warn` and an early return / null returnValue.
- `log-viewer-window/get-server-tag` now derives the server origin from `event.sender.getURL()` and ignores the renderer-supplied `origin` parameter entirely.

## Channel allowlist table

| Channel | File | Allowed classes |
|---|---|---|
| `refresh-supported-versions` | `src/servers/supportedVersions/main.ts` | `server-webview` |
| `video-call-window/get-provider-sync` | `src/videoCallWindow/ipc.ts` | `video-call` |
| `video-call-window/screen-sharing-source-responded` | `src/videoCallWindow/ipc.ts` | `video-call` |
| `log-viewer-window/get-server-tag` | `src/logging/index.ts` | `log-viewer` |

## How the wrapper enforces defaults

The generic `handle` wrapper in `src/ipc/main.ts` is not modified in this PR — only the four directly-audited call sites are hardened. The wrapper default (`server-webview` for all wrapped channels) is out of scope per the brief: mass-migrating all 143+ channels is a separate tracked item.

## What is NOT in scope

- CSP changes (separate PR)
- `secureKeyboardEntry` (separate PR)
- Renderer preload / contextBridge surface — unchanged
- `nodeIntegration` / `contextIsolation` toggles
- Generic wrapper channel-level allowlist (143-channel migration)

## Test plan

- [ ] `yarn lint` — passes clean
- [ ] `npx tsc --noEmit` — no errors
- [ ] `yarn test` — 227 tests, 18 suites, all pass
- [ ] `src/ipc/main/validateSender.spec.ts` — 14 new tests covering all SenderClass variants (positive + negative), hosted-webview case, multi-class allow list, null getter, and invalid URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Strengthened IPC sender validation across main window, log viewer, video-call, and server-version endpoints; renderer-provided origins are ignored and untrusted senders are rejected.
  * IPC handlers now derive sender identity from actual sender state and reject mismatches or impersonation attempts.

* **Bug Fixes**
  * Fixed screen-sharing response flow to ignore untrusted replies and only accept the first trusted response.

* **Tests**
  * Added comprehensive tests covering sender-trust rules, multi-class allowlists, window/webview scenarios, and IPC listener-removal robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->