### PR TITLE
fix: skip thumbnail cache warm when provider has native picker (#3308)

### DIFF
--- a/src/screenSharing/main/serverViewScreenSharing.spec.ts
+++ b/src/screenSharing/main/serverViewScreenSharing.spec.ts
@@ -1,0 +1,159 @@
+import type { WebContents } from 'electron';
+
+import type { ScreenPickerProvider } from '../screenPicker/types';
+
+jest.mock('../desktopCapturerCache', () => ({
+  prewarmDesktopCapturerCache: jest.fn(),
+}));
+
+jest.mock('../../ipc/main', () => ({
+  handle: jest.fn(),
+}));
+
+jest.mock('../../navigation/main', () => ({
+  isProtocolAllowed: jest.fn(() => Promise.resolve(true)),
+}));
+
+jest.mock('../../ui/main/rootWindow', () => ({
+  getRootWindow: jest.fn(() => Promise.resolve(null)),
+}));
+
+jest.mock('../../utils/browserLauncher', () => ({
+  openExternal: jest.fn(),
+}));
+
+jest.mock('../screenRecordingPermission', () => ({
+  checkScreenRecordingPermission: jest.fn(() => Promise.resolve(true)),
+}));
+
+const portalProvider: ScreenPickerProvider = {
+  type: 'portal',
+  requiresInternalUI: false,
+  requiresCacheWarming: false,
+  handleDisplayMediaRequest: jest.fn(),
+  initialize: jest.fn(() => Promise.resolve()),
+  cleanup: jest.fn(),
+};
+
+const internalProvider: ScreenPickerProvider = {
+  type: 'internal',
+  requiresInternalUI: true,
+  requiresCacheWarming: true,
+  handleDisplayMediaRequest: jest.fn(),
+  initialize: jest.fn(() => Promise.resolve()),
+  cleanup: jest.fn(),
+};
+
+const detectPickerType = jest.fn();
+
+class PortalPickerProvider {
+  type = portalProvider.type;
+
+  requiresInternalUI = portalProvider.requiresInternalUI;
+
+  requiresCacheWarming = portalProvider.requiresCacheWarming;
+
+  handleDisplayMediaRequest = portalProvider.handleDisplayMediaRequest;
+
+  initialize = portalProvider.initialize;
+
+  cleanup = portalProvider.cleanup;
+}
+
+class InternalPickerProvider {
+  type = internalProvider.type;
+
+  requiresInternalUI = internalProvider.requiresInternalUI;
+
+  requiresCacheWarming = internalProvider.requiresCacheWarming;
+
+  handleDisplayMediaRequest = internalProvider.handleDisplayMediaRequest;
+
+  initialize = internalProvider.initialize;
+
+  cleanup = internalProvider.cleanup;
+
+  setHandleRequestHandler = jest.fn();
+}
+
+jest.mock('../screenPicker', () => ({
+  detectPickerType: () => detectPickerType(),
+  PortalPickerProvider,
+  InternalPickerProvider,
+}));
+
+const flushPromises = (): Promise<void> =>
+  new Promise((resolve) => setImmediate(resolve));
+
+const createGuestWebContents = () => {
+  const setDisplayMediaRequestHandler = jest.fn();
+  return {
+    webContents: {
+      session: { setDisplayMediaRequestHandler },
+      isDestroyed: jest.fn(() => false),
+    } as unknown as WebContents,
+    setDisplayMediaRequestHandler,
+  };
+};
+
+const loadModule = async () => {
+  const sut = await import('../serverViewScreenSharing');
+  const cache = await import('../desktopCapturerCache');
+  return {
+    setupServerViewDisplayMedia: sut.setupServerViewDisplayMedia,
+    prewarmMock: cache.prewarmDesktopCapturerCache as jest.Mock,
+  };
+};
+
+describe('setupServerViewDisplayMedia — cache warming gate', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it('skips prewarmDesktopCapturerCache for portal provider (Linux/Wayland)', async () => {
+    detectPickerType.mockReturnValue('portal');
+    const { setupServerViewDisplayMedia, prewarmMock } = await loadModule();
+
+    const guest = createGuestWebContents();
+    setupServerViewDisplayMedia(guest.webContents);
+
+    await flushPromises();
+    await flushPromises();
+
+    expect(guest.setDisplayMediaRequestHandler).toHaveBeenCalledTimes(1);
+    expect(guest.setDisplayMediaRequestHandler.mock.calls[0][1]).toEqual({
+      useSystemPicker: false,
+    });
+    expect(prewarmMock).not.toHaveBeenCalled();
+  });
+
+  it('calls prewarmDesktopCapturerCache for internal provider', async () => {
+    detectPickerType.mockReturnValue('internal');
+    const { setupServerViewDisplayMedia, prewarmMock } = await loadModule();
+
+    const guest = createGuestWebContents();
+    setupServerViewDisplayMedia(guest.webContents);
+
+    await flushPromises();
+    await flushPromises();
+
+    expect(guest.setDisplayMediaRequestHandler).toHaveBeenCalledTimes(1);
+    expect(prewarmMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not register handler when guest webContents is destroyed before init resolves', async () => {
+    detectPickerType.mockReturnValue('portal');
+    const { setupServerViewDisplayMedia, prewarmMock } = await loadModule();
+
+    const guest = createGuestWebContents();
+    (guest.webContents.isDestroyed as jest.Mock).mockReturnValue(true);
+    setupServerViewDisplayMedia(guest.webContents);
+
+    await flushPromises();
+    await flushPromises();
+
+    expect(guest.setDisplayMediaRequestHandler).not.toHaveBeenCalled();
+    expect(prewarmMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/screenSharing/serverViewScreenSharing.ts
+++ b/src/screenSharing/serverViewScreenSharing.ts
@@ -82,7 +82,9 @@ export const setupServerViewDisplayMedia = (
         },
         { useSystemPicker: false }
       );
-      prewarmDesktopCapturerCache();
+      if (currentProvider.requiresCacheWarming) {
+        prewarmDesktopCapturerCache();
+      }
     } catch (error) {
       console.error(
         'Server view screen sharing: error setting up handler:',


### PR DESCRIPTION
## Summary

Fixes #3308 — screen-share picker no longer pops on every app launch on Linux/Wayland (Fedora). Honors the `requiresCacheWarming` flag already declared by `PortalPickerProvider` so `desktopCapturer.getSources()` is not invoked at `WEBVIEW_READY` when the OS provides its own native picker via XDG portal.

## Context

Since 4.14.0 (PR #3266), `setupServerViewDisplayMedia` runs on every server-view `WEBVIEW_READY` and unconditionally calls `prewarmDesktopCapturerCache()`. On Linux/Wayland with `WebRTCPipeWireCapturer` enabled, `desktopCapturer.getSources()` routes through the XDG portal and opens the OS picker UI directly — so the prewarm itself triggers the dialog at startup, before any user action. `PortalPickerProvider` already declares `requiresCacheWarming = false`; the flag was just not consulted.

## Changes

- `src/screenSharing/serverViewScreenSharing.ts`: gate `prewarmDesktopCapturerCache()` behind `currentProvider.requiresCacheWarming`. Internal picker (Windows/macOS/X11) keeps prewarming — UI thumbnails unchanged.
- `src/screenSharing/main/serverViewScreenSharing.spec.ts`: new main-process spec covering portal, internal, and destroyed-`webContents` paths.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx eslint src/screenSharing/**`
- [x] `npx jest src/screenSharing/main/serverViewScreenSharing.spec.ts` — 3/3 pass
- [ ] Manual on Fedora 43 Wayland (Flatpak): launch five times, confirm zero picker pops
- [ ] Manual share flow on Linux Wayland: confirm portal picker still fires when user actually starts a share
- [ ] Manual share flow on Windows + macOS: confirm internal picker thumbnails still render

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite for screen picker cache warming behavior across different configurations.

* **Improvements**
  * Enhanced desktop capturer cache handling for screen sharing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->