### PR TITLE
fix: add Cmd+, shortcut to open Preferences on macOS

### DIFF
--- a/src/i18n/en.i18n.json
+++ b/src/i18n/en.i18n.json
@@ -392,6 +392,7 @@
     "toggleDevTools": "Toggle &DevTools",
     "openConfigFolder": "Open &Configuration Folder",
     "openLogViewer": "Open &Log Viewer",
+    "preferences": "Preferences",
     "videoCallDevTools": "Open Video Call &DevTools",
     "videoCallTools": "Video Call Tools",
     "videoCallDevToolsAutoOpen": "Auto-open DevTools",

--- a/src/ui/main/menuBar.ts
+++ b/src/ui/main/menuBar.ts
@@ -65,6 +65,21 @@ const createAppMenu = createSelector(
         },
         { type: 'separator' },
         {
+          id: 'preferences',
+          label: t('menus.preferences'),
+          accelerator: 'Command+,',
+          click: async () => {
+            const browserWindow = await getRootWindow();
+
+            if (!browserWindow.isVisible()) {
+              browserWindow.showInactive();
+            }
+            browserWindow.focus();
+            dispatch({ type: SIDE_BAR_SETTINGS_BUTTON_CLICKED });
+          },
+        },
+        { type: 'separator' },
+        {
           id: 'services',
           label: t('menus.services'),
           role: 'services',


### PR DESCRIPTION
## Description

Adds the standard macOS keyboard shortcut **Cmd+, (Command+Comma)** to open Preferences/Settings. This is a universal macOS convention — most native apps support it.

### Changes

1. **src/i18n/en.i18n.json**: Added `menus.preferences` → `"Preferences"` translation key
2. **src/ui/main/menuBar.ts**: Inserted Preferences menu item in the macOS app menu (inside `process.platform === 'darwin'` block) with:
   - Label: Preferences
   - Accelerator: `Command+,`
   - Action: dispatches `SIDE_BAR_SETTINGS_BUTTON_CLICKED` (same as clicking Settings in the sidebar)

### Menu order (macOS only)

```
About Rocket.Chat
---
Preferences...   Cmd+,
---
Services
---
Hide Rocket.Chat
Hide Others
Show All
---
Quit Rocket.Chat   Cmd+Q
```

### Testing checklist

- [x] `Command+,` is not used by any other menu item
- [x] Only applies on macOS (`process.platform === 'darwin'` block)
- [x] Click dispatches the same action as navigating to Settings
- [x] Translation key added in `en.i18n.json`

Closes #3325


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Preferences menu item to the main application menu (macOS only)
  * Preferences menu item can be accessed using the Command+, keyboard shortcut
  * Selecting Preferences opens the application settings panel

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat.Electron/pull/3340?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->