### PR TITLE
test(telephony): stabilize shortcut notification click

### DIFF
--- a/src/telephony/main.spec.ts
+++ b/src/telephony/main.spec.ts
@@ -299,10 +299,9 @@ describe('telephony global shortcut main process pipeline', () => {
       .results[0].value;
     const clickListener = notification.addListener.mock.calls.find(
       ([event]: [string]) => event === 'click'
-    )?.[1] as (() => void) | undefined;
+    )?.[1] as (() => Promise<void>) | undefined;
 
-    clickListener?.();
-    await Promise.resolve();
+    await clickListener?.();
 
     expect(rootWindow.focus).toHaveBeenCalled();
     expect(dispatchMock).toHaveBeenCalledWith({

--- a/src/telephony/main.ts
+++ b/src/telephony/main.ts
@@ -131,11 +131,18 @@ const notifyRegistrationFailure = (
       title: 'Rocket.Chat',
       body: `Telephony shortcut ${accelerator} could not be registered. It may already be in use.`,
     });
-    notification.addListener('click', () => {
-      void focusRootWindow().finally(() => {
-        dispatch({ type: SIDE_BAR_SETTINGS_BUTTON_CLICKED });
-      });
-    });
+    notification.addListener('click', () =>
+      focusRootWindow()
+        .catch((error) => {
+          logger.warn(
+            'Failed to focus Rocket.Chat from telephony shortcut notification'
+          );
+          logger.warn(error);
+        })
+        .finally(() => {
+          dispatch({ type: SIDE_BAR_SETTINGS_BUTTON_CLICKED });
+        })
+    );
     notification.show();
   } catch (notificationError) {
     logger.warn('Failed to show telephony shortcut registration feedback');


### PR DESCRIPTION
## Summary
- stabilize the telephony shortcut registration-failure notification click handler
- make the test await the actual click promise instead of racing the dispatch

## Validation
- yarn test src/telephony/main.spec.ts src/telephony/renderer/preload.spec.ts src/ui/components/SettingsView/features/TelephonyGlobalShortcut.spec.tsx src/app/PersistableValues.spec.ts src/deepLinks/main.spec.ts — 66 passed
- yarn eslint src/telephony/main.ts src/telephony/main.spec.ts
- yarn .:lint:tsc

Note: Electron/Jest must be run with GUI permission on macOS; the earlier SIGABRT was caused by launching Electron inside the sandbox.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved registration failure notification click handling to properly manage asynchronous operations and log window focus failures, ensuring the settings interface reliably opens when the notification is clicked.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat.Electron/pull/3331)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->