### PR TITLE
fix: #3244 sidebar tooltip shows null for servers beyond 9th position

### DIFF
--- a/src/ui/components/SideBar/ServerButton.tsx
+++ b/src/ui/components/SideBar/ServerButton.tsx
@@ -143,7 +143,7 @@ const ServerButton = ({
   };
 
   const tooltipContent = `
-  ${title} (${process.platform === 'darwin' ? '⌘' : '^'}+${shortcutNumber})
+ ${title}${shortcutNumber !== null ? ` (${process.platform === 'darwin' ? '⌘' : '^'}+${shortcutNumber})` : ''}
   ${
     hasUnreadMessages
       ? `

--- a/src/ui/components/SideBar/index.tsx
+++ b/src/ui/components/SideBar/index.tsx
@@ -103,7 +103,7 @@ export const SideBar = () => {
                     : server.title ?? server.url
                 }
                 shortcutNumber={
-                  typeof order === 'number' && order <= 9
+                  typeof order === 'number' && order < 9
                     ? String(order + 1)
                     : null
                 }


### PR DESCRIPTION
## Description

Fixes #3244 — two bugs in sidebar tooltip shortcut formatting.

### Bug 1: Off-by-one (`index.tsx`)
```
order <= 9  →  order < 9
```
Server #10 was getting shortcutNumber "10" even though Ctrl+10 doesn't exist. Now only servers 1-9 get shortcuts.

### Bug 2: Null tooltip (`ServerButton.tsx`)
```
${title} (${mod}+${shortcutNumber})  →  ${title}${shortcutNumber !== null ? ... : ''}
```
When `shortcutNumber` is null (servers 10+), the template rendered "(^+null)" in the tooltip. Now the shortcut portion is conditional.

### Changes
- `src/ui/components/SideBar/index.tsx`: 1 line changed
- `src/ui/components/SideBar/ServerButton.tsx`: 1 line changed

## Risk
LOW — pure presentation change, no state or logic modifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar shortcut display to only show keyboard shortcut information in tooltips when a shortcut is available.
  * Refined server button shortcut assignment to apply only to the first eight items in the sidebar.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat.Electron/pull/3326)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->