### PR TITLE
fix: #3226 missing aria-label on IconButtons in downloads/settings views

### DIFF
--- a/src/i18n/en.i18n.json
+++ b/src/i18n/en.i18n.json
@@ -220,7 +220,8 @@
       "retry": "Retry",
       "showInFolder": "Show in Folder"
     },
-    "showingResults": "Showing results {{first}} - {{last}} of {{count}}"
+    "showingResults": "Showing results {{first}} - {{last}} of {{count}}",
+    "back": "Back"
   },
   "certificatesManager": {
     "title": "Certificates manager",
@@ -336,7 +337,8 @@
         "title": "Verbose Logging",
         "description": "Writes all console output to the log file. When disabled, only errors and important messages are saved, keeping logs smaller and focused."
       }
-    }
+    },
+    "back": "Back"
   },
   "error": {
     "authNeeded": "Auth needed, try <strong>{{- auth}}</strong>",

--- a/src/ui/components/DownloadsManagerView/index.tsx
+++ b/src/ui/components/DownloadsManagerView/index.tsx
@@ -196,7 +196,7 @@ const DownloadsManagerView = () => {
         alignItems='center'
       >
         {!isSideBarEnabled && (
-          <IconButton icon='arrow-back' onClick={handleBackButton} />
+          <IconButton icon='arrow-back' onClick={handleBackButton} aria-label={t('downloads.back')} />
         )}
         <Box is='div' color='default' fontScale='h1'>
           {t('downloads.title')}
@@ -257,6 +257,7 @@ const DownloadsManagerView = () => {
           <IconButton
             icon='trash'
             title={t('downloads.filters.clear')}
+            aria-label={t('downloads.filters.clear')}
             onClick={handleClearAll}
           />
         </Box>

--- a/src/ui/components/DownloadsManagerView/index.tsx
+++ b/src/ui/components/DownloadsManagerView/index.tsx
@@ -196,7 +196,11 @@ const DownloadsManagerView = () => {
         alignItems='center'
       >
         {!isSideBarEnabled && (
-          <IconButton icon='arrow-back' onClick={handleBackButton} aria-label={t('downloads.back')} />
+          <IconButton
+            icon='arrow-back'
+            onClick={handleBackButton}
+            aria-label={t('downloads.back')}
+          />
         )}
         <Box is='div' color='default' fontScale='h1'>
           {t('downloads.title')}

--- a/src/ui/components/SettingsView/SettingsView.tsx
+++ b/src/ui/components/SettingsView/SettingsView.tsx
@@ -63,7 +63,11 @@ export const SettingsView = () => {
         color='default'
       >
         {!isSideBarEnabled && (
-          <IconButton icon='arrow-back' onClick={handleBackButton} aria-label={t('settings.back')} />
+          <IconButton
+            icon='arrow-back'
+            onClick={handleBackButton}
+            aria-label={t('settings.back')}
+          />
         )}
         {t('settings.title')}
       </Box>

--- a/src/ui/components/SettingsView/SettingsView.tsx
+++ b/src/ui/components/SettingsView/SettingsView.tsx
@@ -63,7 +63,7 @@ export const SettingsView = () => {
         color='default'
       >
         {!isSideBarEnabled && (
-          <IconButton icon='arrow-back' onClick={handleBackButton} />
+          <IconButton icon='arrow-back' onClick={handleBackButton} aria-label={t('settings.back')} />
         )}
         {t('settings.title')}
       </Box>


### PR DESCRIPTION
## Description

Fixes #3226 — adds `aria-label` to 3 `<IconButton>` components lacking them. Follows the pattern established in `DocumentViewer`.

### Changes (3 files, 3 buttons)

1. **`DownloadsManagerView/index.tsx:199`** — Back button (`arrow-back`): added `aria-label={t('downloads.back')}`
2. **`DownloadsManagerView/index.tsx:257`** — Clear filters (`trash`): was missing `aria-label` despite having `title`
3. **`SettingsView/SettingsView.tsx:66`** — Back button (`arrow-back`): added `aria-label={t('settings.back')}`

Also added `downloads.back` and `settings.back` translation keys to `en.i18n.json`.

### Testing
- ✅ `yarn start` — console accessibility warnings gone for these components
- Screen reader now announces correct labels

### Risk
LOW — presentation only, no behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility by adding localized "back" labels for back buttons in Downloads and Settings views, ensuring consistent, translatable UI text.
  * Added a localized accessibility label to the clear action in the Downloads view to improve screen reader support and clarity for assistive technologies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat.Electron/pull/3327)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->