### PR TITLE
Add telephony clipboard dial shortcut

### DIFF
--- a/src/app/PersistableValues.spec.ts
+++ b/src/app/PersistableValues.spec.ts
@@ -1,0 +1,17 @@
+import { migrations } from './PersistableValues';
+
+describe('PersistableValues migrations', () => {
+  it('adds telephony shortcut config without losing a persisted telephony server', () => {
+    const before = ({
+      telephonyPreferredServer: 'https://chat.example.com',
+    } as unknown) as Parameters<(typeof migrations)['>=4.14.0']>[0];
+
+    expect(migrations['>=4.14.0'](before)).toEqual({
+      telephonyPreferredServer: 'https://chat.example.com',
+      telephonyGlobalShortcutConfig: {
+        enabled: false,
+        accelerator: null,
+      },
+    });
+  });
+});

--- a/src/app/PersistableValues.ts
+++ b/src/app/PersistableValues.ts
@@ -209,7 +209,9 @@ export const migrations = {
   }),
   '>=4.14.0': (before: PersistableValues_4_13_0): PersistableValues_4_14_0 => ({
     ...before,
-    telephonyPreferredServer: null,
+    telephonyPreferredServer:
+      (before as Partial<PersistableValues_4_14_0>).telephonyPreferredServer ??
+      null,
     telephonyGlobalShortcutConfig: {
       enabled: false,
       accelerator: null,

--- a/src/app/PersistableValues.ts
+++ b/src/app/PersistableValues.ts
@@ -2,6 +2,7 @@ import type { Certificate } from 'electron';
 
 import type { Download } from '../downloads/common';
 import type { Server } from '../servers/common';
+import type { TelephonyGlobalShortcutConfig } from '../telephony/actions';
 import type { WindowState } from '../ui/common';
 
 type PersistableValues_0_0_0 = {
@@ -106,9 +107,14 @@ type PersistableValues_4_13_0 = PersistableValues_4_11_0 & {
   isDebugLoggingEnabled: boolean;
 };
 
+type PersistableValues_4_14_0 = PersistableValues_4_13_0 & {
+  telephonyPreferredServer: string | null;
+  telephonyGlobalShortcutConfig: TelephonyGlobalShortcutConfig;
+};
+
 export type PersistableValues = Pick<
-  PersistableValues_4_13_0,
-  keyof PersistableValues_4_13_0
+  PersistableValues_4_14_0,
+  keyof PersistableValues_4_14_0
 >;
 
 export const migrations = {
@@ -200,5 +206,13 @@ export const migrations = {
   '>=4.13.0': (before: PersistableValues_4_11_0): PersistableValues_4_13_0 => ({
     ...before,
     isDebugLoggingEnabled: false,
+  }),
+  '>=4.14.0': (before: PersistableValues_4_13_0): PersistableValues_4_14_0 => ({
+    ...before,
+    telephonyPreferredServer: null,
+    telephonyGlobalShortcutConfig: {
+      enabled: false,
+      accelerator: null,
+    },
   }),
 };

--- a/src/app/selectors.ts
+++ b/src/app/selectors.ts
@@ -85,4 +85,7 @@ export const selectPersistableValues = createStructuredSelector({
     isDebugLoggingEnabled,
   telephonyPreferredServer: ({ telephonyPreferredServer }: RootState) =>
     telephonyPreferredServer,
+  telephonyGlobalShortcutConfig: ({
+    telephonyGlobalShortcutConfig,
+  }: RootState) => telephonyGlobalShortcutConfig,
 });

--- a/src/deepLinks/main.spec.ts
+++ b/src/deepLinks/main.spec.ts
@@ -188,6 +188,22 @@ describe('deepLinks/main.ts', () => {
       expect(listenMock).not.toHaveBeenCalled();
     });
 
+    it('should open dialpad path with empty input when requested', async () => {
+      selectMock.mockReturnValue([
+        { url: 'https://chat.example.com', title: 'Chat' },
+      ]);
+
+      await performTelephonyCall({ phoneNumber: '', rawUri: '' });
+
+      expect(mockWebContents.send).toHaveBeenCalledWith(
+        'telephony/call-requested',
+        {
+          phoneNumber: '',
+          rawUri: '',
+        }
+      );
+    });
+
     it('should show dialog when there are 2+ servers and no preference', async () => {
       selectMock
         .mockReturnValueOnce([

--- a/src/deepLinks/main.ts
+++ b/src/deepLinks/main.ts
@@ -7,12 +7,9 @@ import {
 } from '../app/main/app';
 import { ServerUrlResolutionStatus } from '../servers/common';
 import { resolveServerUrl } from '../servers/main';
-import { select, dispatch, listen } from '../store';
-import { TELEPHONY_PREFERRED_SERVER_SET } from '../telephony/actions';
-import {
-  TELEPHONY_SERVER_SELECT_OPEN,
-  TELEPHONY_SERVER_SELECT_CLOSE,
-} from '../ui/actions';
+import { select, dispatch } from '../store';
+import { openTelephonyDialpad } from '../telephony/dialpad';
+import { parseTelephonyLink } from '../telephony/links';
 import {
   askForServerAddition,
   warnAboutInvalidServerUrl,
@@ -20,6 +17,10 @@ import {
 import { getRootWindow } from '../ui/main/rootWindow';
 import { getWebContentsByServerUrl } from '../ui/main/serverView';
 import { DEEP_LINKS_SERVER_FOCUSED, DEEP_LINKS_SERVER_ADDED } from './actions';
+
+export type { TelephonyLink } from '../telephony/common';
+export { openTelephonyDialpad as performTelephonyCall } from '../telephony/dialpad';
+export { parseTelephonyLink } from '../telephony/links';
 
 const isDefinedProtocol = (parsedUrl: URL): boolean =>
   parsedUrl.protocol === `${electronBuilderJsonInformation.protocol}:`;
@@ -57,135 +58,6 @@ const parseDeepLink = (
   }
 
   return null;
-};
-
-const TELEPHONY_PROTOCOLS = ['tel:', 'callto:'];
-
-export type TelephonyLink = { phoneNumber: string; rawUri: string };
-
-export const parseTelephonyLink = (input: string): TelephonyLink | null => {
-  if (/^--/.test(input)) {
-    return null;
-  }
-
-  let url: URL;
-
-  try {
-    url = new URL(input);
-  } catch {
-    return null;
-  }
-
-  if (!TELEPHONY_PROTOCOLS.includes(url.protocol)) {
-    return null;
-  }
-
-  let raw: string;
-  try {
-    raw = decodeURIComponent(
-      url.pathname || url.href.slice(url.protocol.length)
-    );
-  } catch {
-    return null;
-  }
-
-  const phoneNumber = raw.replace(/^\/+/, '').replace(/[\s\-().]/g, '');
-
-  if (!phoneNumber) {
-    return null;
-  }
-
-  return { phoneNumber, rawUri: input };
-};
-
-const MODAL_TIMEOUT_MS = 120_000;
-const WEB_CONTENTS_TIMEOUT_MS = 10_000;
-
-let telephonyCallInProgress = false;
-
-export const performTelephonyCall = async (
-  link: TelephonyLink
-): Promise<void> => {
-  if (telephonyCallInProgress) {
-    return;
-  }
-
-  const servers = select(({ servers }) => servers);
-
-  if (servers.length === 0) {
-    return;
-  }
-
-  telephonyCallInProgress = true;
-
-  try {
-    let serverUrl: string;
-
-    if (servers.length === 1) {
-      serverUrl = servers[0].url;
-    } else {
-      const preferredServer = select(
-        ({ telephonyPreferredServer }) => telephonyPreferredServer
-      );
-
-      if (preferredServer && servers.some((s) => s.url === preferredServer)) {
-        serverUrl = preferredServer;
-      } else {
-        const result = await new Promise<{
-          serverUrl: string;
-          rememberChoice: boolean;
-        } | null>((resolve) => {
-          const timeout = setTimeout(() => {
-            unsubscribe();
-            dispatch({ type: TELEPHONY_SERVER_SELECT_CLOSE, payload: null });
-            resolve(null);
-          }, MODAL_TIMEOUT_MS);
-
-          const unsubscribe = listen(
-            TELEPHONY_SERVER_SELECT_CLOSE,
-            (action) => {
-              clearTimeout(timeout);
-              unsubscribe();
-              resolve(action.payload);
-            }
-          );
-
-          dispatch({
-            type: TELEPHONY_SERVER_SELECT_OPEN,
-            payload: { phoneNumber: link.phoneNumber, rawUri: link.rawUri },
-          });
-        });
-
-        if (!result) {
-          return;
-        }
-
-        serverUrl = result.serverUrl;
-
-        if (result.rememberChoice) {
-          dispatch({
-            type: TELEPHONY_PREFERRED_SERVER_SET,
-            payload: serverUrl,
-          });
-        }
-      }
-    }
-
-    const webContents = await getWebContents(
-      serverUrl,
-      WEB_CONTENTS_TIMEOUT_MS
-    );
-    if (!webContents) {
-      return;
-    }
-
-    webContents.send('telephony/call-requested', {
-      phoneNumber: link.phoneNumber,
-      rawUri: link.rawUri,
-    });
-  } finally {
-    telephonyCallInProgress = false;
-  }
 };
 
 export let processDeepLinksInArgs = async (): Promise<void> => undefined;
@@ -333,7 +205,7 @@ const performConference = async ({ host, path }: InviteParams): Promise<void> =>
 const processDeepLink = async (deepLink: string): Promise<void> => {
   const telephonyLink = parseTelephonyLink(deepLink);
   if (telephonyLink) {
-    await performTelephonyCall(telephonyLink);
+    await openTelephonyDialpad(telephonyLink);
     return;
   }
 

--- a/src/i18n/en.i18n.json
+++ b/src/i18n/en.i18n.json
@@ -299,8 +299,16 @@
       },
       "telephonyServer": {
         "title": "Telephony Server",
-        "description": "Choose which server handles incoming phone calls (tel: and callto: links).",
+        "description": "Choose which server handles telephony calls from global shortcuts and tel:/callto: links.",
         "auto": "Auto (ask each time)"
+      },
+      "telephonyShortcut": {
+        "title": "Telephony Global Shortcut",
+        "description": "Press this shortcut anywhere to focus Rocket.Chat and open the telephony dial pad. Clipboard is read only when the shortcut is pressed.",
+        "placeholder": "CommandOrControl+Shift+D",
+        "save": "Save",
+        "clear": "Clear",
+        "registered": "Shortcut registered"
       },
       "clearPermittedScreenCaptureServers": {
         "title": "Clear Screen Capture Permissions",

--- a/src/i18n/en.i18n.json
+++ b/src/i18n/en.i18n.json
@@ -308,7 +308,8 @@
         "placeholder": "CommandOrControl+Shift+D",
         "save": "Save",
         "clear": "Clear",
-        "registered": "Shortcut registered"
+        "registered": "Shortcut registered",
+        "reservedAccelerator": "{{accelerator}} is reserved by Rocket.Chat or your operating system."
       },
       "clearPermittedScreenCaptureServers": {
         "title": "Clear Screen Capture Permissions",

--- a/src/i18n/en.i18n.json
+++ b/src/i18n/en.i18n.json
@@ -306,6 +306,7 @@
         "title": "Telephony Global Shortcut",
         "description": "Press this shortcut anywhere to focus Rocket.Chat and open the telephony dial pad. Clipboard is read only when the shortcut is pressed.",
         "placeholder": "CommandOrControl+Shift+D",
+        "capturePlaceholder": "Press keys...",
         "save": "Save",
         "clear": "Clear",
         "registered": "Shortcut registered",

--- a/src/main.spec.ts
+++ b/src/main.spec.ts
@@ -115,6 +115,10 @@ jest.mock('./spellChecking/main', () => ({
   setupSpellChecking: jest.fn(() => Promise.resolve()),
 }));
 
+jest.mock('./telephony/main', () => ({
+  setupTelephonyGlobalShortcut: jest.fn(),
+}));
+
 jest.mock('./ui/components/CertificatesManager/main', () => ({
   handleCertificatesManager: jest.fn(),
 }));

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,6 +44,7 @@ import { checkSupportedVersionServers } from './servers/supportedVersions/main';
 import { setupSpellChecking } from './spellChecking/main';
 import { createMainReduxStore } from './store';
 import { applySystemCertificates } from './systemCertificates';
+import { setupTelephonyGlobalShortcut } from './telephony/main';
 import { handleCertificatesManager } from './ui/components/CertificatesManager/main';
 import dock from './ui/main/dock';
 import menuBar from './ui/main/menuBar';
@@ -120,6 +121,7 @@ const start = async (): Promise<void> => {
   await setupSpellChecking();
 
   setupDeepLinks();
+  setupTelephonyGlobalShortcut();
   await setupNavigation();
   setupPowerMonitor();
   await setupUpdates();

--- a/src/store/rootReducer.ts
+++ b/src/store/rootReducer.ts
@@ -18,7 +18,11 @@ import { allowInsecureOutlookConnections } from '../outlookCalendar/reducers/all
 import { outlookCalendarSyncInterval } from '../outlookCalendar/reducers/outlookCalendarSyncInterval';
 import { outlookCalendarSyncIntervalOverride } from '../outlookCalendar/reducers/outlookCalendarSyncIntervalOverride';
 import { servers } from '../servers/reducers';
-import { telephonyPreferredServer } from '../telephony/reducers';
+import {
+  telephonyGlobalShortcutConfig,
+  telephonyGlobalShortcutRegistrationStatus,
+  telephonyPreferredServer,
+} from '../telephony/reducers';
 import { availableBrowsers } from '../ui/reducers/availableBrowsers';
 import { currentView } from '../ui/reducers/currentView';
 import { dialogs } from '../ui/reducers/dialogs';
@@ -120,6 +124,8 @@ export const rootReducer = combineReducers({
   isTransparentWindowEnabled,
   isVideoCallScreenCaptureFallbackEnabled,
   telephonyPreferredServer,
+  telephonyGlobalShortcutConfig,
+  telephonyGlobalShortcutRegistrationStatus,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/src/telephony/actions.ts
+++ b/src/telephony/actions.ts
@@ -1,5 +1,22 @@
 export const TELEPHONY_PREFERRED_SERVER_SET = 'telephony/preferred-server-set';
+export const TELEPHONY_GLOBAL_SHORTCUT_CONFIG_SET =
+  'telephony/global-shortcut-config-set';
+export const TELEPHONY_GLOBAL_SHORTCUT_REGISTRATION_CHANGED =
+  'telephony/global-shortcut-registration-changed';
+
+export type TelephonyGlobalShortcutConfig = {
+  enabled: boolean;
+  accelerator: string | null;
+};
+
+export type TelephonyGlobalShortcutRegistrationStatus = {
+  registered: boolean;
+  accelerator: string | null;
+  error: string | null;
+};
 
 export type TelephonyActionTypeToPayloadMap = {
   [TELEPHONY_PREFERRED_SERVER_SET]: string | null;
+  [TELEPHONY_GLOBAL_SHORTCUT_CONFIG_SET]: TelephonyGlobalShortcutConfig;
+  [TELEPHONY_GLOBAL_SHORTCUT_REGISTRATION_CHANGED]: TelephonyGlobalShortcutRegistrationStatus;
 };

--- a/src/telephony/common.ts
+++ b/src/telephony/common.ts
@@ -1,0 +1,4 @@
+export type TelephonyLink = {
+  phoneNumber: string;
+  rawUri: string;
+};

--- a/src/telephony/dialpad.ts
+++ b/src/telephony/dialpad.ts
@@ -1,0 +1,132 @@
+import type { WebContents } from 'electron';
+
+import { select, dispatch, listen } from '../store';
+import {
+  TELEPHONY_SERVER_SELECT_OPEN,
+  TELEPHONY_SERVER_SELECT_CLOSE,
+} from '../ui/actions';
+import { getWebContentsByServerUrl } from '../ui/main/serverView';
+import { TELEPHONY_PREFERRED_SERVER_SET } from './actions';
+import type { TelephonyLink } from './common';
+
+const MODAL_TIMEOUT_MS = 120_000;
+const WEB_CONTENTS_TIMEOUT_MS = 10_000;
+
+let telephonyDialpadOpenInProgress = false;
+
+const getTelephonyWebContents = (
+  serverUrl: string,
+  timeoutMs: number
+): Promise<WebContents | null> =>
+  new Promise((resolve) => {
+    const deadline = Date.now() + timeoutMs;
+
+    const poll = (): void => {
+      const webContents = getWebContentsByServerUrl(serverUrl);
+      if (webContents) {
+        resolve(webContents);
+        return;
+      }
+
+      if (Date.now() >= deadline) {
+        resolve(null);
+        return;
+      }
+
+      setTimeout(poll, 100);
+    };
+
+    poll();
+  });
+
+const selectTelephonyServerUrl = async (
+  link: TelephonyLink
+): Promise<string | null> => {
+  const servers = select(({ servers }) => servers);
+
+  if (servers.length === 0) {
+    return null;
+  }
+
+  if (servers.length === 1) {
+    return servers[0].url;
+  }
+
+  const preferredServer = select(
+    ({ telephonyPreferredServer }) => telephonyPreferredServer
+  );
+
+  if (
+    preferredServer &&
+    servers.some((server) => server.url === preferredServer)
+  ) {
+    return preferredServer;
+  }
+
+  const result = await new Promise<{
+    serverUrl: string;
+    rememberChoice: boolean;
+  } | null>((resolve) => {
+    const timeout = setTimeout(() => {
+      unsubscribe();
+      dispatch({ type: TELEPHONY_SERVER_SELECT_CLOSE, payload: null });
+      resolve(null);
+    }, MODAL_TIMEOUT_MS);
+
+    const unsubscribe = listen(TELEPHONY_SERVER_SELECT_CLOSE, (action) => {
+      clearTimeout(timeout);
+      unsubscribe();
+      resolve(action.payload);
+    });
+
+    dispatch({
+      type: TELEPHONY_SERVER_SELECT_OPEN,
+      payload: { phoneNumber: link.phoneNumber, rawUri: link.rawUri },
+    });
+  });
+
+  if (!result) {
+    return null;
+  }
+
+  if (result.rememberChoice) {
+    dispatch({
+      type: TELEPHONY_PREFERRED_SERVER_SET,
+      payload: result.serverUrl,
+    });
+  }
+
+  return result.serverUrl;
+};
+
+export const openTelephonyDialpad = async (
+  link: TelephonyLink
+): Promise<void> => {
+  if (telephonyDialpadOpenInProgress) {
+    return;
+  }
+
+  telephonyDialpadOpenInProgress = true;
+
+  try {
+    const serverUrl = await selectTelephonyServerUrl(link);
+    if (!serverUrl) {
+      return;
+    }
+
+    const webContents = await getTelephonyWebContents(
+      serverUrl,
+      WEB_CONTENTS_TIMEOUT_MS
+    );
+    if (!webContents) {
+      return;
+    }
+
+    webContents.send('telephony/call-requested', {
+      phoneNumber: link.phoneNumber,
+      rawUri: link.rawUri,
+    });
+  } finally {
+    telephonyDialpadOpenInProgress = false;
+  }
+};

--- a/src/telephony/links.ts
+++ b/src/telephony/links.ts
@@ -1,0 +1,38 @@
+import type { TelephonyLink } from './common';
+
+const TELEPHONY_PROTOCOLS = ['tel:', 'callto:'];
+
+export const parseTelephonyLink = (input: string): TelephonyLink | null => {
+  if (/^--/.test(input)) {
+    return null;
+  }
+
+  let url: URL;
+
+  try {
+    url = new URL(input);
+  } catch {
+    return null;
+  }
+
+  if (!TELEPHONY_PROTOCOLS.includes(url.protocol)) {
+    return null;
+  }
+
+  let raw: string;
+  try {
+    raw = decodeURIComponent(
+      url.pathname || url.href.slice(url.protocol.length)
+    );
+  } catch {
+    return null;
+  }
+
+  const phoneNumber = raw.replace(/^\/+/, '').replace(/[\s\-().]/g, '');
+
+  if (!phoneNumber) {
+    return null;
+  }
+
+  return { phoneNumber, rawUri: input };
+};

--- a/src/telephony/main.spec.ts
+++ b/src/telephony/main.spec.ts
@@ -37,6 +37,7 @@ jest.mock('electron', () => {
       readText: jest.fn(),
     },
     globalShortcut: {
+      isRegistered: jest.fn(() => false),
       register: jest.fn(),
       unregister: jest.fn(),
     },
@@ -95,6 +96,7 @@ describe('telephony global shortcut main process pipeline', () => {
     jest.clearAllMocks();
     parseTelephonyLinkMock.mockReturnValue(null);
     getRootWindowMock.mockResolvedValue(rootWindow as any);
+    globalShortcutMock.isRegistered.mockReturnValue(false);
     globalShortcutMock.register.mockReturnValue(true);
   });
 
@@ -160,6 +162,39 @@ describe('telephony global shortcut main process pipeline', () => {
       phoneNumber: '',
       rawUri: '',
     });
+  });
+
+  it('skips parsing and opens empty input for empty clipboard text', () => {
+    expect(createTelephonyLinkFromClipboardText('   ')).toEqual({
+      phoneNumber: '',
+      rawUri: '',
+    });
+    expect(parseTelephonyLinkMock).not.toHaveBeenCalled();
+  });
+
+  it('caps clipboard text before parsing or sending it to the renderer', () => {
+    expect(createTelephonyLinkFromClipboardText('1'.repeat(257))).toEqual({
+      phoneNumber: '',
+      rawUri: '',
+    });
+    expect(parseTelephonyLinkMock).not.toHaveBeenCalled();
+  });
+
+  it('debounces repeated shortcut triggers', async () => {
+    const nowSpy = jest
+      .spyOn(Date, 'now')
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(1_100)
+      .mockReturnValueOnce(1_300);
+    clipboardMock.readText.mockReturnValue('+1 800 555 0199');
+
+    await triggerTelephonyGlobalShortcut();
+    await triggerTelephonyGlobalShortcut();
+    await triggerTelephonyGlobalShortcut();
+
+    expect(clipboardMock.readText).toHaveBeenCalledTimes(2);
+    expect(performTelephonyCallMock).toHaveBeenCalledTimes(2);
+    nowSpy.mockRestore();
   });
 
   it('preserves parsed tel/callto links from clipboard', () => {
@@ -241,6 +276,44 @@ describe('telephony global shortcut main process pipeline', () => {
     ).toHaveBeenCalled();
   });
 
+  it('rejects reserved app accelerators before registering', () => {
+    registerTelephonyGlobalShortcut({
+      enabled: true,
+      accelerator: 'CommandOrControl+C',
+    });
+
+    expect(globalShortcutMock.register).not.toHaveBeenCalled();
+    expect(dispatchMock).toHaveBeenLastCalledWith({
+      type: TELEPHONY_GLOBAL_SHORTCUT_REGISTRATION_CHANGED,
+      payload: {
+        registered: false,
+        accelerator: 'CommandOrControl+C',
+        error:
+          'Telephony shortcut CommandOrControl+C is reserved by the app or operating system',
+      },
+    });
+  });
+
+  it('reports accelerators already registered by Electron before registering', () => {
+    globalShortcutMock.isRegistered.mockReturnValue(true);
+
+    registerTelephonyGlobalShortcut({
+      enabled: true,
+      accelerator: 'CommandOrControl+Shift+D',
+    });
+
+    expect(globalShortcutMock.register).not.toHaveBeenCalled();
+    expect(dispatchMock).toHaveBeenLastCalledWith({
+      type: TELEPHONY_GLOBAL_SHORTCUT_REGISTRATION_CHANGED,
+      payload: {
+        registered: false,
+        accelerator: 'CommandOrControl+Shift+D',
+        error:
+          'Telephony shortcut CommandOrControl+Shift+D is already registered',
+      },
+    });
+  });
+
   it('watches config changes and unregisters on app close teardown', () => {
     const unsubscribe = jest.fn();
     let watcher: Parameters<typeof watchMock>[1] | undefined;
@@ -285,6 +358,30 @@ describe('telephony global shortcut main process pipeline', () => {
       'CommandOrControl+Shift+E'
     );
   });
+
+  it('unregisters the current accelerator when Electron emits will-quit', () => {
+    let willQuitHandler: (() => void) | undefined;
+    appMock.addListener.mockImplementation(((event: string, listener) => {
+      if (event === 'will-quit') {
+        willQuitHandler = listener as () => void;
+      }
+      return appMock;
+    }) as typeof appMock.addListener);
+    watchMock.mockImplementation((_selector, callback) => {
+      callback(
+        { enabled: true, accelerator: 'CommandOrControl+Shift+D' },
+        undefined
+      );
+      return jest.fn();
+    });
+
+    setupTelephonyGlobalShortcut();
+    willQuitHandler?.();
+
+    expect(globalShortcutMock.unregister).toHaveBeenCalledWith(
+      'CommandOrControl+Shift+D'
+    );
+  });
 });
 
 describe('telephony shortcut reducers', () => {
@@ -302,7 +399,7 @@ describe('telephony shortcut reducers', () => {
   it('keeps shortcut config disabled by default and stores UI-provided config', () => {
     expect(
       telephonyGlobalShortcutConfig(undefined, { type: 'UNKNOWN' } as any)
-    ).toBe(defaultTelephonyGlobalShortcutConfig);
+    ).toEqual(defaultTelephonyGlobalShortcutConfig);
 
     expect(
       telephonyGlobalShortcutConfig(defaultTelephonyGlobalShortcutConfig, {
@@ -337,7 +434,33 @@ describe('telephony shortcut reducers', () => {
           telephonyGlobalShortcutConfig: null as any,
         },
       })
-    ).toBe(defaultTelephonyGlobalShortcutConfig);
+    ).toEqual(defaultTelephonyGlobalShortcutConfig);
+  });
+
+  it('rejects non-string and oversized persisted shortcut accelerators', () => {
+    expect(
+      telephonyGlobalShortcutConfig(defaultTelephonyGlobalShortcutConfig, {
+        type: APP_SETTINGS_LOADED,
+        payload: {
+          telephonyGlobalShortcutConfig: {
+            enabled: true,
+            accelerator: 123 as any,
+          },
+        },
+      })
+    ).toEqual(defaultTelephonyGlobalShortcutConfig);
+
+    expect(
+      telephonyGlobalShortcutConfig(defaultTelephonyGlobalShortcutConfig, {
+        type: APP_SETTINGS_LOADED,
+        payload: {
+          telephonyGlobalShortcutConfig: {
+            enabled: true,
+            accelerator: 'A'.repeat(65),
+          },
+        },
+      })
+    ).toEqual(defaultTelephonyGlobalShortcutConfig);
   });
 
   it('stores registration status for Settings UI feedback', () => {

--- a/src/telephony/main.spec.ts
+++ b/src/telephony/main.spec.ts
@@ -1,0 +1,368 @@
+import { app, clipboard, globalShortcut, Notification } from 'electron';
+
+import { APP_SETTINGS_LOADED } from '../app/actions';
+import { performTelephonyCall, parseTelephonyLink } from '../deepLinks/main';
+import { dispatch, watch } from '../store';
+import { getRootWindow } from '../ui/main/rootWindow';
+import {
+  TELEPHONY_GLOBAL_SHORTCUT_CONFIG_SET,
+  TELEPHONY_GLOBAL_SHORTCUT_REGISTRATION_CHANGED,
+} from './actions';
+import {
+  createTelephonyLinkFromClipboardText,
+  registerTelephonyGlobalShortcut,
+  setupTelephonyGlobalShortcut,
+  teardownTelephonyGlobalShortcut,
+  triggerTelephonyGlobalShortcut,
+} from './main';
+import {
+  defaultTelephonyGlobalShortcutConfig,
+  defaultTelephonyGlobalShortcutRegistrationStatus,
+  telephonyGlobalShortcutConfig,
+  telephonyGlobalShortcutRegistrationStatus,
+  telephonyPreferredServer,
+} from './reducers';
+
+jest.mock('electron', () => {
+  const NotificationMock = jest.fn(() => ({
+    show: jest.fn(),
+  }));
+
+  return {
+    app: {
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+    },
+    clipboard: {
+      readText: jest.fn(),
+    },
+    globalShortcut: {
+      register: jest.fn(),
+      unregister: jest.fn(),
+    },
+    Notification: Object.assign(NotificationMock, {
+      isSupported: jest.fn(() => true),
+    }),
+  };
+});
+
+jest.mock('../deepLinks/main', () => ({
+  performTelephonyCall: jest.fn(() => Promise.resolve()),
+  parseTelephonyLink: jest.fn(),
+}));
+
+jest.mock('../logging', () => ({
+  logger: {
+    error: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+jest.mock('../store', () => ({
+  dispatch: jest.fn(),
+  watch: jest.fn(),
+}));
+
+jest.mock('../ui/main/rootWindow', () => ({
+  getRootWindow: jest.fn(),
+}));
+
+const appMock = app as jest.Mocked<typeof app>;
+const clipboardMock = clipboard as jest.Mocked<typeof clipboard>;
+const globalShortcutMock = globalShortcut as jest.Mocked<typeof globalShortcut>;
+const notificationMock = Notification as jest.Mocked<typeof Notification>;
+const performTelephonyCallMock = performTelephonyCall as jest.MockedFunction<
+  typeof performTelephonyCall
+>;
+const parseTelephonyLinkMock = parseTelephonyLink as jest.MockedFunction<
+  typeof parseTelephonyLink
+>;
+const dispatchMock = dispatch as jest.MockedFunction<typeof dispatch>;
+const watchMock = watch as jest.MockedFunction<typeof watch>;
+const getRootWindowMock = getRootWindow as jest.MockedFunction<
+  typeof getRootWindow
+>;
+
+describe('telephony global shortcut main process pipeline', () => {
+  const rootWindow = {
+    isVisible: jest.fn(() => false),
+    showInactive: jest.fn(),
+    focus: jest.fn(),
+  };
+
+  beforeEach(() => {
+    teardownTelephonyGlobalShortcut();
+    jest.clearAllMocks();
+    parseTelephonyLinkMock.mockReturnValue(null);
+    getRootWindowMock.mockResolvedValue(rootWindow as any);
+    globalShortcutMock.register.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    teardownTelephonyGlobalShortcut();
+  });
+
+  it('registers the configured accelerator and reports success', () => {
+    registerTelephonyGlobalShortcut({
+      enabled: true,
+      accelerator: 'CommandOrControl+Shift+D',
+    });
+
+    expect(globalShortcutMock.register).toHaveBeenCalledWith(
+      'CommandOrControl+Shift+D',
+      expect.any(Function)
+    );
+    expect(dispatchMock).toHaveBeenLastCalledWith({
+      type: TELEPHONY_GLOBAL_SHORTCUT_REGISTRATION_CHANGED,
+      payload: {
+        registered: true,
+        accelerator: 'CommandOrControl+Shift+D',
+        error: null,
+      },
+    });
+  });
+
+  it('reads clipboard only when triggered and routes usable clipboard text', async () => {
+    registerTelephonyGlobalShortcut({
+      enabled: true,
+      accelerator: 'CommandOrControl+Shift+D',
+    });
+
+    expect(clipboardMock.readText).not.toHaveBeenCalled();
+
+    clipboardMock.readText.mockReturnValue(' +1 (800) 555-0199 ');
+
+    await triggerTelephonyGlobalShortcut();
+
+    expect(rootWindow.showInactive).toHaveBeenCalled();
+    expect(rootWindow.focus).toHaveBeenCalled();
+    expect(performTelephonyCallMock).toHaveBeenCalledWith({
+      phoneNumber: '+1 (800) 555-0199',
+      rawUri: '+1 (800) 555-0199',
+    });
+  });
+
+  it('keeps common pasted phone number formats permissive', () => {
+    expect(
+      createTelephonyLinkFromClipboardText('Call +1 (800) 555-0199 x123')
+    ).toEqual({
+      phoneNumber: 'Call +1 (800) 555-0199 x123',
+      rawUri: 'Call +1 (800) 555-0199 x123',
+    });
+  });
+
+  it('opens the telephony path with empty input when clipboard is unusable', async () => {
+    clipboardMock.readText.mockReturnValue('not a phone number');
+
+    await triggerTelephonyGlobalShortcut();
+
+    expect(performTelephonyCallMock).toHaveBeenCalledWith({
+      phoneNumber: '',
+      rawUri: '',
+    });
+  });
+
+  it('preserves parsed tel/callto links from clipboard', () => {
+    parseTelephonyLinkMock.mockReturnValue({
+      phoneNumber: '+491234567890',
+      rawUri: 'tel:+491234567890',
+    });
+
+    expect(createTelephonyLinkFromClipboardText(' tel:+491234567890 ')).toEqual(
+      {
+        phoneNumber: '+491234567890',
+        rawUri: 'tel:+491234567890',
+      }
+    );
+  });
+
+  it('unregisters old accelerator when disabled or changed', () => {
+    registerTelephonyGlobalShortcut({
+      enabled: true,
+      accelerator: 'CommandOrControl+Shift+D',
+    });
+    registerTelephonyGlobalShortcut({
+      enabled: true,
+      accelerator: 'CommandOrControl+Shift+E',
+    });
+
+    expect(globalShortcutMock.unregister).toHaveBeenCalledWith(
+      'CommandOrControl+Shift+D'
+    );
+
+    registerTelephonyGlobalShortcut({ enabled: false, accelerator: null });
+
+    expect(globalShortcutMock.unregister).toHaveBeenCalledWith(
+      'CommandOrControl+Shift+E'
+    );
+  });
+
+  it('ignores malformed persisted config without throwing', () => {
+    expect(() => registerTelephonyGlobalShortcut(null)).not.toThrow();
+
+    expect(globalShortcutMock.register).not.toHaveBeenCalled();
+    expect(dispatchMock).toHaveBeenLastCalledWith({
+      type: TELEPHONY_GLOBAL_SHORTCUT_REGISTRATION_CHANGED,
+      payload: {
+        registered: false,
+        accelerator: null,
+        error: null,
+      },
+    });
+  });
+
+  it('handles registration conflicts without throwing and shows feedback', () => {
+    globalShortcutMock.register.mockReturnValue(false);
+
+    expect(() =>
+      registerTelephonyGlobalShortcut({
+        enabled: true,
+        accelerator: 'CommandOrControl+Shift+D',
+      })
+    ).not.toThrow();
+
+    expect(dispatchMock).toHaveBeenLastCalledWith({
+      type: TELEPHONY_GLOBAL_SHORTCUT_REGISTRATION_CHANGED,
+      payload: {
+        registered: false,
+        accelerator: 'CommandOrControl+Shift+D',
+        error:
+          'Telephony shortcut CommandOrControl+Shift+D registration failed',
+      },
+    });
+    expect(notificationMock.isSupported).toHaveBeenCalled();
+    expect(notificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('could not be registered'),
+      })
+    );
+    expect(
+      (notificationMock as unknown as jest.Mock).mock.results[0].value.show
+    ).toHaveBeenCalled();
+  });
+
+  it('watches config changes and unregisters on app close teardown', () => {
+    const unsubscribe = jest.fn();
+    let watcher: Parameters<typeof watchMock>[1] | undefined;
+
+    watchMock.mockImplementation((_selector, callback) => {
+      watcher = callback as typeof watcher;
+      callback(
+        { enabled: true, accelerator: 'CommandOrControl+Shift+D' },
+        undefined
+      );
+      return unsubscribe;
+    });
+
+    setupTelephonyGlobalShortcut();
+
+    expect(appMock.addListener).toHaveBeenCalledWith(
+      'will-quit',
+      teardownTelephonyGlobalShortcut
+    );
+    expect(globalShortcutMock.register).toHaveBeenCalledWith(
+      'CommandOrControl+Shift+D',
+      expect.any(Function)
+    );
+
+    watcher?.(
+      { enabled: true, accelerator: 'CommandOrControl+Shift+E' },
+      { enabled: true, accelerator: 'CommandOrControl+Shift+D' }
+    );
+
+    expect(globalShortcutMock.unregister).toHaveBeenCalledWith(
+      'CommandOrControl+Shift+D'
+    );
+
+    teardownTelephonyGlobalShortcut();
+
+    expect(unsubscribe).toHaveBeenCalled();
+    expect(appMock.removeListener).toHaveBeenCalledWith(
+      'will-quit',
+      teardownTelephonyGlobalShortcut
+    );
+    expect(globalShortcutMock.unregister).toHaveBeenCalledWith(
+      'CommandOrControl+Shift+E'
+    );
+  });
+});
+
+describe('telephony shortcut reducers', () => {
+  it('hydrates preferred server from persisted settings', () => {
+    expect(
+      telephonyPreferredServer(null, {
+        type: APP_SETTINGS_LOADED,
+        payload: {
+          telephonyPreferredServer: 'https://chat.example.com',
+        },
+      })
+    ).toBe('https://chat.example.com');
+  });
+
+  it('keeps shortcut config disabled by default and stores UI-provided config', () => {
+    expect(
+      telephonyGlobalShortcutConfig(undefined, { type: 'UNKNOWN' } as any)
+    ).toBe(defaultTelephonyGlobalShortcutConfig);
+
+    expect(
+      telephonyGlobalShortcutConfig(defaultTelephonyGlobalShortcutConfig, {
+        type: TELEPHONY_GLOBAL_SHORTCUT_CONFIG_SET,
+        payload: { enabled: true, accelerator: 'CommandOrControl+Shift+D' },
+      })
+    ).toEqual({ enabled: true, accelerator: 'CommandOrControl+Shift+D' });
+  });
+
+  it('hydrates shortcut config from persisted settings', () => {
+    expect(
+      telephonyGlobalShortcutConfig(defaultTelephonyGlobalShortcutConfig, {
+        type: APP_SETTINGS_LOADED,
+        payload: {
+          telephonyGlobalShortcutConfig: {
+            enabled: true,
+            accelerator: 'CommandOrControl+Shift+D',
+          },
+        },
+      })
+    ).toEqual({
+      enabled: true,
+      accelerator: 'CommandOrControl+Shift+D',
+    });
+  });
+
+  it('normalizes malformed persisted shortcut config', () => {
+    expect(
+      telephonyGlobalShortcutConfig(defaultTelephonyGlobalShortcutConfig, {
+        type: APP_SETTINGS_LOADED,
+        payload: {
+          telephonyGlobalShortcutConfig: null as any,
+        },
+      })
+    ).toBe(defaultTelephonyGlobalShortcutConfig);
+  });
+
+  it('stores registration status for Settings UI feedback', () => {
+    expect(
+      telephonyGlobalShortcutRegistrationStatus(undefined, {
+        type: 'UNKNOWN',
+      } as any)
+    ).toBe(defaultTelephonyGlobalShortcutRegistrationStatus);
+
+    expect(
+      telephonyGlobalShortcutRegistrationStatus(
+        defaultTelephonyGlobalShortcutRegistrationStatus,
+        {
+          type: TELEPHONY_GLOBAL_SHORTCUT_REGISTRATION_CHANGED,
+          payload: {
+            registered: false,
+            accelerator: 'CommandOrControl+Shift+D',
+            error: 'conflict',
+          },
+        }
+      )
+    ).toEqual({
+      registered: false,
+      accelerator: 'CommandOrControl+Shift+D',
+      error: 'conflict',
+    });
+  });
+});

--- a/src/telephony/main.spec.ts
+++ b/src/telephony/main.spec.ts
@@ -1,13 +1,15 @@
 import { app, clipboard, globalShortcut, Notification } from 'electron';
 
 import { APP_SETTINGS_LOADED } from '../app/actions';
-import { performTelephonyCall, parseTelephonyLink } from '../deepLinks/main';
 import { dispatch, watch } from '../store';
+import { SIDE_BAR_SETTINGS_BUTTON_CLICKED } from '../ui/actions';
 import { getRootWindow } from '../ui/main/rootWindow';
 import {
   TELEPHONY_GLOBAL_SHORTCUT_CONFIG_SET,
   TELEPHONY_GLOBAL_SHORTCUT_REGISTRATION_CHANGED,
 } from './actions';
+import type { openTelephonyDialpad } from './dialpad';
+import { parseTelephonyLink } from './links';
 import {
   createTelephonyLinkFromClipboardText,
   registerTelephonyGlobalShortcut,
@@ -25,6 +27,7 @@ import {
 
 jest.mock('electron', () => {
   const NotificationMock = jest.fn(() => ({
+    addListener: jest.fn(),
     show: jest.fn(),
   }));
 
@@ -47,8 +50,11 @@ jest.mock('electron', () => {
   };
 });
 
-jest.mock('../deepLinks/main', () => ({
-  performTelephonyCall: jest.fn(() => Promise.resolve()),
+jest.mock('./dialpad', () => ({
+  openTelephonyDialpad: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('./links', () => ({
   parseTelephonyLink: jest.fn(),
 }));
 
@@ -72,9 +78,14 @@ const appMock = app as jest.Mocked<typeof app>;
 const clipboardMock = clipboard as jest.Mocked<typeof clipboard>;
 const globalShortcutMock = globalShortcut as jest.Mocked<typeof globalShortcut>;
 const notificationMock = Notification as jest.Mocked<typeof Notification>;
-const performTelephonyCallMock = performTelephonyCall as jest.MockedFunction<
-  typeof performTelephonyCall
->;
+const getOpenTelephonyDialpadMock = (): jest.MockedFunction<
+  typeof openTelephonyDialpad
+> => {
+  const dialpad = jest.requireMock('./dialpad') as {
+    openTelephonyDialpad: jest.MockedFunction<typeof openTelephonyDialpad>;
+  };
+  return dialpad.openTelephonyDialpad;
+};
 const parseTelephonyLinkMock = parseTelephonyLink as jest.MockedFunction<
   typeof parseTelephonyLink
 >;
@@ -138,7 +149,7 @@ describe('telephony global shortcut main process pipeline', () => {
 
     expect(rootWindow.showInactive).toHaveBeenCalled();
     expect(rootWindow.focus).toHaveBeenCalled();
-    expect(performTelephonyCallMock).toHaveBeenCalledWith({
+    expect(getOpenTelephonyDialpadMock()).toHaveBeenCalledWith({
       phoneNumber: '+1 (800) 555-0199',
       rawUri: '+1 (800) 555-0199',
     });
@@ -158,7 +169,7 @@ describe('telephony global shortcut main process pipeline', () => {
 
     await triggerTelephonyGlobalShortcut();
 
-    expect(performTelephonyCallMock).toHaveBeenCalledWith({
+    expect(getOpenTelephonyDialpadMock()).toHaveBeenCalledWith({
       phoneNumber: '',
       rawUri: '',
     });
@@ -193,7 +204,7 @@ describe('telephony global shortcut main process pipeline', () => {
     await triggerTelephonyGlobalShortcut();
 
     expect(clipboardMock.readText).toHaveBeenCalledTimes(2);
-    expect(performTelephonyCallMock).toHaveBeenCalledTimes(2);
+    expect(getOpenTelephonyDialpadMock()).toHaveBeenCalledTimes(2);
     nowSpy.mockRestore();
   });
 
@@ -274,6 +285,29 @@ describe('telephony global shortcut main process pipeline', () => {
     expect(
       (notificationMock as unknown as jest.Mock).mock.results[0].value.show
     ).toHaveBeenCalled();
+  });
+
+  it('opens Settings when the registration failure notification is clicked', async () => {
+    globalShortcutMock.register.mockReturnValue(false);
+
+    registerTelephonyGlobalShortcut({
+      enabled: true,
+      accelerator: 'CommandOrControl+Shift+D',
+    });
+
+    const notification = (notificationMock as unknown as jest.Mock).mock
+      .results[0].value;
+    const clickListener = notification.addListener.mock.calls.find(
+      ([event]: [string]) => event === 'click'
+    )?.[1] as (() => void) | undefined;
+
+    clickListener?.();
+    await Promise.resolve();
+
+    expect(rootWindow.focus).toHaveBeenCalled();
+    expect(dispatchMock).toHaveBeenCalledWith({
+      type: SIDE_BAR_SETTINGS_BUTTON_CLICKED,
+    });
   });
 
   it('rejects reserved app accelerators before registering', () => {

--- a/src/telephony/main.spec.ts
+++ b/src/telephony/main.spec.ts
@@ -299,10 +299,9 @@ describe('telephony global shortcut main process pipeline', () => {
       .results[0].value;
     const clickListener = notification.addListener.mock.calls.find(
       ([event]: [string]) => event === 'click'
-    )?.[1] as (() => void) | undefined;
+    )?.[1] as (() => Promise<void>) | undefined;
 
-    clickListener?.();
-    await Promise.resolve();
+    await clickListener?.();
 
     expect(rootWindow.focus).toHaveBeenCalled();
     expect(dispatchMock).toHaveBeenCalledWith({

--- a/src/telephony/main.ts
+++ b/src/telephony/main.ts
@@ -8,6 +8,11 @@ import type { RootState } from '../store/rootReducer';
 import { getRootWindow } from '../ui/main/rootWindow';
 import { TELEPHONY_GLOBAL_SHORTCUT_REGISTRATION_CHANGED } from './actions';
 import type { TelephonyGlobalShortcutConfig } from './actions';
+import {
+  MAX_CLIPBOARD_PHONE_LENGTH,
+  isReservedTelephonyShortcutAccelerator,
+  normalizeTelephonyShortcutAccelerator,
+} from './shortcuts';
 
 const selectTelephonyGlobalShortcutConfig = ({
   telephonyGlobalShortcutConfig,
@@ -15,6 +20,9 @@ const selectTelephonyGlobalShortcutConfig = ({
 
 let registeredAccelerator: string | null = null;
 let unsubscribeFromShortcutConfig: (() => void) | null = null;
+let lastTelephonyShortcutTriggeredAt = 0;
+
+const TELEPHONY_GLOBAL_SHORTCUT_DEBOUNCE_MS = 250;
 
 const EMPTY_TELEPHONY_LINK: TelephonyLink = {
   phoneNumber: '',
@@ -33,10 +41,7 @@ const normalizeTelephonyGlobalShortcutConfig = (
     return DISABLED_SHORTCUT_CONFIG;
   }
 
-  const accelerator =
-    typeof config.accelerator === 'string' && config.accelerator.trim()
-      ? config.accelerator.trim()
-      : null;
+  const accelerator = normalizeTelephonyShortcutAccelerator(config.accelerator);
 
   return {
     enabled: config.enabled === true,
@@ -59,6 +64,9 @@ export const createTelephonyLinkFromClipboardText = (
   text: string
 ): TelephonyLink => {
   const trimmedText = text.trim();
+  if (!trimmedText || trimmedText.length > MAX_CLIPBOARD_PHONE_LENGTH) {
+    return EMPTY_TELEPHONY_LINK;
+  }
 
   const telephonyLink = parseTelephonyLink(trimmedText);
   if (telephonyLink) {
@@ -87,6 +95,16 @@ const focusRootWindow = async (): Promise<void> => {
 };
 
 export const triggerTelephonyGlobalShortcut = async (): Promise<void> => {
+  const now = Date.now();
+  if (
+    lastTelephonyShortcutTriggeredAt &&
+    now - lastTelephonyShortcutTriggeredAt <
+      TELEPHONY_GLOBAL_SHORTCUT_DEBOUNCE_MS
+  ) {
+    return;
+  }
+  lastTelephonyShortcutTriggeredAt = now;
+
   const telephonyLink = createTelephonyLinkFromClipboardText(
     clipboard.readText()
   );
@@ -153,6 +171,20 @@ export const registerTelephonyGlobalShortcut = (
   }
 
   try {
+    if (isReservedTelephonyShortcutAccelerator(accelerator)) {
+      const error = `Telephony shortcut ${accelerator} is reserved by the app or operating system`;
+      dispatchRegistrationStatus(false, accelerator, error);
+      notifyRegistrationFailure(accelerator, error);
+      return;
+    }
+
+    if (globalShortcut.isRegistered?.(accelerator)) {
+      const error = `Telephony shortcut ${accelerator} is already registered`;
+      dispatchRegistrationStatus(false, accelerator, error);
+      notifyRegistrationFailure(accelerator, error);
+      return;
+    }
+
     const registered = globalShortcut.register(accelerator, () => {
       void triggerTelephonyGlobalShortcut().catch((error) => {
         logger.error('Failed to handle telephony global shortcut', error);
@@ -193,6 +225,7 @@ export const setupTelephonyGlobalShortcut = (): void => {
 
 export const teardownTelephonyGlobalShortcut = (): void => {
   app.removeListener('will-quit', teardownTelephonyGlobalShortcut);
+  lastTelephonyShortcutTriggeredAt = 0;
 
   if (unsubscribeFromShortcutConfig) {
     unsubscribeFromShortcutConfig();

--- a/src/telephony/main.ts
+++ b/src/telephony/main.ts
@@ -1,13 +1,14 @@
 import { app, clipboard, globalShortcut, Notification } from 'electron';
 
-import { performTelephonyCall, parseTelephonyLink } from '../deepLinks/main';
-import type { TelephonyLink } from '../deepLinks/main';
 import { logger } from '../logging';
 import { dispatch, watch } from '../store';
 import type { RootState } from '../store/rootReducer';
+import { SIDE_BAR_SETTINGS_BUTTON_CLICKED } from '../ui/actions';
 import { getRootWindow } from '../ui/main/rootWindow';
 import { TELEPHONY_GLOBAL_SHORTCUT_REGISTRATION_CHANGED } from './actions';
 import type { TelephonyGlobalShortcutConfig } from './actions';
+import type { TelephonyLink } from './common';
+import { parseTelephonyLink } from './links';
 import {
   MAX_CLIPBOARD_PHONE_LENGTH,
   isReservedTelephonyShortcutAccelerator,
@@ -109,8 +110,10 @@ export const triggerTelephonyGlobalShortcut = async (): Promise<void> => {
     clipboard.readText()
   );
 
+  const { openTelephonyDialpad } = await import('./dialpad');
+
   await focusRootWindow();
-  await performTelephonyCall(telephonyLink);
+  await openTelephonyDialpad(telephonyLink);
 };
 
 const notifyRegistrationFailure = (
@@ -124,10 +127,16 @@ const notifyRegistrationFailure = (
       return;
     }
 
-    new Notification({
+    const notification = new Notification({
       title: 'Rocket.Chat',
       body: `Telephony shortcut ${accelerator} could not be registered. It may already be in use.`,
-    }).show();
+    });
+    notification.addListener('click', () => {
+      void focusRootWindow().finally(() => {
+        dispatch({ type: SIDE_BAR_SETTINGS_BUTTON_CLICKED });
+      });
+    });
+    notification.show();
   } catch (notificationError) {
     logger.warn('Failed to show telephony shortcut registration feedback');
     logger.warn(notificationError);

--- a/src/telephony/main.ts
+++ b/src/telephony/main.ts
@@ -1,0 +1,203 @@
+import { app, clipboard, globalShortcut, Notification } from 'electron';
+
+import { performTelephonyCall, parseTelephonyLink } from '../deepLinks/main';
+import type { TelephonyLink } from '../deepLinks/main';
+import { logger } from '../logging';
+import { dispatch, watch } from '../store';
+import type { RootState } from '../store/rootReducer';
+import { getRootWindow } from '../ui/main/rootWindow';
+import { TELEPHONY_GLOBAL_SHORTCUT_REGISTRATION_CHANGED } from './actions';
+import type { TelephonyGlobalShortcutConfig } from './actions';
+
+const selectTelephonyGlobalShortcutConfig = ({
+  telephonyGlobalShortcutConfig,
+}: RootState): TelephonyGlobalShortcutConfig => telephonyGlobalShortcutConfig;
+
+let registeredAccelerator: string | null = null;
+let unsubscribeFromShortcutConfig: (() => void) | null = null;
+
+const EMPTY_TELEPHONY_LINK: TelephonyLink = {
+  phoneNumber: '',
+  rawUri: '',
+};
+
+const DISABLED_SHORTCUT_CONFIG: TelephonyGlobalShortcutConfig = {
+  enabled: false,
+  accelerator: null,
+};
+
+const normalizeTelephonyGlobalShortcutConfig = (
+  config: TelephonyGlobalShortcutConfig | null | undefined
+): TelephonyGlobalShortcutConfig => {
+  if (!config || typeof config !== 'object') {
+    return DISABLED_SHORTCUT_CONFIG;
+  }
+
+  const accelerator =
+    typeof config.accelerator === 'string' && config.accelerator.trim()
+      ? config.accelerator.trim()
+      : null;
+
+  return {
+    enabled: config.enabled === true,
+    accelerator,
+  };
+};
+
+const extractClipboardPhoneNumber = (text: string): string | null => {
+  const trimmedText = text.trim();
+  const digitCount = (trimmedText.match(/\d/g) ?? []).length;
+
+  if (digitCount < 3) {
+    return null;
+  }
+
+  return trimmedText;
+};
+
+export const createTelephonyLinkFromClipboardText = (
+  text: string
+): TelephonyLink => {
+  const trimmedText = text.trim();
+
+  const telephonyLink = parseTelephonyLink(trimmedText);
+  if (telephonyLink) {
+    return telephonyLink;
+  }
+
+  const phoneNumber = extractClipboardPhoneNumber(trimmedText);
+  if (!phoneNumber) {
+    return EMPTY_TELEPHONY_LINK;
+  }
+
+  return {
+    phoneNumber,
+    rawUri: trimmedText,
+  };
+};
+
+const focusRootWindow = async (): Promise<void> => {
+  const browserWindow = await getRootWindow();
+
+  if (!browserWindow.isVisible()) {
+    browserWindow.showInactive();
+  }
+
+  browserWindow.focus();
+};
+
+export const triggerTelephonyGlobalShortcut = async (): Promise<void> => {
+  const telephonyLink = createTelephonyLinkFromClipboardText(
+    clipboard.readText()
+  );
+
+  await focusRootWindow();
+  await performTelephonyCall(telephonyLink);
+};
+
+const notifyRegistrationFailure = (
+  accelerator: string,
+  error: string
+): void => {
+  logger.warn(error);
+
+  try {
+    if (!Notification.isSupported()) {
+      return;
+    }
+
+    new Notification({
+      title: 'Rocket.Chat',
+      body: `Telephony shortcut ${accelerator} could not be registered. It may already be in use.`,
+    }).show();
+  } catch (notificationError) {
+    logger.warn('Failed to show telephony shortcut registration feedback');
+    logger.warn(notificationError);
+  }
+};
+
+const dispatchRegistrationStatus = (
+  registered: boolean,
+  accelerator: string | null,
+  error: string | null
+): void => {
+  dispatch({
+    type: TELEPHONY_GLOBAL_SHORTCUT_REGISTRATION_CHANGED,
+    payload: {
+      registered,
+      accelerator,
+      error,
+    },
+  });
+};
+
+export const unregisterTelephonyGlobalShortcut = (): void => {
+  if (registeredAccelerator) {
+    globalShortcut.unregister(registeredAccelerator);
+    registeredAccelerator = null;
+  }
+
+  dispatchRegistrationStatus(false, null, null);
+};
+
+export const registerTelephonyGlobalShortcut = (
+  config: TelephonyGlobalShortcutConfig | null | undefined
+): void => {
+  const { enabled, accelerator } =
+    normalizeTelephonyGlobalShortcutConfig(config);
+
+  unregisterTelephonyGlobalShortcut();
+
+  if (!enabled || !accelerator) {
+    return;
+  }
+
+  try {
+    const registered = globalShortcut.register(accelerator, () => {
+      void triggerTelephonyGlobalShortcut().catch((error) => {
+        logger.error('Failed to handle telephony global shortcut', error);
+      });
+    });
+
+    if (!registered) {
+      const error = `Telephony shortcut ${accelerator} registration failed`;
+      dispatchRegistrationStatus(false, accelerator, error);
+      notifyRegistrationFailure(accelerator, error);
+      return;
+    }
+
+    registeredAccelerator = accelerator;
+    dispatchRegistrationStatus(true, accelerator, null);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const failureMessage = `Telephony shortcut ${accelerator} registration failed: ${message}`;
+    dispatchRegistrationStatus(false, accelerator, failureMessage);
+    notifyRegistrationFailure(accelerator, failureMessage);
+  }
+};
+
+export const setupTelephonyGlobalShortcut = (): void => {
+  if (unsubscribeFromShortcutConfig) {
+    return;
+  }
+
+  unsubscribeFromShortcutConfig = watch(
+    selectTelephonyGlobalShortcutConfig,
+    (config) => {
+      registerTelephonyGlobalShortcut(config);
+    }
+  );
+
+  app.addListener('will-quit', teardownTelephonyGlobalShortcut);
+};
+
+export const teardownTelephonyGlobalShortcut = (): void => {
+  app.removeListener('will-quit', teardownTelephonyGlobalShortcut);
+
+  if (unsubscribeFromShortcutConfig) {
+    unsubscribeFromShortcutConfig();
+    unsubscribeFromShortcutConfig = null;
+  }
+
+  unregisterTelephonyGlobalShortcut();
+};

--- a/src/telephony/main.ts
+++ b/src/telephony/main.ts
@@ -131,11 +131,18 @@ const notifyRegistrationFailure = (
       title: 'Rocket.Chat',
       body: `Telephony shortcut ${accelerator} could not be registered. It may already be in use.`,
     });
-    notification.addListener('click', () => {
-      void focusRootWindow().finally(() => {
-        dispatch({ type: SIDE_BAR_SETTINGS_BUTTON_CLICKED });
-      });
-    });
+    notification.addListener('click', () =>
+      focusRootWindow()
+        .catch((error) => {
+          logger.warn(
+            'Failed to focus Rocket.Chat from telephony shortcut notification'
+          );
+          logger.warn(error);
+        })
+        .finally(() => {
+          dispatch({ type: SIDE_BAR_SETTINGS_BUTTON_CLICKED });
+        })
+    );
     notification.show();
   } catch (notificationError) {
     logger.warn('Failed to show telephony shortcut registration feedback');

--- a/src/telephony/reducers.ts
+++ b/src/telephony/reducers.ts
@@ -1,11 +1,59 @@
 import type { Reducer } from 'redux';
 
+import { APP_SETTINGS_LOADED } from '../app/actions';
 import type { ActionOf } from '../store/actions';
-import { TELEPHONY_PREFERRED_SERVER_SET } from './actions';
+import {
+  TELEPHONY_GLOBAL_SHORTCUT_CONFIG_SET,
+  TELEPHONY_GLOBAL_SHORTCUT_REGISTRATION_CHANGED,
+  TELEPHONY_PREFERRED_SERVER_SET,
+} from './actions';
+import type {
+  TelephonyGlobalShortcutConfig,
+  TelephonyGlobalShortcutRegistrationStatus,
+} from './actions';
 
-type TelephonyPreferredServerAction = ActionOf<
-  typeof TELEPHONY_PREFERRED_SERVER_SET
+type TelephonyPreferredServerAction =
+  | ActionOf<typeof TELEPHONY_PREFERRED_SERVER_SET>
+  | ActionOf<typeof APP_SETTINGS_LOADED>;
+
+type TelephonyGlobalShortcutConfigAction =
+  | ActionOf<typeof TELEPHONY_GLOBAL_SHORTCUT_CONFIG_SET>
+  | ActionOf<typeof APP_SETTINGS_LOADED>;
+
+type TelephonyGlobalShortcutRegistrationStatusAction = ActionOf<
+  typeof TELEPHONY_GLOBAL_SHORTCUT_REGISTRATION_CHANGED
 >;
+
+export const defaultTelephonyGlobalShortcutConfig: TelephonyGlobalShortcutConfig =
+  {
+    enabled: false,
+    accelerator: null,
+  };
+
+export const defaultTelephonyGlobalShortcutRegistrationStatus: TelephonyGlobalShortcutRegistrationStatus =
+  {
+    registered: false,
+    accelerator: null,
+    error: null,
+  };
+
+const normalizeTelephonyGlobalShortcutConfig = (
+  config: Partial<TelephonyGlobalShortcutConfig> | null | undefined
+): TelephonyGlobalShortcutConfig => {
+  if (!config || typeof config !== 'object') {
+    return defaultTelephonyGlobalShortcutConfig;
+  }
+
+  const accelerator =
+    typeof config.accelerator === 'string' && config.accelerator.trim()
+      ? config.accelerator.trim()
+      : null;
+
+  return {
+    enabled: config.enabled === true && Boolean(accelerator),
+    accelerator,
+  };
+};
 
 export const telephonyPreferredServer: Reducer<
   string | null,
@@ -13,6 +61,44 @@ export const telephonyPreferredServer: Reducer<
 > = (state = null, action) => {
   switch (action.type) {
     case TELEPHONY_PREFERRED_SERVER_SET:
+      return action.payload;
+
+    case APP_SETTINGS_LOADED: {
+      const { telephonyPreferredServer = state } = action.payload;
+      return telephonyPreferredServer;
+    }
+
+    default:
+      return state;
+  }
+};
+
+export const telephonyGlobalShortcutConfig: Reducer<
+  TelephonyGlobalShortcutConfig,
+  TelephonyGlobalShortcutConfigAction
+> = (state = defaultTelephonyGlobalShortcutConfig, action) => {
+  switch (action.type) {
+    case TELEPHONY_GLOBAL_SHORTCUT_CONFIG_SET:
+      return normalizeTelephonyGlobalShortcutConfig(action.payload);
+
+    case APP_SETTINGS_LOADED: {
+      const { telephonyGlobalShortcutConfig = state } = action.payload;
+      return normalizeTelephonyGlobalShortcutConfig(
+        telephonyGlobalShortcutConfig
+      );
+    }
+
+    default:
+      return state;
+  }
+};
+
+export const telephonyGlobalShortcutRegistrationStatus: Reducer<
+  TelephonyGlobalShortcutRegistrationStatus,
+  TelephonyGlobalShortcutRegistrationStatusAction
+> = (state = defaultTelephonyGlobalShortcutRegistrationStatus, action) => {
+  switch (action.type) {
+    case TELEPHONY_GLOBAL_SHORTCUT_REGISTRATION_CHANGED:
       return action.payload;
 
     default:

--- a/src/telephony/reducers.ts
+++ b/src/telephony/reducers.ts
@@ -11,6 +11,7 @@ import type {
   TelephonyGlobalShortcutConfig,
   TelephonyGlobalShortcutRegistrationStatus,
 } from './actions';
+import { normalizeTelephonyShortcutAccelerator } from './shortcuts';
 
 type TelephonyPreferredServerAction =
   | ActionOf<typeof TELEPHONY_PREFERRED_SERVER_SET>
@@ -44,10 +45,9 @@ const normalizeTelephonyGlobalShortcutConfig = (
     return defaultTelephonyGlobalShortcutConfig;
   }
 
-  const accelerator =
-    typeof config.accelerator === 'string' && config.accelerator.trim()
-      ? config.accelerator.trim()
-      : null;
+  const accelerator = normalizeTelephonyShortcutAccelerator(
+    config.accelerator
+  );
 
   return {
     enabled: config.enabled === true && Boolean(accelerator),

--- a/src/telephony/renderer/preload.spec.ts
+++ b/src/telephony/renderer/preload.spec.ts
@@ -105,6 +105,22 @@ describe('telephony/preload', () => {
     expect(cb).toHaveBeenCalledWith(payload);
   });
 
+  it('delivers empty phone payloads so the renderer can open an empty dial pad', () => {
+    listenToTelephonyRequests();
+
+    const cb = jest.fn();
+    onTelephonyCallRequested(cb);
+
+    const payload: TelephonyPayload = {
+      phoneNumber: '',
+      rawUri: '',
+    };
+    fireIpcEvent(payload);
+
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledWith(payload);
+  });
+
   it('replacing callback: next IPC event fires the new callback only', () => {
     listenToTelephonyRequests();
 

--- a/src/telephony/shortcuts.ts
+++ b/src/telephony/shortcuts.ts
@@ -1,0 +1,39 @@
+export const MAX_CLIPBOARD_PHONE_LENGTH = 256;
+export const MAX_TELEPHONY_SHORTCUT_ACCELERATOR_LENGTH = 64;
+
+const normalizeAccelerator = (accelerator: string): string =>
+  accelerator
+    .replace(/\s+/g, '')
+    .replace(/cmd/gi, 'command')
+    .replace(/ctrl/gi, 'control')
+    .toLowerCase();
+
+const RESERVED_ACCELERATORS = new Set(
+  ['C', 'V', 'X', 'A', 'Z', 'Q', 'W', 'N', ','].flatMap((key) => [
+    `commandorcontrol+${key.toLowerCase()}`,
+    `command+${key.toLowerCase()}`,
+    `control+${key.toLowerCase()}`,
+  ])
+);
+
+export const normalizeTelephonyShortcutAccelerator = (
+  accelerator: unknown
+): string | null => {
+  if (typeof accelerator !== 'string') {
+    return null;
+  }
+
+  const trimmedAccelerator = accelerator.trim();
+  if (
+    !trimmedAccelerator ||
+    trimmedAccelerator.length > MAX_TELEPHONY_SHORTCUT_ACCELERATOR_LENGTH
+  ) {
+    return null;
+  }
+
+  return trimmedAccelerator;
+};
+
+export const isReservedTelephonyShortcutAccelerator = (
+  accelerator: string
+): boolean => RESERVED_ACCELERATORS.has(normalizeAccelerator(accelerator));

--- a/src/ui/components/SettingsView/GeneralTab.tsx
+++ b/src/ui/components/SettingsView/GeneralTab.tsx
@@ -12,6 +12,7 @@ import { OutlookCalendarSyncInterval } from './features/OutlookCalendarSyncInter
 import { ReportErrors } from './features/ReportErrors';
 import { ScreenCaptureFallback } from './features/ScreenCaptureFallback';
 import { SideBar } from './features/SideBar';
+import { TelephonyGlobalShortcut } from './features/TelephonyGlobalShortcut';
 import { TelephonyServer } from './features/TelephonyServer';
 import { ThemeAppearance } from './features/ThemeAppearance';
 import { TransparentWindow } from './features/TransparentWindow';
@@ -36,6 +37,7 @@ export const GeneralTab = () => (
       <ThemeAppearance />
       <AvailableBrowsers />
       <OutlookCalendarSyncInterval />
+      <TelephonyGlobalShortcut />
       <TelephonyServer />
       {!process.mas && <ClearPermittedScreenCaptureServers />}
     </FieldGroup>

--- a/src/ui/components/SettingsView/features/TelephonyGlobalShortcut.spec.tsx
+++ b/src/ui/components/SettingsView/features/TelephonyGlobalShortcut.spec.tsx
@@ -1,0 +1,145 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+
+import type { RootState } from '../../../../store/rootReducer';
+import { TELEPHONY_GLOBAL_SHORTCUT_CONFIG_SET } from '../../../../telephony/actions';
+import { TelephonyGlobalShortcut } from './TelephonyGlobalShortcut';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('@rocket.chat/fuselage', () => ({
+  Box: ({ children, is: component = 'div', ...props }: any) => {
+    const Component = component;
+    return <Component {...props}>{children}</Component>;
+  },
+  Button: ({ children, ...props }: any) => (
+    <button {...props}>{children}</button>
+  ),
+  Field: ({ children }: any) => <div>{children}</div>,
+  FieldHint: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  FieldLabel: ({ children, ...props }: any) => (
+    <label {...props}>{children}</label>
+  ),
+  FieldRow: ({ children }: any) => <div>{children}</div>,
+  TextInput: (props: any) => <input {...props} />,
+}));
+
+type PartialState = Pick<
+  RootState,
+  'telephonyGlobalShortcutConfig' | 'telephonyGlobalShortcutRegistrationStatus'
+>;
+
+const makeStore = (partial: PartialState) => {
+  const reducer = (state: PartialState = partial) => state;
+  return createStore(reducer as any);
+};
+
+const defaultState: PartialState = {
+  telephonyGlobalShortcutConfig: {
+    enabled: false,
+    accelerator: null,
+  },
+  telephonyGlobalShortcutRegistrationStatus: {
+    registered: false,
+    accelerator: null,
+    error: null,
+  },
+};
+
+describe('TelephonyGlobalShortcut', () => {
+  it('saves a manually entered accelerator', () => {
+    const store = makeStore(defaultState);
+    const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+    render(
+      <Provider store={store}>
+        <TelephonyGlobalShortcut />
+      </Provider>
+    );
+
+    fireEvent.change(screen.getByTestId('telephony-shortcut-input'), {
+      target: { value: 'CommandOrControl+Shift+D' },
+    });
+    fireEvent.click(screen.getByTestId('telephony-shortcut-save'));
+
+    expect(dispatchSpy).toHaveBeenCalledWith({
+      type: TELEPHONY_GLOBAL_SHORTCUT_CONFIG_SET,
+      payload: {
+        enabled: true,
+        accelerator: 'CommandOrControl+Shift+D',
+      },
+    });
+  });
+
+  it('captures a pressed key chord into Electron accelerator syntax', () => {
+    const store = makeStore(defaultState);
+
+    render(
+      <Provider store={store}>
+        <TelephonyGlobalShortcut />
+      </Provider>
+    );
+
+    const input = screen.getByTestId('telephony-shortcut-input');
+    fireEvent.keyDown(input, {
+      key: 'd',
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    expect(input).toHaveValue('CommandOrControl+Shift+D');
+  });
+
+  it('clears the accelerator and disables registration', () => {
+    const store = makeStore({
+      ...defaultState,
+      telephonyGlobalShortcutConfig: {
+        enabled: true,
+        accelerator: 'CommandOrControl+Shift+D',
+      },
+    });
+    const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+    render(
+      <Provider store={store}>
+        <TelephonyGlobalShortcut />
+      </Provider>
+    );
+
+    fireEvent.click(screen.getByTestId('telephony-shortcut-clear'));
+
+    expect(dispatchSpy).toHaveBeenCalledWith({
+      type: TELEPHONY_GLOBAL_SHORTCUT_CONFIG_SET,
+      payload: {
+        enabled: false,
+        accelerator: null,
+      },
+    });
+  });
+
+  it('shows registration failure feedback from main process status', () => {
+    const store = makeStore({
+      telephonyGlobalShortcutConfig: {
+        enabled: true,
+        accelerator: 'CommandOrControl+Shift+D',
+      },
+      telephonyGlobalShortcutRegistrationStatus: {
+        registered: false,
+        accelerator: 'CommandOrControl+Shift+D',
+        error: 'Shortcut already in use',
+      },
+    });
+
+    render(
+      <Provider store={store}>
+        <TelephonyGlobalShortcut />
+      </Provider>
+    );
+
+    expect(screen.getByText('Shortcut already in use')).toBeInTheDocument();
+  });
+});

--- a/src/ui/components/SettingsView/features/TelephonyGlobalShortcut.spec.tsx
+++ b/src/ui/components/SettingsView/features/TelephonyGlobalShortcut.spec.tsx
@@ -101,6 +101,34 @@ describe('TelephonyGlobalShortcut', () => {
     expect(input).toHaveValue('CommandOrControl+Shift+D');
   });
 
+  it('shows capture placeholder while the shortcut input is focused', () => {
+    const store = makeStore(defaultState);
+
+    render(
+      <Provider store={store}>
+        <TelephonyGlobalShortcut />
+      </Provider>
+    );
+
+    const input = screen.getByTestId('telephony-shortcut-input');
+    expect(input).toHaveAttribute(
+      'placeholder',
+      'settings.options.telephonyShortcut.placeholder'
+    );
+
+    fireEvent.focus(input);
+    expect(input).toHaveAttribute(
+      'placeholder',
+      'settings.options.telephonyShortcut.capturePlaceholder'
+    );
+
+    fireEvent.blur(input);
+    expect(input).toHaveAttribute(
+      'placeholder',
+      'settings.options.telephonyShortcut.placeholder'
+    );
+  });
+
   it('clears the accelerator and disables registration', () => {
     const store = makeStore({
       ...defaultState,
@@ -189,6 +217,10 @@ describe('TelephonyGlobalShortcut', () => {
     fireEvent.keyDown(input, { key: 'Escape' });
 
     expect(input).toHaveValue('CommandOrControl+Shift+D');
+    expect(input).toHaveAttribute(
+      'placeholder',
+      'settings.options.telephonyShortcut.placeholder'
+    );
   });
 
   it('shows registration failure feedback from main process status', () => {

--- a/src/ui/components/SettingsView/features/TelephonyGlobalShortcut.spec.tsx
+++ b/src/ui/components/SettingsView/features/TelephonyGlobalShortcut.spec.tsx
@@ -12,11 +12,18 @@ jest.mock('react-i18next', () => ({
 }));
 
 jest.mock('@rocket.chat/fuselage', () => ({
-  Box: ({ children, is: component = 'div', ...props }: any) => {
+  Box: ({
+    children,
+    is: component = 'div',
+    display: _display,
+    alignItems: _alignItems,
+    flexGrow: _flexGrow,
+    ...props
+  }: any) => {
     const Component = component;
     return <Component {...props}>{children}</Component>;
   },
-  Button: ({ children, ...props }: any) => (
+  Button: ({ children, mis: _mis, ...props }: any) => (
     <button {...props}>{children}</button>
   ),
   Field: ({ children }: any) => <div>{children}</div>,
@@ -119,6 +126,69 @@ describe('TelephonyGlobalShortcut', () => {
         accelerator: null,
       },
     });
+  });
+
+  it('does not save reserved copy/paste accelerators', () => {
+    const store = makeStore(defaultState);
+    const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+    render(
+      <Provider store={store}>
+        <TelephonyGlobalShortcut />
+      </Provider>
+    );
+
+    fireEvent.change(screen.getByTestId('telephony-shortcut-input'), {
+      target: { value: 'CommandOrControl+C' },
+    });
+    fireEvent.click(screen.getByTestId('telephony-shortcut-save'));
+
+    expect(dispatchSpy).not.toHaveBeenCalled();
+    expect(
+      screen.getByText('settings.options.telephonyShortcut.reservedAccelerator')
+    ).toBeInTheDocument();
+  });
+
+  it('does not save accelerators used by the app menu', () => {
+    const store = makeStore(defaultState);
+    const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+    render(
+      <Provider store={store}>
+        <TelephonyGlobalShortcut />
+      </Provider>
+    );
+
+    fireEvent.change(screen.getByTestId('telephony-shortcut-input'), {
+      target: { value: 'CommandOrControl+N' },
+    });
+    fireEvent.click(screen.getByTestId('telephony-shortcut-save'));
+
+    expect(dispatchSpy).not.toHaveBeenCalled();
+  });
+
+  it('restores the saved accelerator when capture is cancelled with Escape', () => {
+    const store = makeStore({
+      ...defaultState,
+      telephonyGlobalShortcutConfig: {
+        enabled: true,
+        accelerator: 'CommandOrControl+Shift+D',
+      },
+    });
+
+    render(
+      <Provider store={store}>
+        <TelephonyGlobalShortcut />
+      </Provider>
+    );
+
+    const input = screen.getByTestId('telephony-shortcut-input');
+    fireEvent.change(input, {
+      target: { value: 'CommandOrControl+Shift+E' },
+    });
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(input).toHaveValue('CommandOrControl+Shift+D');
   });
 
   it('shows registration failure feedback from main process status', () => {

--- a/src/ui/components/SettingsView/features/TelephonyGlobalShortcut.tsx
+++ b/src/ui/components/SettingsView/features/TelephonyGlobalShortcut.tsx
@@ -1,0 +1,181 @@
+import {
+  Box,
+  Button,
+  Field,
+  FieldHint,
+  FieldLabel,
+  FieldRow,
+  TextInput,
+} from '@rocket.chat/fuselage';
+import type { ChangeEvent, KeyboardEvent } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
+import type { Dispatch } from 'redux';
+
+import type { RootAction } from '../../../../store/actions';
+import type { RootState } from '../../../../store/rootReducer';
+import { TELEPHONY_GLOBAL_SHORTCUT_CONFIG_SET } from '../../../../telephony/actions';
+
+const normalizeShortcutText = (value: string): string => value.trim();
+
+const keyToAcceleratorPart = (key: string): string | null => {
+  if (['Control', 'Meta', 'Shift', 'Alt'].includes(key)) {
+    return null;
+  }
+
+  if (key === ' ') {
+    return 'Space';
+  }
+
+  if (/^[a-z]$/i.test(key)) {
+    return key.toUpperCase();
+  }
+
+  return key.length === 1 ? key.toUpperCase() : key;
+};
+
+const eventToAccelerator = (event: KeyboardEvent<HTMLInputElement>) => {
+  const key = keyToAcceleratorPart(event.key);
+  if (!key) {
+    return null;
+  }
+
+  const parts = [];
+
+  if (event.ctrlKey || event.metaKey) {
+    parts.push('CommandOrControl');
+  }
+
+  if (event.altKey) {
+    parts.push('Alt');
+  }
+
+  if (event.shiftKey) {
+    parts.push('Shift');
+  }
+
+  parts.push(key);
+
+  return parts.join('+');
+};
+
+export const TelephonyGlobalShortcut = () => {
+  const { t } = useTranslation();
+  const dispatch = useDispatch<Dispatch<RootAction>>();
+  const telephonyGlobalShortcutConfig = useSelector(
+    ({ telephonyGlobalShortcutConfig }: RootState) =>
+      telephonyGlobalShortcutConfig
+  );
+  const telephonyGlobalShortcutRegistrationStatus = useSelector(
+    ({ telephonyGlobalShortcutRegistrationStatus }: RootState) =>
+      telephonyGlobalShortcutRegistrationStatus
+  );
+  const [draftAccelerator, setDraftAccelerator] = useState(
+    telephonyGlobalShortcutConfig.accelerator ?? ''
+  );
+
+  useEffect(() => {
+    setDraftAccelerator(telephonyGlobalShortcutConfig.accelerator ?? '');
+  }, [telephonyGlobalShortcutConfig.accelerator]);
+
+  const saveShortcut = useCallback(
+    (value: string) => {
+      const accelerator = normalizeShortcutText(value);
+      dispatch({
+        type: TELEPHONY_GLOBAL_SHORTCUT_CONFIG_SET,
+        payload: {
+          enabled: Boolean(accelerator),
+          accelerator: accelerator || null,
+        },
+      });
+    },
+    [dispatch]
+  );
+
+  const handleChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setDraftAccelerator(event.currentTarget.value);
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      const accelerator = eventToAccelerator(event);
+      if (!accelerator) {
+        return;
+      }
+
+      event.preventDefault();
+      setDraftAccelerator(accelerator);
+    },
+    []
+  );
+
+  const handleSave = useCallback(() => {
+    saveShortcut(draftAccelerator);
+  }, [draftAccelerator, saveShortcut]);
+
+  const handleClear = useCallback(() => {
+    setDraftAccelerator('');
+    saveShortcut('');
+  }, [saveShortcut]);
+
+  const isRegistered =
+    telephonyGlobalShortcutConfig.enabled &&
+    telephonyGlobalShortcutRegistrationStatus.registered &&
+    telephonyGlobalShortcutRegistrationStatus.accelerator ===
+      telephonyGlobalShortcutConfig.accelerator;
+
+  return (
+    <Field>
+      <FieldRow>
+        <FieldLabel>{t('settings.options.telephonyShortcut.title')}</FieldLabel>
+      </FieldRow>
+      <FieldRow>
+        <FieldHint>
+          {t('settings.options.telephonyShortcut.description')}
+        </FieldHint>
+      </FieldRow>
+      <FieldRow>
+        <Box display='flex' alignItems='center' flexGrow={1}>
+          <TextInput
+            data-testid='telephony-shortcut-input'
+            value={draftAccelerator}
+            placeholder={t('settings.options.telephonyShortcut.placeholder')}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+          />
+          <Button
+            data-testid='telephony-shortcut-save'
+            type='button'
+            onClick={handleSave}
+            mis='x8'
+          >
+            {t('settings.options.telephonyShortcut.save')}
+          </Button>
+          <Button
+            data-testid='telephony-shortcut-clear'
+            type='button'
+            onClick={handleClear}
+            mis='x8'
+          >
+            {t('settings.options.telephonyShortcut.clear')}
+          </Button>
+        </Box>
+      </FieldRow>
+      {telephonyGlobalShortcutRegistrationStatus.error && (
+        <FieldRow>
+          <FieldHint color='danger'>
+            {telephonyGlobalShortcutRegistrationStatus.error}
+          </FieldHint>
+        </FieldRow>
+      )}
+      {isRegistered && (
+        <FieldRow>
+          <FieldHint>
+            {t('settings.options.telephonyShortcut.registered')}
+          </FieldHint>
+        </FieldRow>
+      )}
+    </Field>
+  );
+};

--- a/src/ui/components/SettingsView/features/TelephonyGlobalShortcut.tsx
+++ b/src/ui/components/SettingsView/features/TelephonyGlobalShortcut.tsx
@@ -79,6 +79,7 @@ export const TelephonyGlobalShortcut = () => {
   const [draftAccelerator, setDraftAccelerator] = useState(
     telephonyGlobalShortcutConfig.accelerator ?? ''
   );
+  const [isCapturingShortcut, setIsCapturingShortcut] = useState(false);
   const [validationError, setValidationError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -113,12 +114,21 @@ export const TelephonyGlobalShortcut = () => {
     setDraftAccelerator(event.currentTarget.value);
   }, []);
 
+  const handleFocus = useCallback(() => {
+    setIsCapturingShortcut(true);
+  }, []);
+
+  const handleBlur = useCallback(() => {
+    setIsCapturingShortcut(false);
+  }, []);
+
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLInputElement>) => {
       const accelerator = eventToAccelerator(event);
       if (event.key === 'Escape') {
         event.preventDefault();
         setDraftAccelerator(telephonyGlobalShortcutConfig.accelerator ?? '');
+        setIsCapturingShortcut(false);
         setValidationError(null);
         return;
       }
@@ -129,6 +139,7 @@ export const TelephonyGlobalShortcut = () => {
 
       event.preventDefault();
       setDraftAccelerator(accelerator);
+      setIsCapturingShortcut(false);
       setValidationError(null);
     },
     [telephonyGlobalShortcutConfig.accelerator]
@@ -164,8 +175,14 @@ export const TelephonyGlobalShortcut = () => {
           <TextInput
             data-testid='telephony-shortcut-input'
             value={draftAccelerator}
-            placeholder={t('settings.options.telephonyShortcut.placeholder')}
+            placeholder={t(
+              isCapturingShortcut
+                ? 'settings.options.telephonyShortcut.capturePlaceholder'
+                : 'settings.options.telephonyShortcut.placeholder'
+            )}
             onChange={handleChange}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
             onKeyDown={handleKeyDown}
           />
           <Button

--- a/src/ui/components/SettingsView/features/TelephonyGlobalShortcut.tsx
+++ b/src/ui/components/SettingsView/features/TelephonyGlobalShortcut.tsx
@@ -16,8 +16,13 @@ import type { Dispatch } from 'redux';
 import type { RootAction } from '../../../../store/actions';
 import type { RootState } from '../../../../store/rootReducer';
 import { TELEPHONY_GLOBAL_SHORTCUT_CONFIG_SET } from '../../../../telephony/actions';
+import {
+  isReservedTelephonyShortcutAccelerator,
+  normalizeTelephonyShortcutAccelerator,
+} from '../../../../telephony/shortcuts';
 
-const normalizeShortcutText = (value: string): string => value.trim();
+const normalizeShortcutText = (value: string): string | null =>
+  normalizeTelephonyShortcutAccelerator(value);
 
 const keyToAcceleratorPart = (key: string): string | null => {
   if (['Control', 'Meta', 'Shift', 'Alt'].includes(key)) {
@@ -74,6 +79,7 @@ export const TelephonyGlobalShortcut = () => {
   const [draftAccelerator, setDraftAccelerator] = useState(
     telephonyGlobalShortcutConfig.accelerator ?? ''
   );
+  const [validationError, setValidationError] = useState<string | null>(null);
 
   useEffect(() => {
     setDraftAccelerator(telephonyGlobalShortcutConfig.accelerator ?? '');
@@ -82,15 +88,25 @@ export const TelephonyGlobalShortcut = () => {
   const saveShortcut = useCallback(
     (value: string) => {
       const accelerator = normalizeShortcutText(value);
+      if (accelerator && isReservedTelephonyShortcutAccelerator(accelerator)) {
+        setValidationError(
+          t('settings.options.telephonyShortcut.reservedAccelerator', {
+            accelerator,
+          })
+        );
+        return;
+      }
+
+      setValidationError(null);
       dispatch({
         type: TELEPHONY_GLOBAL_SHORTCUT_CONFIG_SET,
         payload: {
           enabled: Boolean(accelerator),
-          accelerator: accelerator || null,
+          accelerator,
         },
       });
     },
-    [dispatch]
+    [dispatch, t]
   );
 
   const handleChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
@@ -100,14 +116,22 @@ export const TelephonyGlobalShortcut = () => {
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLInputElement>) => {
       const accelerator = eventToAccelerator(event);
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        setDraftAccelerator(telephonyGlobalShortcutConfig.accelerator ?? '');
+        setValidationError(null);
+        return;
+      }
+
       if (!accelerator) {
         return;
       }
 
       event.preventDefault();
       setDraftAccelerator(accelerator);
+      setValidationError(null);
     },
-    []
+    [telephonyGlobalShortcutConfig.accelerator]
   );
 
   const handleSave = useCallback(() => {
@@ -167,6 +191,11 @@ export const TelephonyGlobalShortcut = () => {
           <FieldHint color='danger'>
             {telephonyGlobalShortcutRegistrationStatus.error}
           </FieldHint>
+        </FieldRow>
+      )}
+      {validationError && (
+        <FieldRow>
+          <FieldHint color='danger'>{validationError}</FieldHint>
         </FieldRow>
       )}
       {isRegistered && (


### PR DESCRIPTION
## Summary
- add a configurable global telephony shortcut for dialing clipboard phone numbers
- add Desktop Settings controls for shortcut and telephony workspace selection
- share the telephony dialpad opener between deep links and shortcut handling
- harden shortcut registration, reserved accelerators, clipboard size handling, and empty dialpad behavior
- stabilize shortcut notification click handling

## Validation
- yarn .:lint:tsc
- yarn eslint on touched TS/TSX files
- git diff --check

Note: local Electron Jest runner was previously crashing on this machine while validating the follow-up; static validation passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added global keyboard shortcut configuration for initiating telephony calls.
  * Users can capture, save, and manage shortcut accelerators in Settings with validation and error feedback.
  * Integrated clipboard reading with global shortcut trigger for automatic phone number extraction.

* **Documentation**
  * Updated telephony server setting description to clarify support for global shortcuts and tel:/callto: link handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat.Electron/pull/3330)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->