### PR TITLE
chore: Polish Settings, Certificates, and Downloads views against Fuselage

### DIFF
--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,324 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-05-26T00:00:00Z",
+  "title": "Design System: Rocket.Chat Desktop",
+  "extensions": {
+    "colorMeta": {
+      "button-background-primary-default": {
+        "role": "primary",
+        "displayName": "Action Blue",
+        "canonical": "oklch(58% 0.20 257)",
+        "fuselageToken": "button.backgroundPrimaryDefault -> colors.b500",
+        "darkThemeValue": "#1d74f5 (b500 also used in dark)",
+        "tonalRamp": [
+          "#012247",
+          "#01336B",
+          "#10529E",
+          "#095AD2",
+          "#1D74F5",
+          "#549DF9",
+          "#76B7FC",
+          "#D1EBFE"
+        ]
+      },
+      "badge-background-level-1": {
+        "role": "secondary",
+        "displayName": "Mention Slate",
+        "canonical": "oklch(52% 0.012 256)",
+        "fuselageToken": "badge.light.level-1 -> colors.n700",
+        "darkThemeValue": "#484C51",
+        "tonalRamp": [
+          "#1F2329",
+          "#2F343D",
+          "#6C737A",
+          "#9EA2A8",
+          "#CBCED1",
+          "#D7DBE0",
+          "#E4E7EA",
+          "#F7F8FA"
+        ]
+      },
+      "badge-background-level-3": {
+        "role": "tertiary",
+        "displayName": "Caution Orange",
+        "canonical": "oklch(72% 0.16 51)",
+        "fuselageToken": "badge.light.level-3 -> colors.o500",
+        "darkThemeValue": "#955828",
+        "tonalRamp": [
+          "#713607",
+          "#974809",
+          "#BD5A0B",
+          "#E26D0E",
+          "#F38C39",
+          "#F59B53",
+          "#F7B27B",
+          "#FAD1B0"
+        ]
+      },
+      "badge-background-level-4": {
+        "role": "tertiary",
+        "displayName": "Alert Crimson",
+        "canonical": "oklch(65% 0.22 18)",
+        "fuselageToken": "badge.light.level-4 -> colors.r500",
+        "darkThemeValue": "#B43C4C",
+        "tonalRamp": [
+          "#8B0719",
+          "#9B1325",
+          "#BB0B21",
+          "#D40C26",
+          "#EC0D2A",
+          "#F5455C",
+          "#F98F9D",
+          "#FFC1C9"
+        ]
+      },
+      "button-background-danger-default": {
+        "role": "tertiary",
+        "displayName": "Destructive Red",
+        "canonical": "oklch(57% 0.23 24)",
+        "fuselageToken": "button.backgroundDangerDefault -> colors.r500",
+        "darkThemeValue": "#EC0D2A (also used in dark)",
+        "tonalRamp": [
+          "#8B0719",
+          "#9B1325",
+          "#BB0B21",
+          "#D40C26",
+          "#EC0D2A",
+          "#F5495F",
+          "#F98F9D",
+          "#FFC1C9"
+        ]
+      },
+      "surface-room": {
+        "role": "neutral",
+        "displayName": "Room",
+        "canonical": "theme-following",
+        "fuselageToken": "surface.{theme}.room",
+        "lightHex": "#FFFFFF",
+        "darkHex": "#1F2329",
+        "highContrastHex": "#FFFFFF",
+        "tonalRamp": [
+          "#1F2329",
+          "#2F343D",
+          "#6C737A",
+          "#9EA2A8",
+          "#CBCED1",
+          "#D7DBE0",
+          "#E4E7EA",
+          "#FFFFFF"
+        ]
+      },
+      "surface-tint": {
+        "role": "neutral",
+        "displayName": "Wall Cream",
+        "canonical": "oklch(98% 0.004 250)",
+        "fuselageToken": "surface.light.tint -> colors.n100",
+        "darkHex": "#1F2329",
+        "tonalRamp": [
+          "#1F2329",
+          "#2F343D",
+          "#6C737A",
+          "#9EA2A8",
+          "#CBCED1",
+          "#D7DBE0",
+          "#E4E7EA",
+          "#F7F8FA"
+        ]
+      },
+      "surface-selected": {
+        "role": "neutral",
+        "displayName": "Active Tone",
+        "canonical": "oklch(88% 0.006 256)",
+        "fuselageToken": "surface.light.selected -> colors.n450",
+        "darkHex": "#4C5362",
+        "tonalRamp": [
+          "#1F2329",
+          "#2F343D",
+          "#6C737A",
+          "#9EA2A8",
+          "#CBCED1",
+          "#D7DBE0",
+          "#E4E7EA",
+          "#F7F8FA"
+        ]
+      },
+      "surface-hover": {
+        "role": "neutral",
+        "displayName": "Hover Tone",
+        "canonical": "oklch(96% 0.005 250)",
+        "fuselageToken": "surface.light.hover -> colors.n200",
+        "darkHex": "#1A1E23",
+        "tonalRamp": [
+          "#1F2329",
+          "#2F343D",
+          "#6C737A",
+          "#9EA2A8",
+          "#CBCED1",
+          "#D7DBE0",
+          "#E4E7EA",
+          "#F2F3F5"
+        ]
+      }
+    },
+    "typographyMeta": {
+      "hero": { "displayName": "Hero", "purpose": "Splash / pre-hydration only." },
+      "h1": { "displayName": "H1", "purpose": "Reserved (Settings/Downloads use h2 instead)." },
+      "h2": { "displayName": "H2", "purpose": "SettingsView and DownloadsManagerView titles." },
+      "h3": { "displayName": "H3", "purpose": "Subsection titles, large dialog titles." },
+      "h4": { "displayName": "H4", "purpose": "Section headers in GeneralTab / DeveloperTab / CertificatesManager." },
+      "h5": { "displayName": "H5", "purpose": "Compact list-item titles." },
+      "p1": { "displayName": "P1", "purpose": "Primary dialog copy." },
+      "p2": { "displayName": "P2", "purpose": "Default shell body." },
+      "c1": { "displayName": "C1", "purpose": "Server initials, hint subtitles, metadata." },
+      "c2": { "displayName": "C2", "purpose": "Emphasized micro-labels." },
+      "micro": { "displayName": "Micro", "purpose": "Extreme density. Not currently used." }
+    },
+    "shadows": [
+      { "name": "shadow-highlight", "value": "from --rcx-color-shadow-highlight", "purpose": "Focus ring on input-like surfaces." },
+      { "name": "shadow-danger", "value": "from --rcx-color-shadow-danger", "purpose": "Error-state ring." },
+      { "name": "shadow-elevation-border", "value": "from --rcx-color-shadow-elevation-border", "purpose": "Hairline edge accent on elevated surfaces." },
+      { "name": "shadow-elevation-1", "value": "from --rcx-color-shadow-elevation-1", "purpose": "Default tile lift." },
+      { "name": "shadow-elevation-2x", "value": "from --rcx-color-shadow-elevation-2x", "purpose": "Modal-tier x-axis shadow on Dialog and Dropdown." },
+      { "name": "shadow-elevation-2y", "value": "from --rcx-color-shadow-elevation-2y", "purpose": "Modal-tier y-axis shadow on Dialog and Dropdown." }
+    ],
+    "motion": [
+      { "name": "selection-stripe", "value": "height var(--transitions-duration), opacity var(--transitions-duration)", "purpose": "Animates the 4px selection stripe on server buttons." },
+      { "name": "row-hover", "value": "background-color 120ms ease-out", "purpose": "Hover tint transition on list rows (Downloads + Certificates)." }
+    ],
+    "themes": ["light", "dark", "high-contrast"],
+    "breakpoints": [
+      { "name": "xs", "value": "0" },
+      { "name": "sm", "value": "600px" },
+      { "name": "md", "value": "768px" },
+      { "name": "lg", "value": "1024px" },
+      { "name": "xl", "value": "1280px" },
+      { "name": "xxl", "value": "1600px" },
+      { "name": "xxxl", "value": "1920px" }
+    ]
+  },
+  "components": [
+    {
+      "name": "Server Button (Selected)",
+      "kind": "custom",
+      "refersTo": "server-button-selected",
+      "description": "44px rail item with 28px square avatar and the canonical 4px selection stripe to its left.",
+      "html": "<li class=\"ds-server-btn ds-server-btn--selected\"><button class=\"ds-server-btn__avatar\"><span class=\"ds-server-btn__initials\">RC</span></button></li>",
+      "css": ".ds-server-btn { position: relative; display: flex; list-style: none; padding: 4px 0; } .ds-server-btn::before { position: absolute; content: ''; left: -8px; width: 4px; height: 0; border-radius: 0 4px 4px 0; background-color: var(--rcx-color-surface-selected, #d7dbe0); transition: height 0.2s, opacity 0.2s; } .ds-server-btn--selected::before { height: 28px; opacity: 1; } .ds-server-btn__avatar { width: 36px; height: 36px; border-radius: 4px; background: var(--rcx-color-surface-tint, #f7f8fa); border: none; cursor: pointer; display: flex; align-items: center; justify-content: center; font: 400 12px/16px Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: var(--rcx-color-font-titles-labels, #1f2329); } .ds-server-btn__avatar:hover { background: var(--rcx-color-surface-selected, #d7dbe0); }"
+    },
+    {
+      "name": "Mention Count Badge (variant=secondary)",
+      "kind": "chip",
+      "refersTo": "badge-mention-count",
+      "description": "Unread mention count anchored top-right of avatar. Fuselage Badge variant='secondary' — gray, not red.",
+      "html": "<span class=\"ds-badge-secondary\">3</span>",
+      "css": ".ds-badge-secondary { display: inline-flex; align-items: center; justify-content: center; min-width: 16px; height: 16px; padding: 0 5px; background: var(--rcx-color-badge-background-level-1, #6c737a); color: var(--rcx-color-font-white, #fff); font: 700 12px/16px Inter, -apple-system, sans-serif; border-radius: 9999px; transform: translate(30%, -30%); }"
+    },
+    {
+      "name": "Warning Badge (variant=warning)",
+      "kind": "chip",
+      "refersTo": "badge-warning",
+      "description": "Not-logged-in state. Fuselage Badge variant='warning' — orange.",
+      "html": "<span class=\"ds-badge-warning\">!</span>",
+      "css": ".ds-badge-warning { display: inline-flex; align-items: center; justify-content: center; min-width: 16px; height: 16px; padding: 0 5px; background: var(--rcx-color-badge-background-level-3, #f38c39); color: var(--rcx-color-font-white, #fff); font: 700 12px/16px Inter, -apple-system, sans-serif; border-radius: 9999px; transform: translate(30%, -30%); }"
+    },
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "Dominant action inside dialogs.",
+      "html": "<button class=\"ds-btn-primary\">Save</button>",
+      "css": ".ds-btn-primary { display: inline-flex; align-items: center; justify-content: center; padding: 8px 16px; background: var(--rcx-color-button-background-primary-default, #1d74f5); color: var(--rcx-color-font-white, #fff); border: none; border-radius: 4px; font: 400 14px/20px Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; cursor: pointer; transition: background 0.15s; } .ds-btn-primary:hover { background: var(--rcx-color-button-background-primary-hover, #095ad2); } .ds-btn-primary:active { background: var(--rcx-color-button-background-primary-press, #10529e); } .ds-btn-primary:focus-visible { outline: 2px solid var(--rcx-color-stroke-highlight, #156ff5); outline-offset: 2px; }"
+    },
+    {
+      "name": "Danger Button",
+      "kind": "button",
+      "refersTo": "button-danger",
+      "description": "Destructive confirmation (Remove server, Clear cache).",
+      "html": "<button class=\"ds-btn-danger\">Remove</button>",
+      "css": ".ds-btn-danger { display: inline-flex; align-items: center; justify-content: center; padding: 8px 16px; background: var(--rcx-color-button-background-danger-default, #ec0d2a); color: var(--rcx-color-font-white, #fff); border: none; border-radius: 4px; font: 400 14px/20px Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; cursor: pointer; transition: background 0.15s; } .ds-btn-danger:hover { background: var(--rcx-color-button-background-danger-hover, #d40c26); } .ds-btn-danger:focus-visible { outline: 2px solid var(--rcx-color-shadow-danger, #ec0d2a); outline-offset: 2px; }"
+    },
+    {
+      "name": "Dialog",
+      "kind": "card",
+      "refersTo": "dialog",
+      "description": "Centered modal with title, body, action row.",
+      "html": "<div class=\"ds-dialog\"><div class=\"ds-dialog__title\">Remove workspace</div><div class=\"ds-dialog__body\">This removes the workspace from this device. Your messages on the server are unaffected.</div><div class=\"ds-dialog__actions\"><button class=\"ds-btn-ghost\">Cancel</button><button class=\"ds-btn-danger\">Remove</button></div></div>",
+      "css": ".ds-dialog { background: var(--rcx-color-surface-light, #fff); color: var(--rcx-color-font-default, #2f343d); border-radius: 4px; padding: 24px; max-width: 480px; font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; box-shadow: 0 4px 12px rgba(31,35,41,0.08), 0 12px 28px rgba(31,35,41,0.12); } .ds-dialog__title { font: 700 24px/32px inherit; margin-bottom: 8px; color: var(--rcx-color-font-titles-labels, #1f2329); } .ds-dialog__body { font: 400 16px/24px inherit; color: var(--rcx-color-font-secondary-info, #6c737a); margin-bottom: 24px; max-width: 65ch; } .ds-dialog__actions { display: flex; gap: 8px; justify-content: flex-end; } .ds-btn-ghost { background: transparent; color: var(--rcx-color-font-default, #2f343d); border: 1px solid var(--rcx-color-stroke-light, #cbced1); border-radius: 4px; padding: 8px 16px; font: 400 14px/20px inherit; cursor: pointer; } .ds-btn-ghost:hover { background: var(--rcx-color-surface-hover, #f2f3f5); } .ds-btn-danger { background: var(--rcx-color-button-background-danger-default, #ec0d2a); color: #fff; border: none; border-radius: 4px; padding: 8px 16px; font: 400 14px/20px inherit; cursor: pointer; } .ds-btn-danger:hover { background: var(--rcx-color-button-background-danger-hover, #d40c26); }"
+    },
+    {
+      "name": "Sidebar Rail",
+      "kind": "nav",
+      "refersTo": "sidebar",
+      "description": "44-pixel vertical workshop wall holding server buttons and bottom-anchored controls.",
+      "html": "<aside class=\"ds-rail\"><ul class=\"ds-rail__servers\"><li class=\"ds-server-btn ds-server-btn--selected\"><button class=\"ds-server-btn__avatar\">RC</button><span class=\"ds-badge-secondary ds-badge-secondary--anchored\">3</span></li><li class=\"ds-server-btn\"><button class=\"ds-server-btn__avatar\">OS</button></li><li class=\"ds-server-btn\"><button class=\"ds-server-btn__avatar\">DV</button><span class=\"ds-badge-warning ds-badge-warning--anchored\">!</span></li></ul><div class=\"ds-rail__footer\"><button class=\"ds-rail__icon\" aria-label=\"Add server\">+</button></div></aside>",
+      "css": ".ds-rail { width: 44px; height: 100%; background: var(--rcx-color-surface-tint, #f7f8fa); padding: 8px 0; display: flex; flex-direction: column; justify-content: space-between; align-items: center; font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; } .ds-rail__servers { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 4px; align-items: center; } .ds-server-btn { position: relative; } .ds-server-btn::before { position: absolute; content: ''; left: -8px; width: 4px; height: 0; border-radius: 0 4px 4px 0; background: var(--rcx-color-surface-selected, #d7dbe0); transition: height 0.2s; } .ds-server-btn--selected::before { height: 28px; } .ds-server-btn__avatar { width: 36px; height: 36px; border-radius: 4px; background: #fff; border: none; cursor: pointer; display: flex; align-items: center; justify-content: center; font: 400 12px/16px inherit; color: var(--rcx-color-font-titles-labels, #1f2329); } .ds-server-btn__avatar:hover { background: var(--rcx-color-surface-selected, #d7dbe0); } .ds-badge-secondary--anchored, .ds-badge-warning--anchored { position: absolute; top: 0; right: 0; transform: translate(30%, -30%); } .ds-badge-secondary { display: inline-flex; align-items: center; justify-content: center; min-width: 16px; height: 16px; padding: 0 5px; background: var(--rcx-color-badge-background-level-1, #6c737a); color: #fff; font: 700 12px/16px inherit; border-radius: 9999px; } .ds-badge-warning { display: inline-flex; align-items: center; justify-content: center; min-width: 16px; height: 16px; padding: 0 5px; background: var(--rcx-color-badge-background-level-3, #f38c39); color: #fff; font: 700 12px/16px inherit; border-radius: 9999px; } .ds-rail__icon { width: 36px; height: 36px; border-radius: 4px; background: transparent; border: none; cursor: pointer; color: var(--rcx-color-font-secondary-info, #6c737a); font-size: 18px; } .ds-rail__icon:hover { background: var(--rcx-color-surface-selected, #d7dbe0); color: var(--rcx-color-font-default, #2f343d); }"
+    },
+    {
+      "name": "List Row (Downloads / Certificates)",
+      "kind": "custom",
+      "refersTo": "list-row",
+      "description": "Shared row affordance: hairline divider above each row (skipped on :first-of-type) + hover tint reaching edge-to-edge. Used by DownloadItem and TableRow action.",
+      "html": "<div class=\"ds-row-list\"><div class=\"ds-row\"><div class=\"ds-row__primary\">first item</div><div class=\"ds-row__actions\">action</div></div><div class=\"ds-row\"><div class=\"ds-row__primary\">second item</div><div class=\"ds-row__actions\">action</div></div></div>",
+      "css": ".ds-row-list { font-family: Inter, -apple-system, sans-serif; color: var(--rcx-color-font-default, #2f343d); } .ds-row { display: flex; align-items: center; justify-content: space-between; padding: 16px 8px; border-block-start: 1px solid var(--rcx-color-stroke-extra-light, #e4e7ea); transition: background-color 120ms ease-out; } .ds-row:first-of-type { border-block-start: none; } .ds-row:hover { background: var(--rcx-color-surface-hover, #f2f3f5); } .ds-row__primary { font: 400 14px/20px inherit; } .ds-row__actions { font: 400 12px/16px inherit; color: var(--rcx-color-font-secondary-info, #6c737a); }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Workshop Wall",
+    "overview": "The desktop shell is a tool rail: a quiet 44-pixel column of workspaces hung along the side of a screen, each one sized for instant reach. Tokens are sourced from @rocket.chat/fuselage-tokens and emitted at runtime by PaletteStyleTag as --rcx-color-* CSS custom properties. Three themes ship: light, dark, and high-contrast. The Electron shell does not invent colors, weights, radii, or spacing values outside that scheme.",
+    "keyCharacteristics": [
+      "44-pixel server rail as the signature surface.",
+      "Flat by default, depth through tonal tint shifts.",
+      "Inter primary, system stack fallback.",
+      "One accent gesture: the 4-pixel selection stripe in surface-selected.",
+      "Color follows runtime --rcx-color-* CSS variables; three themes (light, dark, high-contrast) ship.",
+      "Native per-platform: macOS vibrancy + 22-pixel drag bar, Windows Mica, Linux fallback."
+    ],
+    "rules": [
+      { "name": "The Fuselage Truth Rule", "body": "Every color resolves to a semantic --rcx-color-* custom property emitted by PaletteStyleTag. Palette-grade vars are not emitted at runtime.", "section": "colors" },
+      { "name": "The Three-Theme Rule", "body": "Every shell color choice must look correct in light, dark, and high-contrast. High-contrast is not optional for this product.", "section": "colors" },
+      { "name": "The One Stripe Rule", "body": "The 4-pixel left stripe on the selected server button is the entire decorative vocabulary of the rail.", "section": "colors" },
+      { "name": "The Quiet Mention Rule", "body": "Mention badge is Badge variant=secondary: gray badge-background-level-1, not red. Red is reserved for variant=danger on true alerts.", "section": "colors" },
+      { "name": "The Semantic-Token-First Rule", "body": "Read tokens through their semantic name, never through palette grades. TS palette maps primary->b, danger->r, success->g, warning->y, neutral->n.", "section": "colors" },
+      { "name": "The fontScale Rule", "body": "Use Fuselage fontScale on Box rather than raw font-size literals.", "section": "typography" },
+      { "name": "The Inter-First Rule", "body": "Add Inter at the front of the family stack. Do not strip back to system-ui.", "section": "typography" },
+      { "name": "The Sentence Case Rule", "body": "All shell strings are sentence case in source. Fuselage applies title case or uppercase at the component layer when needed.", "section": "typography" },
+      { "name": "The Tonal Step Rule", "body": "Adjacent shell surfaces differ by exactly one tint step. Stacking two surfaces of the same tint is a layout bug.", "section": "elevation" },
+      { "name": "The Shadow Tenancy Rule", "body": "Shadows belong to Fuselage's transient overlays and the OS-native layer. The shell does not author box-shadow in any CSS it owns.", "section": "elevation" }
+    ],
+    "dos": [
+      "Do import primitives from @rocket.chat/fuselage first.",
+      "Do reference colors via semantic --rcx-color-<category>-<role> CSS custom properties.",
+      "Do use Fuselage fontScale on Box rather than raw font-size literals.",
+      "Do keep the 44-pixel rail width sacred.",
+      "Do use the 4-pixel left selection stripe as the only selected-state decoration.",
+      "Do respect prefers-reduced-motion on every shell transition.",
+      "Do keep Badge variant=secondary (gray) for unread counts and variant=warning (orange) for not-logged-in.",
+      "Do verify every color choice in light, dark, and high-contrast themes.",
+      "Do use sentence case in source strings.",
+      "Do apply the shared row affordance (hairline + hover) to every new list surface.",
+      "Do use Box withTruncatedText and title={...} tooltip for long URLs and file names.",
+      "Do use pi/pbs/pbe Fuselage spacing shorthand on multiples of 4."
+    ],
+    "donts": [
+      "Don't use Discord/gamer aesthetics: no neon, no drenched purple, no playful microcopy.",
+      "Don't revive old Skype or legacy Teams chrome: no heavy gradients, no decorative iconography.",
+      "Don't use generic SaaS marketing patterns: no hero metric tiles, no identical card grids.",
+      "Don't pursue Linear-empty minimalism at the cost of sidebar density.",
+      "Don't use border-left or border-right greater than 1px as a colored stripe except the canonical 4-pixel server selection stripe.",
+      "Don't use background-clip: text gradient text.",
+      "Don't introduce glassmorphism. OS-provided vibrancy is acceptable; CSS backdrop-filter is forbidden.",
+      "Don't author box-shadow in shell-owned CSS.",
+      "Don't treat hardcoded #2f343d or #d7dbe0 as design tokens. They are pre-hydration backstops.",
+      "Don't pass a ghost prop to Fuselage Button (does not exist). Use secondary for subtle non-primary actions.",
+      "Don't use Table striped. Stripe clashes with surface-room. Use <TableRow action> for hover.",
+      "Don't strip Inter out of the font stack.",
+      "Don't wrap shell content in card grids.",
+      "Don't use modals as the first thought for new flows.",
+      "Don't rename, recolor, or re-style Fuselage primitives.",
+      "Don't confuse Badge variants: unread is secondary (gray), not-logged-in is warning (orange), danger (red) is reserved.",
+      "Don't invent border-radius outside 2 / 4 / 8 / 9999 pixels.",
+      "Don't add a settings divergence across light / dark / high-contrast themes.",
+      "Don't use em dashes anywhere in shell copy."
+    ]
+  }
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,419 @@
+---
+name: Rocket.Chat Desktop
+description: Native desktop shell around one or more Rocket.Chat server webviews.
+colors:
+  surface-light: "#ffffff"
+  surface-tint: "#f7f8fa"
+  surface-room: "#ffffff"
+  surface-neutral: "#e4e7ea"
+  surface-hover: "#f2f3f5"
+  surface-selected: "#d7dbe0"
+  surface-sidebar: "#e4e7ea"
+  surface-overlay: "#2f343d80"
+  stroke-extra-light: "#e4e7ea"
+  stroke-light: "#cbced1"
+  stroke-medium: "#9ea2a8"
+  stroke-dark: "#6c737a"
+  stroke-extra-dark: "#2f343d"
+  stroke-highlight: "#156ff5"
+  stroke-error: "#ec0d2a"
+  font-default: "#2f343d"
+  font-titles-labels: "#1f2329"
+  font-secondary-info: "#6c737a"
+  font-hint: "#6c737a"
+  font-annotation: "#9ea2a8"
+  font-disabled: "#cbced1"
+  font-info: "#095ad2"
+  font-danger: "#d40c26"
+  font-white: "#ffffff"
+  button-background-primary-default: "#1d74f5"
+  button-background-primary-hover: "#095ad2"
+  button-background-primary-press: "#10529e"
+  button-background-secondary-default: "#e4e7ea"
+  button-background-danger-default: "#ec0d2a"
+  button-background-danger-hover: "#d40c26"
+  badge-background-level-0: "#e4e7ea"
+  badge-background-level-1: "#6c737a"
+  badge-background-level-2: "#1d74f5"
+  badge-background-level-3: "#f38c39"
+  badge-background-level-4: "#f5455c"
+typography:
+  hero:
+    fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+    fontSize: "48px"
+    fontWeight: 800
+    lineHeight: "64px"
+    letterSpacing: "0"
+  h1:
+    fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+    fontSize: "32px"
+    fontWeight: 700
+    lineHeight: "40px"
+    letterSpacing: "0"
+  h2:
+    fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+    fontSize: "24px"
+    fontWeight: 700
+    lineHeight: "32px"
+    letterSpacing: "0"
+  h3:
+    fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+    fontSize: "20px"
+    fontWeight: 700
+    lineHeight: "28px"
+    letterSpacing: "0"
+  h4:
+    fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+    fontSize: "16px"
+    fontWeight: 700
+    lineHeight: "24px"
+    letterSpacing: "0"
+  h5:
+    fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+    fontSize: "14px"
+    fontWeight: 700
+    lineHeight: "20px"
+    letterSpacing: "0"
+  p1:
+    fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+    fontSize: "16px"
+    fontWeight: 400
+    lineHeight: "24px"
+    letterSpacing: "0"
+  p2:
+    fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+    fontSize: "14px"
+    fontWeight: 400
+    lineHeight: "20px"
+    letterSpacing: "0"
+  c1:
+    fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+    fontSize: "12px"
+    fontWeight: 400
+    lineHeight: "16px"
+    letterSpacing: "0"
+  c2:
+    fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+    fontSize: "12px"
+    fontWeight: 700
+    lineHeight: "16px"
+    letterSpacing: "0"
+  micro:
+    fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+    fontSize: "10px"
+    fontWeight: 700
+    lineHeight: "12px"
+    letterSpacing: "0"
+rounded:
+  none: "0"
+  small: "2px"
+  medium: "4px"
+  large: "8px"
+  full: "9999px"
+spacing:
+  x1: "1px"
+  x2: "2px"
+  x4: "4px"
+  x8: "8px"
+  x12: "12px"
+  x16: "16px"
+  x24: "24px"
+  x28: "28px"
+  x32: "32px"
+  x44: "44px"
+components:
+  sidebar:
+    backgroundColor: "{colors.surface-sidebar}"
+    width: "44px"
+    padding: "8px 0"
+  server-button:
+    backgroundColor: "{colors.surface-tint}"
+    rounded: "{rounded.medium}"
+    size: "28px"
+  server-button-selected:
+    backgroundColor: "{colors.surface-selected}"
+  badge-mention-count:
+    backgroundColor: "{colors.badge-background-level-1}"
+    textColor: "{colors.font-white}"
+    rounded: "{rounded.full}"
+  badge-warning:
+    backgroundColor: "{colors.badge-background-level-3}"
+    textColor: "{colors.font-white}"
+    rounded: "{rounded.full}"
+  dialog:
+    backgroundColor: "{colors.surface-light}"
+    textColor: "{colors.font-default}"
+    rounded: "{rounded.medium}"
+    padding: "24px"
+  topbar:
+    backgroundColor: "{colors.surface-tint}"
+    height: "22px"
+  button-primary:
+    backgroundColor: "{colors.button-background-primary-default}"
+    textColor: "{colors.font-white}"
+    rounded: "{rounded.medium}"
+    padding: "8px 16px"
+  button-primary-hover:
+    backgroundColor: "{colors.button-background-primary-hover}"
+  button-primary-press:
+    backgroundColor: "{colors.button-background-primary-press}"
+  button-danger:
+    backgroundColor: "{colors.button-background-danger-default}"
+    textColor: "{colors.font-white}"
+    rounded: "{rounded.medium}"
+    padding: "8px 16px"
+  button-danger-hover:
+    backgroundColor: "{colors.button-background-danger-hover}"
+---
+
+# Design System: Rocket.Chat Desktop
+
+## 1. Overview
+
+**Creative North Star: "The Workshop Wall"**
+
+The desktop shell is a tool rail: a quiet 44-pixel column of workspaces hung along the side of a screen, each one sized for instant reach. Like a workshop wall, every tool has its place, density is the point, and the rail itself is invisible during work. Users move through the rail without thinking; they only notice it when a server badge calls them back, when they drag a workspace to reorder it, or when a dialog steps forward to handle something the browser cannot.
+
+The visual system inherits directly from Fuselage. Tokens are sourced from `@rocket.chat/fuselage-tokens` and emitted at runtime by `PaletteStyleTag` (`packages/fuselage/src/components/PaletteStyleTag/PaletteStyleTag.tsx`) as `--rcx-color-*` CSS custom properties keyed by category: `surface-*`, `font-*`, `stroke-*`, `badge-background-level-*`, `button-background-*`, `status-background-*`, `status-font-on-*`, `status-bullet-*`, `shadow-*`. **Three themes ship: `light`, `dark`, and `high-contrast`.** The shell picks its theme via `userThemePreference` falling back to `machineTheme`. The Electron shell does not invent colors, weights, radii, or spacing values outside that scheme.
+
+This system explicitly rejects four neighbors. It is not Discord (no neon, no drenched purple, no playful microcopy). It is not legacy Skype or Teams (no heavy gradients, no decorative iconography in the titlebar, no busy toolbar). It is not generic SaaS marketing (no hero metric tiles, no identical card grids, no gradient accents on numbers). And it is not Linear-minimalism for its own sake (sidebar density matters; sparse-when-it-could-be-useful is a regression).
+
+**Key Characteristics:**
+
+- 44-pixel server rail as the signature surface.
+- Flat by default, depth through tonal tint shifts. Adjacent surfaces step by exactly one tint.
+- Inter primary, system stack fallback (`-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, ...`).
+- One accent gesture: the 4-pixel selection stripe to the left of the active server in `surface-selected`.
+- Color follows runtime Fuselage CSS variables emitted by `PaletteStyleTag`. Three themes: light, dark, high-contrast.
+- Native per-platform: macOS vibrancy + 22-pixel drag bar, Windows Mica, Linux fallback.
+
+## 2. Colors
+
+Tokens are sourced from `@rocket.chat/fuselage-tokens/dist/<category>.json` (`badge`, `button`, `font`, `shadow`, `status`, `statusBullet`, `stroke`, `surface`) and emitted by `PaletteStyleTag` as `--rcx-color-<category>-<role>` CSS variables. **All hex values below are light-theme; dark-theme and high-contrast resolve through the same variable name to different values.** The desktop shell never reads palette grades (`n400`, `b500`) directly; it always reads the semantic variable.
+
+### Primary
+- **Action Blue** (`#1d74f5`, oklch(58% 0.20 257), `--rcx-color-button-background-primary-default`): The dominant action color. Primary buttons, focus rings inside dialogs. Hover steps to `button-background-primary-hover` (`#095ad2`), press to `button-background-primary-press` (`#10529e`). Disabled background `button-background-primary-disabled`. Source: `colors.b500` via `fuselage-tokens/dist/button.json`. **Do not confuse with `status-background-info`** (`#d1ebfe`), which is the light tint used behind info banners.
+
+### Secondary
+- **Mention Slate** (`#6c737a`, oklch(52% 0.012 256), `--rcx-color-badge-background-level-1`): The unread-mention count badge background. Fuselage `Badge variant='secondary'`. Source: `colors.n700` via `fuselage-tokens/dist/badge.json`. The badge is a count, not an alarm; gray is intentional.
+
+### Tertiary
+- **Caution Orange** (`#f38c39`, oklch(72% 0.16 51), `--rcx-color-badge-background-level-3`): The warning-state badge shown over a server avatar when the user is not logged in. Fuselage `Badge variant='warning'`. Source: `colors.o500`.
+- **Alert Crimson** (`#f5455c`, oklch(65% 0.22 18), `--rcx-color-badge-background-level-4`): Reserved for true alerts requiring user response. Fuselage `Badge variant='danger'`. Source: `colors.r500`. Not currently in the rail vocabulary.
+- **Destructive Red** (`#ec0d2a`, oklch(57% 0.23 24), `--rcx-color-button-background-danger-default`): Background of destructive confirmation buttons (Remove server, Clear cache). Hover steps to `--rcx-color-button-background-danger-hover` (`#d40c26`). Source: `colors.r500` family.
+
+### Neutral surfaces
+- **Working Surface** (`#ffffff`, `--rcx-color-surface-light`): Dialog interiors.
+- **Wall Cream** (`#f7f8fa`, `--rcx-color-surface-tint`): The light sidebar background fill.
+- **Room** (`#ffffff` in light theme, `#1F2329` in dark, white in high-contrast, `--rcx-color-surface-room`): The full-window panel surface used by SettingsView and DownloadsManagerView. **Theme-following.** The earlier hardcoded `#2f343d` in `Shell/styles.tsx` and `SideBar/styles.tsx` is a pre-hydration backstop only; once `PaletteStyleTag` mounts it is overridden. Do not treat the hex literal as a token.
+- **Hover** (`#f2f3f5`, `--rcx-color-surface-hover`): Row hover background. Applied by Fuselage `TableRow action`, `Option`, `MenuItem`, and by the custom hairline-row pattern in `DownloadItem`.
+- **Selected** (`#d7dbe0`, `--rcx-color-surface-selected`): The fill of the 4-pixel selection stripe and the hover background on rail items.
+- **Sidebar** (`#e4e7ea`, `--rcx-color-surface-sidebar`): Available for sidebar-bg overrides.
+- **Neutral / Disabled / Dark / Featured / Featured-Hover / Overlay**: full set available via `--rcx-color-surface-*`. Use only when their semantic role applies.
+
+### Font
+- `font-default` (`#2f343d`): default text on light surfaces.
+- `font-titles-labels` (`#1f2329`): headings, titles.
+- `font-secondary-info` (`#6c737a`): metadata, secondary info, hint subtitles. Equivalent to `font-hint`.
+- `font-annotation` (`#9ea2a8`): annotation text.
+- `font-disabled` (`#cbced1`).
+- `font-info` (`#095ad2`): info-state text.
+- `font-danger` (`#d40c26`): error-state text.
+- `font-white` (`#ffffff`): text on saturated backgrounds (primary button, mention badge).
+- `font-pure-white` / `font-pure-black`: bypass theme. Use sparingly.
+
+### Stroke
+Nine semantic stroke tokens are available. Most used in the shell:
+- `stroke-extra-light` (`#e4e7ea`): row dividers, faint hairlines.
+- `stroke-light` (`#cbced1`): default border on inputs and ghost buttons.
+- `stroke-medium` / `stroke-dark` / `stroke-extra-dark`: progressively heavier.
+- `stroke-highlight` (`#156ff5`): focus ring on Fuselage inputs.
+- `stroke-error` (`#ec0d2a`): error-state input border.
+
+### Named Rules
+
+**The Fuselage Truth Rule.** Every color in the desktop shell resolves to a `--rcx-color-*` custom property emitted by `PaletteStyleTag`. Hardcoded fallbacks (`#2f343d`, `#d7dbe0`) inside `src/ui/components/SideBar/styles.tsx` and `Shell/styles.tsx` exist only as pre-hydration backstops. Do not reuse those literal hex codes anywhere else; reference the CSS variable, and never assume the fallback hex is the live value.
+
+**The Three-Theme Rule.** Every shell color choice must look correct in `light`, `dark`, and `high-contrast`. Verify all three (cycle via `userThemePreference` setting). High-contrast is not optional for this product (PRODUCT.md mandates WCAG 2.2 AA plus government and healthcare extras).
+
+**The One Stripe Rule.** The 4-pixel left stripe on the selected server button is the entire decorative vocabulary of the rail. Do not add second stripes, glows, halos, or contrast borders to indicate selection elsewhere. If a new affordance needs to signal selection, repeat the stripe.
+
+**The Quiet Mention Rule.** The mention-count badge is `Badge variant='secondary'`: gray (`badge-background-level-1`, `#6c737a`), white text. Not red. The badge is a number, not an alarm. Red (`badge-background-level-4`, `#f5455c`) is reserved for `variant='danger'` on true alerts. Warning state (not-logged-in) uses `variant='warning'`: orange (`badge-background-level-3`).
+
+**The Semantic-Token-First Rule.** Read tokens through their semantic name (`--rcx-color-button-background-primary-default`, `--rcx-color-font-default`), never through palette grades (`--rcx-color-primary-500`, `--rcx-color-neutral-800`). Palette-grade vars are not emitted by `PaletteStyleTag`; they exist only as SCSS fallbacks. The TS palette pipeline maps `primary → b`, `danger → r`, `success → g`, `warning → y`, `neutral → n`, which is why semantic tokens are the only stable contract.
+
+## 3. Typography
+
+**Display Font:** Inter (with fallback `-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif`).
+**Body Font:** Inter (same stack).
+**Mono Font:** `Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace`. Reserved for code surfaces.
+
+**Character:** Inter is the Fuselage standard (`fuselage-tokens/src/typography/base.json`, `fontFamilies.sans`). Where Inter is unavailable the stack falls back to the host OS font.
+
+### Hierarchy
+
+Use Fuselage `fontScale` props on `Box` and components rather than raw CSS. Each scale entry below comes verbatim from `fuselage-tokens/typography.json`.
+
+- **hero** (800, 48 / 64): Splash screens, marketing-style hero blocks. Not used inside the shell after first paint.
+- **h1** (700, 32 / 40): Reserved.
+- **h2** (700, 24 / 32): SettingsView and DownloadsManagerView titles.
+- **h3** (700, 20 / 28): Subsection titles, large dialog titles.
+- **h4** (700, 16 / 24): Form group labels, section headers in GeneralTab / DeveloperTab / CertificatesManager.
+- **h5** (700, 14 / 20): Compact list-item titles.
+- **p1 / p1m / p1b** (16 / 24 at 400 / 500 / 700): Primary running copy in dialogs.
+- **p2 / p2m / p2b** (14 / 20 at 400 / 500 / 700): Default shell body. Tooltips, settings rows, dropdown items.
+- **c1** (400, 12 / 16): Server initials, badge numbers, hint subtitles, metadata.
+- **c2** (700, 12 / 16): Emphasized micro-labels.
+- **micro** (700, 10 / 12): Extreme density. Not currently used in the shell.
+
+### Named Rules
+
+**The fontScale Rule.** Use Fuselage `fontScale='p2'` (or other key) on `Box` rather than raw `font-size` literals. Pixel literals drift; scale tags are the contract.
+
+**The Inter-First Rule.** Inter at the front of the family stack. Do not strip back to `system-ui`. The existing `font-family: system-ui` in `Shell/styles.tsx:37` predates the Inter migration in Fuselage and is a known drift item.
+
+**The Sentence Case Rule.** All shell strings are sentence case in source. Fuselage applies title case or uppercase at the component layer when needed (e.g. `Option.title` is uppercased by CSS).
+
+## 4. Elevation
+
+Flat by default with tonal layering. Depth steps through neutrals (`surface-room` → `surface-tint` → `surface-light`/`surface-selected` → `surface-hover`). The sanctioned shadow vocabulary lives in `--rcx-color-shadow-*` tokens emitted by `PaletteStyleTag` and is applied by Fuselage transient-overlay components.
+
+### Shadow Vocabulary (inherited, not authored)
+- `--rcx-color-shadow-highlight`: focus ring on input-like surfaces.
+- `--rcx-color-shadow-danger`: error-state ring.
+- `--rcx-color-shadow-elevation-border`: hairline edge accent on elevated surfaces.
+- `--rcx-color-shadow-elevation-1`: default tile lift.
+- `--rcx-color-shadow-elevation-2x` and `-2y`: modal-tier lift on Dialog and Dropdown.
+
+### Named Rules
+
+**The Tonal Step Rule.** Adjacent shell surfaces differ by exactly one tint step. Stacking two surfaces of the same tint is a layout bug.
+
+**The Shadow Tenancy Rule.** Shadows belong to Fuselage's transient overlays and to the OS-native layer (window chrome, vibrancy backdrops). The shell does not author `box-shadow` in any CSS it owns. If a thing looks like it wants a shadow, it wants a tonal step or a hairline.
+
+## 5. Components
+
+### Server Button (signature)
+
+- **Shape:** Fuselage `IconButton small secondary` (28-pixel square hit target with 4-pixel radius), wrapped in a 44-pixel-wide list item.
+- **Default:** Favicon or two-letter `Initials` on `surface-tint`. Initials use `c1` typography.
+- **Hover:** Background steps to `surface-selected`.
+- **Selected:** A 4-pixel-wide, 28-pixel-tall vertical bar in `surface-selected` (`#d7dbe0`) positioned `left: -8px` outside the button, right-edge radius `0 4px 4px 0`. Height transitions on `var(--transitions-duration)`. (`src/ui/components/SideBar/styles.tsx:22-49`.) Entire selected-state vocabulary.
+- **Unread count:** Fuselage `Badge variant='secondary'` (gray, `badge-background-level-1` = `#6c737a`) anchored top-right with `translate(30%, -30%)`.
+- **Not logged in:** Fuselage `Badge variant='warning'` (orange, `badge-background-level-3` = `#f38c39`), same anchor.
+- **Drag:** Opacity 0.5 while dragged. No border highlight on the drop target.
+- **Context menu:** Fuselage `Dropdown` with `Option`s: Reload, Copy URL, Open Dev Tools, Server Info, Reload Clearing Cache, divider, Remove (`variant='danger'`).
+
+### Sidebar Rail
+
+- **Width:** Exactly 44 pixels.
+- **Background:** `surface-tint` in opaque mode; `undefined` on macOS when `isTransparentWindowEnabled` (vibrancy passes through).
+- **Padding:** `paddingBlockStart={8} paddingBlockEnd={8}`.
+- **Layout:** Vertical `ButtonGroup large` of server buttons at the top, `MenuV2` (Downloads, Settings) anchored at the bottom.
+
+### TopBar (macOS only)
+
+- **Render:** `process.platform === 'darwin'` only.
+- **Background:** `surface-tint` (or `undefined` for vibrancy).
+- **Height:** 22-pixel drag bar above the rail.
+
+### SettingsView / DownloadsManagerView
+
+Full-window panels layered over the webview.
+- **Background:** `bg='room'` (Fuselage prop). Theme-following.
+- **Title:** `fontScale='h2'` with `pi={24} pbs={24} pbe={16}` rhythm.
+- **Tabs:** Wrapped in `<Box pi={24}>` to share the content gutter.
+- **Scroll content:** Inside `<Scrollable>` with `pi={24} pbs/pbe={16-24}` padding (never `m=` margin).
+- **Esc:** Dismisses the view via `onKeyDown` on the root `<Box>` (`tabIndex={-1}` to capture).
+
+### Dialogs (About, Update, Clear Cache, Screen Sharing, etc.)
+
+- **Surface:** Fuselage `Dialog` on `surface-light`.
+- **Corner:** `rounded.medium` (4px).
+- **Internal padding:** 24px on the outer Box; tighter inside form rows.
+- **Title:** `fontScale='h2'` or `h3`.
+- **Body:** `p1`, max 65 to 75 characters per line.
+- **Actions:** Right-aligned `ButtonGroup`. Primary uses `button-primary`; destructive uses `button-danger`.
+
+### Settings sections
+
+GeneralTab, DeveloperTab, and CertificatesManager all use the same `<Section>` shape: `fontScale='h4'` title, optional `c1` hint paragraph, contents inside a `FieldGroup` (settings) or content body (certs). Sections separate with `mbs={32}`. First section uses `mbs={0}`.
+
+### List rows (Downloads, Certificates)
+
+Two list surfaces share one row affordance pattern:
+- A 1-pixel `--rcx-color-stroke-extra-light` divider above each row (`:first-of-type` skipped).
+- A hover background of `--rcx-color-surface-hover`.
+- For Tables: Fuselage `<TableRow action>` carries this behavior natively. Do not use `striped` (clashes with `surface-room`).
+- For Box-based rows (DownloadItem): emotion `@rocket.chat/css-in-js` `css` block applies the divider + hover, with symmetric `pbs={16} pbe={16}` padding instead of `mbe={24}` so the hover bg reaches edge to edge.
+
+### Buttons (Fuselage `Button`)
+
+- **Primary:** `button-background-primary-default = #1d74f5`. Hover `#095ad2`, press `#10529e`. Font `font-white`. Used for the dominant action in any dialog.
+- **Secondary:** `button-background-secondary-default = #e4e7ea`. Hover `#cbced1`, press `#9ea2a8`. Font `font-default`.
+- **Danger:** `button-background-danger-default = #ec0d2a`. Hover `#d40c26`. Used only for Remove Server, Clear Cache, equivalent destructive confirmations.
+- **Warning:** `button-background-warning-default = warning-400`. Font `font-default` (dark text on yellow).
+- **Success:** `button-background-success-default = success-500`. Font `font-default`.
+- **Icon buttons:** Fuselage `IconButton small secondary` is the rail and chrome default. No labels alongside icons in chrome; tooltips carry meaning.
+- **Variants Fuselage does NOT have in this repo:** `ghost`. Do not pass that prop. Use `secondary` for subtle non-primary actions.
+
+### Dropdowns and Menus (Fuselage `Dropdown`, `Option`, `MenuV2`)
+
+- **Surface:** `surface-light` with Fuselage `shadow-elevation-2x`/`2y`.
+- **Items:** `OptionIcon` + `OptionContent`, single line, `p2`.
+- **Section labels:** `rcx-option__title` uppercased by Fuselage; source is sentence case.
+- **Dangerous items:** `variant='danger'` (Fuselage `font-danger` text).
+- **Dividers:** `OptionDivider` paints `stroke-extra-light`.
+
+### Badges (Fuselage `Badge`, exact level mapping)
+
+`variant` prop maps to `badge-background-level-*` tokens. **Live light-theme hex from `fuselage-tokens/badge.json`:**
+
+| variant | level | light hex | dark hex | use |
+|---|---|---|---|---|
+| (none) | 0 | `#e4e7ea` (n400) | `#404754` | disabled state |
+| `secondary` | 1 | `#6c737a` (n700) | `#484C51` | unread count |
+| `primary` | 2 | `#1d74f5` (b500) | `#2C65BA` | not used in rail |
+| `warning` | 3 | `#f38c39` (o500) | `#955828` | not-logged-in |
+| `danger` | 4 | `#f5455c` (r500) | `#B43C4C` | reserved alerts |
+
+All badges use `rounded.full` and white text.
+
+## 6. Do's and Don'ts
+
+### Do:
+
+- **Do** import primitives from `@rocket.chat/fuselage` first. Compose `Box`, `Button`, `IconButton`, `Badge`, `Dialog`, `Tabs`, `Dropdown`, `Option`, `MenuV2`, `Scrollable`, `Table` before reaching for `styled` or `@emotion/css`.
+- **Do** reference colors via the semantic `--rcx-color-<category>-<role>` CSS custom properties emitted by `PaletteStyleTag`. Never hand-code palette-grade vars like `--rcx-color-primary-500`; those are SCSS-only and not emitted at runtime.
+- **Do** use Fuselage `fontScale='h1'` / `'p2'` / `'c1'` etc. on `Box` and components rather than raw `font-size` literals.
+- **Do** keep the 44-pixel rail width sacred.
+- **Do** use the 4-pixel left selection stripe as the only selected-state decoration. Repeat it if a new affordance needs the gesture.
+- **Do** respect `prefers-reduced-motion` on every shell transition.
+- **Do** keep `Badge variant='secondary'` (gray) for unread counts and `variant='warning'` (orange) for not-logged-in.
+- **Do** verify every color choice in light, dark, **and high-contrast** themes before merging.
+- **Do** use sentence case in source strings; Fuselage applies title or uppercase at the component layer when needed.
+- **Do** apply the shared row affordance (`<TableRow action>` for tables; hairline+hover via emotion `css` for Box rows) to every new list surface.
+- **Do** use Fuselage `Box withTruncatedText` and a `title={...}` tooltip for long URLs, file names, and identifiers.
+- **Do** use `pi/pbs/pbe` Fuselage spacing shorthand on multiples of 4 (and 1, 2 where Fuselage allows).
+
+### Don't:
+
+- **Don't** use Discord/gamer aesthetics: no neon accents, no drenched dark purple, no playful microcopy.
+- **Don't** revive old Skype or legacy Teams chrome: no heavy gradients, no decorative iconography in titlebars.
+- **Don't** use generic SaaS marketing patterns: no hero metric tiles, no identical icon-and-title card grids, no gradient accents on numbers.
+- **Don't** pursue Linear-empty minimalism at the cost of sidebar density.
+- **Don't** use `border-left` or `border-right` greater than 1px as a colored stripe anywhere other than the canonical 4-pixel server selection stripe.
+- **Don't** use `background-clip: text` gradient text.
+- **Don't** introduce glassmorphism as a stylistic choice. OS-provided vibrancy is acceptable; CSS `backdrop-filter` is forbidden.
+- **Don't** author `box-shadow` in shell-owned CSS. Depth through tonal stepping; rely on Fuselage's overlay shadow for `Dropdown` and `Dialog`.
+- **Don't** treat the hardcoded `#2f343d` or `#d7dbe0` fallbacks as design tokens. They are pre-hydration backstops only. The live value of `surface-room` is `#ffffff` in light theme.
+- **Don't** pass a `ghost` prop to Fuselage `Button` (does not exist on this version). Use `secondary` for the subtle variant.
+- **Don't** use `Table striped`. The stripe clashes with `bg='room'` and violates the Tonal Step Rule. Use `<TableRow action>` for hover affordance instead.
+- **Don't** strip Inter out of the font stack.
+- **Don't** wrap shell content in card grids.
+- **Don't** use modals as the first thought for new flows.
+- **Don't** rename, recolor, or re-style Fuselage `Badge`, `Option`, `Tabs`, `Dropdown`, `IconButton` primitives.
+- **Don't** confuse Badge variants: unread is `secondary` (gray `#6c737a`), not-logged-in is `warning` (orange), danger (`#f5455c`) is reserved for true alerts. Red mention badges are not part of this design system.
+- **Don't** invent `border-radius` outside `2 / 4 / 8 / 9999` pixels.
+- **Don't** add a settings divergence between light, dark, and high-contrast themes. All three must offer the same affordances; only the palette resolves differently.
+- **Don't** use em dashes anywhere in shell copy. Commas, colons, semicolons, periods, parentheses only.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -270,7 +270,14 @@ Use Fuselage `fontScale` props on `Box` and components rather than raw CSS. Each
 
 **The fontScale Rule.** Use Fuselage `fontScale='p2'` (or other key) on `Box` rather than raw `font-size` literals. Pixel literals drift; scale tags are the contract.
 
-**The Inter-First Rule.** Inter at the front of the family stack. Do not strip back to `system-ui`. The existing `font-family: system-ui` in `Shell/styles.tsx:37` predates the Inter migration in Fuselage and is a known drift item.
+**The Inter-First Rule.** Inter at the front of the family stack inside React-rendered surfaces. Do not strip back to `system-ui`.
+
+**The Pre-Hydration Exception.** Two stylesheets are loaded by `index.html` before the React tree mounts and before Fuselage's `PaletteStyleTag` runs:
+
+- `src/public/loading.css` (renderer boot splash)
+- `src/public/error.css` (renderer fatal-error screen)
+
+These intentionally use `font-family: system-ui` and the hardcoded `#2f343d` background (also seen in `Shell/styles.tsx` and `SideBar/styles.tsx` as fallback values inside `var()` expressions). Inter is not yet available at this point; `--rcx-color-*` variables are not yet emitted; the React palette has not hydrated. The hardcoded values are the only thing visible in the racy window between window-open and first paint. **Do not "fix" them to reference Fuselage tokens or Inter, and do not reuse those hex literals anywhere else.** They are bug-prevention backstops, not design tokens.
 
 **The Sentence Case Rule.** All shell strings are sentence case in source. Fuselage applies title case or uppercase at the component layer when needed (e.g. `Option.title` is uppercased by CSS).
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,52 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Enterprise knowledge workers who keep Rocket.Chat open all day, often in the background. Many work inside regulated or self-hosted environments (government, healthcare, finance, on-prem IT). A meaningful subset are power users juggling multiple Rocket.Chat workspaces (work + community + customer tenants) and depend on the desktop client for fast cross-server switching, OS-level notifications, and native integrations the browser cannot offer.
+
+Primary context: long-session use on a work machine, alongside other native apps. Users alt-tab in and out; they do not study the chrome, they reach for it.
+
+## Product Purpose
+
+Rocket.Chat Desktop is the native shell around one or more Rocket.Chat server webviews. Its job is to make managing multiple workspaces fast: server list switching, notification badges, deep links, certificate handling, screen sharing, downloads, tray presence, auto-update. The webview is the chat product; the desktop client is the connective tissue that makes running several at once feel like one tool instead of several browser tabs.
+
+Success looks like: users forget the shell exists during normal use, and reach for it instinctively the moment they need to switch servers, recover from a stuck webview, or configure something the browser cannot do.
+
+## Brand Personality
+
+Reliable, professional, focused. Voice is plain and unornamented: short labels, no marketing flourishes, no playful microcopy. The interface should feel like a tool an IT admin would trust on a regulated network, while remaining warm enough for end users who live in it eight hours a day. Confident, not loud. Capable, not clever.
+
+## Anti-references
+
+- **Discord / gamer chat aesthetics.** Neon accents, drenched dark purple, playful empty states, animated reactions in chrome. Wrong register for enterprise and public sector.
+- **Old Skype / legacy Teams chrome.** Heavy gradients, layered drop shadows, busy toolbars, decorative iconography in titlebars. Dated, visually noisy, undermines trust.
+- **Generic SaaS marketing patterns inside the app.** Gradient hero numbers, identical icon-and-title card grids, "modern dashboard" aesthetics. The desktop shell is not a marketing surface.
+- **Pure brand minimalism (Linear-empty for its own sake).** Multi-server power users need information density in the sidebar. Sparse-for-sparseness-sake hides the value of the shell.
+
+## Design Principles
+
+1. **Shell disappears, servers shine.** Desktop chrome must not compete with the webview. Sidebar, titlebar, and dialogs exist to switch, notify, and configure, then recede. If a chrome element draws the eye during normal chat use, it is wrong.
+
+2. **Density without clutter.** Multi-workspace power users need many servers and signals visible at once. Earn every pixel: tight rhythm, considered hierarchy, no decorative padding. Density and clarity are compatible; sparse is not automatically better.
+
+3. **Native, not web-pretending.** Respect OS conventions per platform: macOS traffic lights and vibrancy, Windows titlebar buttons and Mica, Linux menubar fallbacks. The desktop edge over the browser IS the native feel. Cross-platform consistency matters less than per-platform correctness.
+
+4. **Trust through restraint.** Enterprise, government, and healthcare users need confidence. No surprises, no flourishes, no theatrical motion. Predictable beats clever. Errors are quiet and actionable, not dramatic.
+
+5. **Fuselage first, custom last.** Visual coherence with the Rocket.Chat web app is a feature for users who move between web and desktop. Use `@rocket.chat/fuselage` primitives by default. Introduce custom components only where the desktop shell has no web equivalent (server sidebar, native dialogs, platform-specific affordances).
+
+## Accessibility & Inclusion
+
+Target: **WCAG 2.2 AA**, with attention to extras commonly required by Rocket.Chat's public sector and healthcare deployments.
+
+- Full keyboard navigation across the shell (sidebar, menus, dialogs). No mouse-only affordances.
+- Screen reader labels on every interactive shell element, including server sidebar entries and notification badges.
+- Honor `prefers-reduced-motion` for all shell motion (sidebar transitions, dialog enters, badge animations).
+- Honor system-level high contrast and forced colors on Windows.
+- Contrast meets 2.2 AA against the active theme; verify against both light and dark.
+- Do not rely on color alone to convey state (unread, error, connecting). Always pair with shape, icon, or text.
+- Color-vision-deficient safe accent choices when introducing new status colors.

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -123,12 +123,12 @@
     "executableName": "rocketchat-desktop",
     "category": "GNOME;GTK;Network;InstantMessaging",
     "desktop": {
-      "MimeType": "x-scheme-handler/rocketchat;x-scheme-handler/callto;x-scheme-handler/tel;",
       "entry": {
         "Name": "Rocket.Chat",
         "Comment": "Official Rocket.Chat Desktop Client",
         "GenericName": "Rocket.Chat",
-        "Categories": "GNOME;GTK;Network;InstantMessaging"
+        "Categories": "GNOME;GTK;Network;InstantMessaging",
+        "MimeType": "x-scheme-handler/rocketchat;x-scheme-handler/callto;x-scheme-handler/tel;"
       }
     },
     "artifactName": "rocketchat-${version}-${os}-${arch}.${ext}"

--- a/src/i18n/en.i18n.json
+++ b/src/i18n/en.i18n.json
@@ -234,10 +234,16 @@
   },
   "settings": {
     "title": "Settings",
+    "back": "Back",
     "general": "General",
     "certificates": "Certificates",
     "developer": "Developer",
     "sections": {
+      "notifications": "Notifications",
+      "performance": "Performance",
+      "callsAndVideo": "Calls & video",
+      "windowAndAppearance": "Window & appearance",
+      "integrations": "Integrations",
       "logging": "Logging"
     },
     "options": {

--- a/src/i18n/en.i18n.json
+++ b/src/i18n/en.i18n.json
@@ -225,7 +225,13 @@
   "certificatesManager": {
     "title": "Certificates manager",
     "trustedCertificates": "Trusted certificates",
+    "trustedHint": "Servers whose certificates you accepted when connecting. Remove an entry to be prompted again on the next connection.",
     "notTrustedCertificates": "Not trusted certificates",
+    "notTrustedHint": "Servers whose certificates were flagged and not stored. Remove an entry to clear the rejection.",
+    "empty": {
+      "trusted": "No trusted certificates yet.",
+      "notTrusted": "No certificates have been flagged."
+    },
     "item": {
       "domain": "Domain",
       "actions": "Actions",

--- a/src/i18n/en.i18n.json
+++ b/src/i18n/en.i18n.json
@@ -182,6 +182,13 @@
   },
   "downloads": {
     "title": "Downloads",
+    "back": "Back",
+    "empty": {
+      "noDownloads": "No downloads yet.",
+      "noDownloadsDescription": "Files downloaded from your Rocket.Chat workspaces appear here.",
+      "noResults": "No downloads match these filters.",
+      "noResultsAction": "Clear filters"
+    },
     "notifications": {
       "downloadFinished": "Download Finished",
       "downloadInterrupted": "Download Interrupted",
@@ -218,7 +225,7 @@
       "remove": "Remove from list",
       "resume": "Resume",
       "retry": "Retry",
-      "showInFolder": "Show in Folder"
+      "showInFolder": "Show in folder"
     },
     "showingResults": "Showing results {{first}} - {{last}} of {{count}}"
   },

--- a/src/ui/components/CertificatesManager/ActionButton.tsx
+++ b/src/ui/components/CertificatesManager/ActionButton.tsx
@@ -1,14 +1,10 @@
-import { Box } from '@rocket.chat/fuselage';
-import type { AllHTMLAttributes } from 'react';
+import { Button } from '@rocket.chat/fuselage';
+import type { ComponentProps } from 'react';
 
-type ActionButtonProps = AllHTMLAttributes<HTMLAnchorElement>;
+type ActionButtonProps = ComponentProps<typeof Button>;
 
 const ActionButton = (props: ActionButtonProps) => (
-  <>
-    <Box marginInline={4} withRichContent>
-      <a href='#' {...props} />
-    </Box>
-  </>
+  <Button small danger {...props} />
 );
 
 export default ActionButton;

--- a/src/ui/components/CertificatesManager/CertificateItem.tsx
+++ b/src/ui/components/CertificatesManager/CertificateItem.tsx
@@ -17,7 +17,7 @@ const CertificateItem = ({ url }: CertificateItemProps) => {
   }, [url]);
 
   return (
-    <TableRow key={url}>
+    <TableRow key={url} action>
       <TableCell>
         <Box withTruncatedText title={url}>
           {url}

--- a/src/ui/components/CertificatesManager/CertificateItem.tsx
+++ b/src/ui/components/CertificatesManager/CertificateItem.tsx
@@ -1,4 +1,4 @@
-import { Icon, TableCell, TableRow } from '@rocket.chat/fuselage';
+import { Box, TableCell, TableRow } from '@rocket.chat/fuselage';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -19,8 +19,9 @@ const CertificateItem = ({ url }: CertificateItemProps) => {
   return (
     <TableRow key={url}>
       <TableCell>
-        <Icon name='key' size='x16' />
-        {url}
+        <Box withTruncatedText title={url}>
+          {url}
+        </Box>
       </TableCell>
       <TableCell align='end'>
         <ActionButton onClick={handleRemove}>

--- a/src/ui/components/CertificatesManager/CertificateSection.tsx
+++ b/src/ui/components/CertificatesManager/CertificateSection.tsx
@@ -1,0 +1,60 @@
+import {
+  Box,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+} from '@rocket.chat/fuselage';
+import { useTranslation } from 'react-i18next';
+
+import CertificateItem from './CertificateItem';
+
+export type CertificateSectionProps = {
+  title: string;
+  hint: string;
+  emptyText: string;
+  urls: string[];
+  isFirst?: boolean;
+};
+
+export const CertificateSection = ({
+  title,
+  hint,
+  emptyText,
+  urls,
+  isFirst,
+}: CertificateSectionProps) => {
+  const { t } = useTranslation();
+  return (
+    <Box mbs={isFirst ? 0 : 32}>
+      <Box fontScale='h4' color='font-default' mbe={8}>
+        {title}
+      </Box>
+      <Box fontScale='c1' color='font-hint' mbe={16}>
+        {hint}
+      </Box>
+      {urls.length === 0 ? (
+        <Box fontScale='p2' color='font-annotation' pb={16}>
+          {emptyText}
+        </Box>
+      ) : (
+        <Table fixed>
+          <TableHead>
+            <TableRow>
+              <TableCell>{t('certificatesManager.item.domain')}</TableCell>
+              <TableCell align='end' width='x120'>
+                {t('certificatesManager.item.actions')}
+              </TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {urls.map((url) => (
+              <CertificateItem key={url} url={url} />
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </Box>
+  );
+};

--- a/src/ui/components/CertificatesManager/CertificatesManager.tsx
+++ b/src/ui/components/CertificatesManager/CertificatesManager.tsx
@@ -1,5 +1,4 @@
 import {
-  Label,
   Box,
   Table,
   TableHead,
@@ -7,11 +6,73 @@ import {
   TableCell,
   TableBody,
 } from '@rocket.chat/fuselage';
+import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
 import type { RootState } from '../../../store/rootReducer';
 import CertificateItem from './CertificateItem';
+
+type CertificateSectionProps = {
+  title: string;
+  hint: string;
+  emptyText: string;
+  urls: string[];
+  isFirst?: boolean;
+};
+
+const CertificateSection = ({
+  title,
+  hint,
+  emptyText,
+  urls,
+  isFirst,
+}: CertificateSectionProps) => {
+  const { t } = useTranslation();
+  return (
+    <Box mbs={isFirst ? 0 : 32}>
+      <Box fontScale='h4' color='font-default' mbe={8}>
+        {title}
+      </Box>
+      <Box fontScale='c1' color='hint' mbe={16}>
+        {hint}
+      </Box>
+      {urls.length === 0 ? (
+        <Box fontScale='p2' color='annotation' pb={16}>
+          {emptyText}
+        </Box>
+      ) : (
+        <Table striped fixed>
+          <TableHead>
+            <TableRow>
+              <TableCell>{t('certificatesManager.item.domain')}</TableCell>
+              <TableCell align='end' width='x120'>
+                {t('certificatesManager.item.actions')}
+              </TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {urls.map((url) => (
+              <CertificateItem key={url} url={url} />
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </Box>
+  );
+};
+
+type CertificatesManagerWrapperProps = {
+  children: ReactNode;
+};
+
+const CertificatesManagerWrapper = ({
+  children,
+}: CertificatesManagerWrapperProps) => (
+  <Box flexGrow={1} flexShrink={1}>
+    {children}
+  </Box>
+);
 
 export const CertificatesManager = () => {
   const trustedCertificates = useSelector(
@@ -23,44 +84,22 @@ export const CertificatesManager = () => {
   );
 
   const { t } = useTranslation();
+
   return (
-    <Box is='form' padding={24} flexGrow={1} flexShrink={1}>
-      <Box flexGrow={1} flexShrink={1} paddingBlock={8}>
-        <Label>{t('certificatesManager.trustedCertificates')}</Label>
-        <Table sticky striped fixed>
-          <TableHead>
-            <TableRow>
-              <TableCell>{t('certificatesManager.item.domain')}</TableCell>
-              <TableCell align='end'>
-                {t('certificatesManager.item.actions')}
-              </TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {Object.keys(trustedCertificates).map((url) => (
-              <CertificateItem key={url} url={url} />
-            ))}
-          </TableBody>
-        </Table>
-      </Box>
-      <Box marginBlockStart={50} flexGrow={1} flexShrink={1} paddingBlock={8}>
-        <Label>{t('certificatesManager.notTrustedCertificates')}</Label>
-        <Table sticky striped fixed>
-          <TableHead>
-            <TableRow>
-              <TableCell>{t('certificatesManager.item.domain')}</TableCell>
-              <TableCell align='end'>
-                {t('certificatesManager.item.actions')}
-              </TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {Object.keys(notTrustedCertificates).map((url) => (
-              <CertificateItem key={url} url={url} />
-            ))}
-          </TableBody>
-        </Table>
-      </Box>
-    </Box>
+    <CertificatesManagerWrapper>
+      <CertificateSection
+        isFirst
+        title={t('certificatesManager.trustedCertificates')}
+        hint={t('certificatesManager.trustedHint')}
+        emptyText={t('certificatesManager.empty.trusted')}
+        urls={Object.keys(trustedCertificates)}
+      />
+      <CertificateSection
+        title={t('certificatesManager.notTrustedCertificates')}
+        hint={t('certificatesManager.notTrustedHint')}
+        emptyText={t('certificatesManager.empty.notTrusted')}
+        urls={Object.keys(notTrustedCertificates)}
+      />
+    </CertificatesManagerWrapper>
   );
 };

--- a/src/ui/components/CertificatesManager/CertificatesManager.tsx
+++ b/src/ui/components/CertificatesManager/CertificatesManager.tsx
@@ -1,78 +1,9 @@
-import {
-  Box,
-  Table,
-  TableHead,
-  TableRow,
-  TableCell,
-  TableBody,
-} from '@rocket.chat/fuselage';
-import type { ReactNode } from 'react';
+import { Box } from '@rocket.chat/fuselage';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
 import type { RootState } from '../../../store/rootReducer';
-import CertificateItem from './CertificateItem';
-
-type CertificateSectionProps = {
-  title: string;
-  hint: string;
-  emptyText: string;
-  urls: string[];
-  isFirst?: boolean;
-};
-
-const CertificateSection = ({
-  title,
-  hint,
-  emptyText,
-  urls,
-  isFirst,
-}: CertificateSectionProps) => {
-  const { t } = useTranslation();
-  return (
-    <Box mbs={isFirst ? 0 : 32}>
-      <Box fontScale='h4' color='font-default' mbe={8}>
-        {title}
-      </Box>
-      <Box fontScale='c1' color='font-hint' mbe={16}>
-        {hint}
-      </Box>
-      {urls.length === 0 ? (
-        <Box fontScale='p2' color='font-annotation' pb={16}>
-          {emptyText}
-        </Box>
-      ) : (
-        <Table fixed>
-          <TableHead>
-            <TableRow>
-              <TableCell>{t('certificatesManager.item.domain')}</TableCell>
-              <TableCell align='end' width='x120'>
-                {t('certificatesManager.item.actions')}
-              </TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {urls.map((url) => (
-              <CertificateItem key={url} url={url} />
-            ))}
-          </TableBody>
-        </Table>
-      )}
-    </Box>
-  );
-};
-
-type CertificatesManagerWrapperProps = {
-  children: ReactNode;
-};
-
-const CertificatesManagerWrapper = ({
-  children,
-}: CertificatesManagerWrapperProps) => (
-  <Box flexGrow={1} flexShrink={1}>
-    {children}
-  </Box>
-);
+import { CertificateSection } from './CertificateSection';
 
 export const CertificatesManager = () => {
   const trustedCertificates = useSelector(
@@ -86,7 +17,7 @@ export const CertificatesManager = () => {
   const { t } = useTranslation();
 
   return (
-    <CertificatesManagerWrapper>
+    <Box flexGrow={1} flexShrink={1}>
       <CertificateSection
         isFirst
         title={t('certificatesManager.trustedCertificates')}
@@ -100,6 +31,6 @@ export const CertificatesManager = () => {
         emptyText={t('certificatesManager.empty.notTrusted')}
         urls={Object.keys(notTrustedCertificates)}
       />
-    </CertificatesManagerWrapper>
+    </Box>
   );
 };

--- a/src/ui/components/CertificatesManager/CertificatesManager.tsx
+++ b/src/ui/components/CertificatesManager/CertificatesManager.tsx
@@ -34,11 +34,11 @@ const CertificateSection = ({
       <Box fontScale='h4' color='font-default' mbe={8}>
         {title}
       </Box>
-      <Box fontScale='c1' color='hint' mbe={16}>
+      <Box fontScale='c1' color='font-hint' mbe={16}>
         {hint}
       </Box>
       {urls.length === 0 ? (
-        <Box fontScale='p2' color='annotation' pb={16}>
+        <Box fontScale='p2' color='font-annotation' pb={16}>
           {emptyText}
         </Box>
       ) : (

--- a/src/ui/components/CertificatesManager/CertificatesManager.tsx
+++ b/src/ui/components/CertificatesManager/CertificatesManager.tsx
@@ -42,7 +42,7 @@ const CertificateSection = ({
           {emptyText}
         </Box>
       ) : (
-        <Table striped fixed>
+        <Table fixed>
           <TableHead>
             <TableRow>
               <TableCell>{t('certificatesManager.item.domain')}</TableCell>

--- a/src/ui/components/DownloadsManagerView/ActionButton.tsx
+++ b/src/ui/components/DownloadsManagerView/ActionButton.tsx
@@ -1,14 +1,10 @@
-import { Box } from '@rocket.chat/fuselage';
-import type { AllHTMLAttributes } from 'react';
+import { Button } from '@rocket.chat/fuselage';
+import type { ComponentProps } from 'react';
 
-type ActionButtonProps = AllHTMLAttributes<HTMLAnchorElement>;
+type ActionButtonProps = ComponentProps<typeof Button>;
 
 const ActionButton = (props: ActionButtonProps) => (
-  <>
-    <Box marginInline={4} withRichContent>
-      <a href='#' {...props} />
-    </Box>
-  </>
+  <Button small secondary {...props} />
 );
 
 export default ActionButton;

--- a/src/ui/components/DownloadsManagerView/DownloadItem.tsx
+++ b/src/ui/components/DownloadsManagerView/DownloadItem.tsx
@@ -1,4 +1,5 @@
-import { Box, ProgressBar } from '@rocket.chat/fuselage';
+import { css } from '@rocket.chat/css-in-js';
+import { Box, ButtonGroup, ProgressBar } from '@rocket.chat/fuselage';
 import type { ComponentProps } from 'react';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -9,6 +10,18 @@ import ActionButton from './ActionButton';
 import FileIcon from './FileIcon';
 
 type DownloadItemProps = Download & ComponentProps<typeof Box>;
+
+const rowStyles = css`
+  border-block-start: 1px solid
+    var(--rcx-color-stroke-extra-light, transparent);
+  transition: background-color 120ms ease-out;
+  &:first-of-type {
+    border-block-start: none;
+  }
+  &:hover {
+    background-color: var(--rcx-color-surface-hover, transparent);
+  }
+`;
 
 const DownloadItem = ({
   itemId,
@@ -114,50 +127,67 @@ const DownloadItem = ({
 
   return (
     <Box
+      className={rowStyles}
       width='100%'
-      height={44}
-      mbe={26}
+      pbs={16}
+      pbe={16}
+      pi={8}
       display='flex'
       alignItems='center'
       {...props}
     >
       <Box
-        width={388}
         flexShrink={0}
         display='flex'
         flexDirection='row'
-        alignItems='left'
-        justifyContent='center'
+        alignItems='center'
+        minWidth='x320'
+        maxWidth='x388'
+        flexGrow={0}
+        flexBasis='x388'
       >
         <FileIcon fileName={fileName} mimeType={mimeType} />
-        <Box width={344} mis={8}>
+        <Box mis={8} minWidth={0} flexGrow={1}>
           <Box
             mbe={4}
-            color={errored || expired ? 'danger-500' : 'default'}
+            color={errored || expired ? 'font-danger' : 'font-default'}
             fontScale='p1'
             withTruncatedText
           >
             {fileName}
           </Box>
-          <Box color='neutral-600' fontScale='c1' withTruncatedText>
+          <Box color='font-secondary-info' fontScale='c1' withTruncatedText>
             {serverTitle}
           </Box>
         </Box>
       </Box>
 
-      <Box display='flex' flexDirection='column' flexGrow={1} mi={16}>
+      <Box
+        display='flex'
+        flexDirection='column'
+        flexGrow={1}
+        flexShrink={1}
+        minWidth={0}
+        mi={16}
+      >
         <Box
           display='flex'
           flexDirection='row'
-          mbe={6}
+          mbe={8}
           alignItems='center'
           justifyContent='space-between'
         >
-          <Box display='flex' flexDirection='row' alignItems='center'>
+          <Box
+            display='flex'
+            flexDirection='row'
+            alignItems='center'
+            minWidth={0}
+            flexShrink={1}
+          >
             {progressSize ? (
               <Box
                 mie={12}
-                color='neutral-600'
+                color='font-secondary-info'
                 fontScale='c1'
                 withTruncatedText
               >
@@ -167,7 +197,7 @@ const DownloadItem = ({
             {progressSpeed ? (
               <Box
                 mie={12}
-                color='neutral-600'
+                color='font-secondary-info'
                 fontScale='c1'
                 withTruncatedText
               >
@@ -175,14 +205,18 @@ const DownloadItem = ({
               </Box>
             ) : null}
             {estimatedTimeLeft ? (
-              <Box color='neutral-600' fontScale='c1' withTruncatedText>
+              <Box
+                color='font-secondary-info'
+                fontScale='c1'
+                withTruncatedText
+              >
                 {estimatedTimeLeft}
               </Box>
             ) : null}
           </Box>
-          <Box display='flex' fontScale='c1'>
+          <ButtonGroup small>
             {expired && (
-              <ActionButton onClick={handleRemove}>
+              <ActionButton danger onClick={handleRemove}>
                 {t('downloads.item.remove')}
               </ActionButton>
             )}
@@ -196,7 +230,7 @@ const DownloadItem = ({
                 <ActionButton onClick={handlePause}>
                   {t('downloads.item.pause')}
                 </ActionButton>
-                <ActionButton onClick={handleCancel}>
+                <ActionButton danger onClick={handleCancel}>
                   {t('downloads.item.cancel')}
                 </ActionButton>
               </>
@@ -206,7 +240,7 @@ const DownloadItem = ({
                 <ActionButton onClick={handleResume}>
                   {t('downloads.item.resume')}
                 </ActionButton>
-                <ActionButton onClick={handleCancel}>
+                <ActionButton danger onClick={handleCancel}>
                   {t('downloads.item.cancel')}
                 </ActionButton>
               </>
@@ -216,7 +250,7 @@ const DownloadItem = ({
                 <ActionButton onClick={handleShowInFolder}>
                   {t('downloads.item.showInFolder')}
                 </ActionButton>
-                <ActionButton onClick={handleRemove}>
+                <ActionButton danger onClick={handleRemove}>
                   {t('downloads.item.remove')}
                 </ActionButton>
               </>
@@ -226,21 +260,22 @@ const DownloadItem = ({
                 <ActionButton onClick={handleRetry}>
                   {t('downloads.item.retry')}
                 </ActionButton>
-                <ActionButton onClick={handleRemove}>
+                <ActionButton danger onClick={handleRemove}>
                   {t('downloads.item.remove')}
                 </ActionButton>
               </>
             )}
+          </ButtonGroup>
+        </Box>
+        {state !== 'completed' && (
+          <Box position='relative'>
+            <ProgressBar
+              percentage={percentage}
+              error={errored ? t('downloads.item.errored') : undefined}
+              animated={percentage !== 100}
+            />
           </Box>
-        </Box>
-        <Box mbe={8} position='relative'>
-          <ProgressBar
-            percentage={percentage}
-            error={errored ? t('downloads.item.errored') : undefined}
-            // TODO: get complete file details, such as file-size from different cloud storages
-            animated={percentage !== 100}
-          />
-        </Box>
+        )}
       </Box>
     </Box>
   );

--- a/src/ui/components/DownloadsManagerView/DownloadItem.tsx
+++ b/src/ui/components/DownloadsManagerView/DownloadItem.tsx
@@ -12,8 +12,7 @@ import FileIcon from './FileIcon';
 type DownloadItemProps = Download & ComponentProps<typeof Box>;
 
 const rowStyles = css`
-  border-block-start: 1px solid
-    var(--rcx-color-stroke-extra-light, transparent);
+  border-block-start: 1px solid var(--rcx-color-stroke-extra-light, transparent);
   transition: background-color 120ms ease-out;
   &:first-of-type {
     border-block-start: none;
@@ -205,11 +204,7 @@ const DownloadItem = ({
               </Box>
             ) : null}
             {estimatedTimeLeft ? (
-              <Box
-                color='font-secondary-info'
-                fontScale='c1'
-                withTruncatedText
-              >
+              <Box color='font-secondary-info' fontScale='c1' withTruncatedText>
                 {estimatedTimeLeft}
               </Box>
             ) : null}

--- a/src/ui/components/DownloadsManagerView/FileIcon.tsx
+++ b/src/ui/components/DownloadsManagerView/FileIcon.tsx
@@ -26,7 +26,7 @@ const FileIcon = ({ fileName, mimeType }: FileIconProps) => {
         width={32}
         mi={2}
         mbs={-20}
-        color='neutral-600'
+        color='font-secondary-info'
         fontScale='c2'
         textAlign='center'
         withTruncatedText

--- a/src/ui/components/DownloadsManagerView/index.tsx
+++ b/src/ui/components/DownloadsManagerView/index.tsx
@@ -221,7 +221,7 @@ const DownloadsManagerView = () => {
         flexWrap='nowrap'
         alignItems='center'
         fontScale='h2'
-        color='default'
+        color='font-default'
       >
         {!isSideBarEnabled && (
           <Box mie={8} display='flex' alignItems='center'>

--- a/src/ui/components/DownloadsManagerView/index.tsx
+++ b/src/ui/components/DownloadsManagerView/index.tsx
@@ -1,14 +1,15 @@
 import {
   Box,
+  Button,
   SearchInput,
   Icon,
   Pagination,
   Scrollable,
   IconButton,
-  SelectLegacy,
+  Select,
 } from '@rocket.chat/fuselage';
 import { useLocalStorage } from '@rocket.chat/fuselage-hooks';
-import type { ChangeEvent } from 'react';
+import type { ChangeEvent, Key, KeyboardEvent } from 'react';
 import { useState, useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
@@ -68,8 +69,8 @@ const DownloadsManagerView = () => {
   >('download-server', '');
 
   const handleServerFilterChange = useCallback(
-    (value: (typeof serverFilterOptions)[number][0]) => {
-      setServerFilter(value);
+    (value: Key) => {
+      setServerFilter(String(value));
     },
     [setServerFilter]
   );
@@ -91,8 +92,8 @@ const DownloadsManagerView = () => {
   >('download-type', '');
 
   const handleMimeFilter = useCallback(
-    (value: (typeof mimeTypeOptions)[number][0]) => {
-      setMimeTypeFilter(value);
+    (value: Key) => {
+      setMimeTypeFilter(String(value));
     },
     [setMimeTypeFilter]
   );
@@ -111,17 +112,23 @@ const DownloadsManagerView = () => {
   >('download-tab', DownloadStatus.ALL);
 
   const handleTabChange = useCallback(
-    (value: (typeof statusFilterOptions)[number][0]) => {
-      setStatusFilter(value);
+    (value: Key) => {
+      setStatusFilter(String(value));
     },
     [setStatusFilter]
   );
+
+  const hasActiveFilters =
+    Boolean(searchFilter) ||
+    (serverFilter !== '' && serverFilter !== '*') ||
+    (mimeTypeFilter !== '' && mimeTypeFilter !== '*') ||
+    (statusFilter !== '' && statusFilter !== DownloadStatus.ALL);
 
   const handleClearAll = useCallback((): void => {
     setSearchFilter('');
     setMimeTypeFilter('');
     setServerFilter('');
-    setStatusFilter('');
+    setStatusFilter(DownloadStatus.ALL);
   }, [setSearchFilter, setMimeTypeFilter, setServerFilter, setStatusFilter]);
 
   const [itemsPerPage, setItemsPerPage] = useState<25 | 50 | 100>(25);
@@ -143,6 +150,10 @@ const DownloadsManagerView = () => {
         count,
       }),
     [t]
+  );
+
+  const totalDownloads = useSelector(
+    ({ downloads }: RootState) => Object.keys(downloads).length
   );
 
   const downloads = useSelector(({ downloads }: RootState) => {
@@ -170,12 +181,24 @@ const DownloadsManagerView = () => {
       .sort((a, b) => b.itemId - a.itemId);
   });
 
-  const handleBackButton = function (): void {
+  const handleBackButton = useCallback((): void => {
     dispatch({
       type: DOWNLOADS_BACK_BUTTON_CLICKED,
       payload: lastSelectedServerUrl,
     });
-  };
+  }, [lastSelectedServerUrl]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === 'Escape') {
+        handleBackButton();
+      }
+    },
+    [handleBackButton]
+  );
+
+  const isEmpty = downloads.length === 0;
+  const noDownloadsAtAll = totalDownloads === 0;
 
   return (
     <Box
@@ -185,93 +208,146 @@ const DownloadsManagerView = () => {
       flexDirection='column'
       height='full'
       width='full'
-      backgroundColor='light'
+      bg='room'
+      onKeyDown={handleKeyDown}
+      tabIndex={isVisible ? -1 : undefined}
     >
       <Box
-        minHeight={64}
-        padding={24}
+        pi={24}
+        pbs={24}
+        pbe={16}
         display='flex'
         flexDirection='row'
         flexWrap='nowrap'
         alignItems='center'
+        fontScale='h2'
+        color='default'
       >
         {!isSideBarEnabled && (
-          <IconButton icon='arrow-back' onClick={handleBackButton} />
+          <Box mie={8} display='flex' alignItems='center'>
+            <IconButton
+              icon='arrow-back'
+              onClick={handleBackButton}
+              aria-label={t('downloads.back')}
+            />
+          </Box>
         )}
-        <Box is='div' color='default' fontScale='h1'>
-          {t('downloads.title')}
-        </Box>
+        {t('downloads.title')}
       </Box>
+
       <Box
         display='flex'
-        justifyContent='space-between'
         alignItems='center'
-        marginBlock={8}
-        padding={24}
+        pi={24}
+        pbe={16}
       >
         <Box
-          display='flex'
-          flexGrow={7}
-          flexShrink={7}
-          flexBasis='0'
-          paddingInline={2}
+          flexGrow={3}
+          flexShrink={1}
+          flexBasis={0}
+          minWidth='x160'
+          mie={8}
         >
           <SearchInput
             value={searchFilter}
             placeholder={t('downloads.filters.search')}
-            addon={<Icon name='magnifier' size={20} />}
+            addon={<Icon name='magnifier' size='x20' />}
             onChange={handleSearchFilterChange}
           />
         </Box>
         <Box
-          display='flex'
-          flexGrow={3}
-          flexShrink={3}
-          flexBasis='0'
-          paddingInline={2}
+          flexGrow={2}
+          flexShrink={1}
+          flexBasis={0}
+          minWidth='x140'
+          mie={8}
         >
-          <SelectLegacy
+          <Select
             value={serverFilter}
             placeholder={t('downloads.filters.server')}
             options={serverFilterOptions}
             onChange={handleServerFilterChange}
           />
         </Box>
-        <Box display='flex' flexGrow={3} flexShrink={3} paddingInline={2}>
-          <SelectLegacy
+        <Box
+          flexGrow={2}
+          flexShrink={1}
+          flexBasis={0}
+          minWidth='x120'
+          mie={8}
+        >
+          <Select
             value={mimeTypeFilter}
             placeholder={t('downloads.filters.mimeType')}
             options={mimeTypeOptions}
             onChange={handleMimeFilter}
           />
         </Box>
-        <Box display='flex' flexGrow={3} flexShrink={3} paddingInline={2}>
-          <SelectLegacy
+        <Box
+          flexGrow={2}
+          flexShrink={1}
+          flexBasis={0}
+          minWidth='x120'
+          mie={8}
+        >
+          <Select
             value={statusFilter}
             placeholder={t('downloads.filters.status')}
             options={statusFilterOptions}
             onChange={handleTabChange}
           />
         </Box>
-        <Box display='flex' flexGrow={1} flexShrink={1} paddingInline={2}>
-          <IconButton
-            icon='trash'
-            title={t('downloads.filters.clear')}
-            onClick={handleClearAll}
-          />
-        </Box>
+        <IconButton
+          icon='cross'
+          aria-label={t('downloads.filters.clear')}
+          title={t('downloads.filters.clear')}
+          disabled={!hasActiveFilters}
+          onClick={handleClearAll}
+        />
       </Box>
+
       <Scrollable>
-        <Box flexGrow={1} flexShrink={1} paddingBlock={8} paddingInline={64}>
-          <Box>
-            {downloads
+        <Box flexGrow={1} flexShrink={1} pi={24} pbs={16} pbe={16}>
+          {isEmpty ? (
+            <Box
+              display='flex'
+              flexDirection='column'
+              alignItems='center'
+              justifyContent='center'
+              pb={64}
+              pbs={64}
+            >
+              <Box fontScale='h4' color='font-default' mbe={8}>
+                {noDownloadsAtAll
+                  ? t('downloads.empty.noDownloads')
+                  : t('downloads.empty.noResults')}
+              </Box>
+              <Box
+                fontScale='p2'
+                color='font-secondary-info'
+                mbe={hasActiveFilters ? 16 : 0}
+                style={{ maxWidth: '48ch', textAlign: 'center' }}
+              >
+                {noDownloadsAtAll
+                  ? t('downloads.empty.noDownloadsDescription')
+                  : ''}
+              </Box>
+              {hasActiveFilters && (
+                <Button small onClick={handleClearAll}>
+                  {t('downloads.empty.noResultsAction')}
+                </Button>
+              )}
+            </Box>
+          ) : (
+            downloads
               .slice(currentPagination, currentPagination + itemsPerPage)
               .map((downloadItem) => (
                 <DownloadItem key={downloadItem.itemId} {...downloadItem} />
-              ))}
-          </Box>
+              ))
+          )}
         </Box>
       </Scrollable>
+
       {downloads.length > 0 && (
         <Pagination
           divider

--- a/src/ui/components/DownloadsManagerView/index.tsx
+++ b/src/ui/components/DownloadsManagerView/index.tsx
@@ -235,19 +235,8 @@ const DownloadsManagerView = () => {
         {t('downloads.title')}
       </Box>
 
-      <Box
-        display='flex'
-        alignItems='center'
-        pi={24}
-        pbe={16}
-      >
-        <Box
-          flexGrow={3}
-          flexShrink={1}
-          flexBasis={0}
-          minWidth='x160'
-          mie={8}
-        >
+      <Box display='flex' alignItems='center' pi={24} pbe={16}>
+        <Box flexGrow={3} flexShrink={1} flexBasis={0} minWidth='x160' mie={8}>
           <SearchInput
             value={searchFilter}
             placeholder={t('downloads.filters.search')}
@@ -255,13 +244,7 @@ const DownloadsManagerView = () => {
             onChange={handleSearchFilterChange}
           />
         </Box>
-        <Box
-          flexGrow={2}
-          flexShrink={1}
-          flexBasis={0}
-          minWidth='x140'
-          mie={8}
-        >
+        <Box flexGrow={2} flexShrink={1} flexBasis={0} minWidth='x140' mie={8}>
           <Select
             value={serverFilter}
             placeholder={t('downloads.filters.server')}
@@ -269,13 +252,7 @@ const DownloadsManagerView = () => {
             onChange={handleServerFilterChange}
           />
         </Box>
-        <Box
-          flexGrow={2}
-          flexShrink={1}
-          flexBasis={0}
-          minWidth='x120'
-          mie={8}
-        >
+        <Box flexGrow={2} flexShrink={1} flexBasis={0} minWidth='x120' mie={8}>
           <Select
             value={mimeTypeFilter}
             placeholder={t('downloads.filters.mimeType')}
@@ -283,13 +260,7 @@ const DownloadsManagerView = () => {
             onChange={handleMimeFilter}
           />
         </Box>
-        <Box
-          flexGrow={2}
-          flexShrink={1}
-          flexBasis={0}
-          minWidth='x120'
-          mie={8}
-        >
+        <Box flexGrow={2} flexShrink={1} flexBasis={0} minWidth='x120' mie={8}>
           <Select
             value={statusFilter}
             placeholder={t('downloads.filters.status')}

--- a/src/ui/components/ServerInfoContent.tsx
+++ b/src/ui/components/ServerInfoContent.tsx
@@ -345,7 +345,11 @@ const ServerInfoContent = ({
                       )}
                     </Box>
                   )}
-                  <Box fontSize='x10' color='font-annotation' style={textWrapStyle}>
+                  <Box
+                    fontSize='x10'
+                    color='font-annotation'
+                    style={textWrapStyle}
+                  >
                     {(() => {
                       const expirationDate = new Date(
                         expirationData.expiration

--- a/src/ui/components/ServerInfoContent.tsx
+++ b/src/ui/components/ServerInfoContent.tsx
@@ -124,7 +124,7 @@ const ServerInfoContent = ({
         <OptionContent style={{ minWidth: 0, overflow: 'visible' }}>
           <Box>
             <Box fontWeight='bold'>{t('serverInfo.urlLabel')}</Box>
-            <Box fontSize='x12' color='hint' style={textWrapStyle}>
+            <Box fontSize='x12' color='font-hint' style={textWrapStyle}>
               {url}
             </Box>
           </Box>
@@ -135,7 +135,7 @@ const ServerInfoContent = ({
         <OptionContent style={{ minWidth: 0, overflow: 'visible' }}>
           <Box>
             <Box fontWeight='bold'>{t('serverInfo.versionLabel')}</Box>
-            <Box fontSize='x12' color='hint' style={textWrapStyle}>
+            <Box fontSize='x12' color='font-hint' style={textWrapStyle}>
               {version || t('serverInfo.unknown')}
             </Box>
           </Box>
@@ -147,7 +147,7 @@ const ServerInfoContent = ({
           <OptionContent style={{ minWidth: 0, overflow: 'visible' }}>
             <Box>
               <Box fontWeight='bold'>{t('serverInfo.exchangeUrlLabel')}</Box>
-              <Box fontSize='x12' color='hint' style={textWrapStyle}>
+              <Box fontSize='x12' color='font-hint' style={textWrapStyle}>
                 {exchangeUrl}
               </Box>
             </Box>
@@ -181,7 +181,7 @@ const ServerInfoContent = ({
                   color={
                     supportedVersionsFetchState === 'error'
                       ? 'status-font-on-danger'
-                      : 'hint'
+                      : 'font-hint'
                   }
                   style={textWrapStyle}
                 >
@@ -257,7 +257,7 @@ const ServerInfoContent = ({
             <OptionContent style={{ minWidth: 0, overflow: 'visible' }}>
               <Box>
                 <Box fontWeight='bold'>Timestamp:</Box>
-                <Box fontSize='x12' color='hint' style={textWrapStyle}>
+                <Box fontSize='x12' color='font-hint' style={textWrapStyle}>
                   {new Date(supportedVersions.timestamp).toLocaleString()}
                 </Box>
               </Box>
@@ -270,7 +270,7 @@ const ServerInfoContent = ({
                 <Box fontWeight='bold'>Exceptions:</Box>
                 {supportedVersions.exceptions?.versions &&
                 supportedVersions.exceptions.versions.length > 0 ? (
-                  <Box fontSize='x12' color='hint' marginBlockStart='x4'>
+                  <Box fontSize='x12' color='font-hint' marginBlockStart='x4'>
                     <Box fontWeight='bold'>Exception Versions:</Box>
                     {supportedVersions.exceptions.versions
                       .slice(0, 3)
@@ -279,7 +279,7 @@ const ServerInfoContent = ({
                           <Box style={textWrapStyle}>• {version.version}</Box>
                           <Box
                             fontSize='x10'
-                            color='annotation'
+                            color='font-annotation'
                             style={textWrapStyle}
                           >
                             Expires:{' '}
@@ -290,7 +290,7 @@ const ServerInfoContent = ({
                     {supportedVersions.exceptions.versions.length > 3 && (
                       <Box
                         fontSize='x10'
-                        color='annotation'
+                        color='font-annotation'
                         marginInlineStart='x8'
                         style={textWrapStyle}
                       >
@@ -300,7 +300,7 @@ const ServerInfoContent = ({
                     )}
                   </Box>
                 ) : (
-                  <Box fontSize='x12' color='hint' style={textWrapStyle}>
+                  <Box fontSize='x12' color='font-hint' style={textWrapStyle}>
                     No version exceptions configured
                   </Box>
                 )}
@@ -325,7 +325,7 @@ const ServerInfoContent = ({
                   {expirationData.message && (
                     <Box
                       fontSize='x10'
-                      color='annotation'
+                      color='font-annotation'
                       marginBlockStart='x4'
                     >
                       {expirationData.message.title && (
@@ -345,7 +345,7 @@ const ServerInfoContent = ({
                       )}
                     </Box>
                   )}
-                  <Box fontSize='x10' color='annotation' style={textWrapStyle}>
+                  <Box fontSize='x10' color='font-annotation' style={textWrapStyle}>
                     {(() => {
                       const expirationDate = new Date(
                         expirationData.expiration

--- a/src/ui/components/ServersView/DocumentViewer.tsx
+++ b/src/ui/components/ServersView/DocumentViewer.tsx
@@ -32,7 +32,7 @@ const DocumentViewer = ({
       <Box
         display='flex'
         alignItems='center'
-        color='default'
+        color='font-default'
         pbe='x8'
         pbs='x8'
         pis='x8'

--- a/src/ui/components/ServersView/MarkdownContent.tsx
+++ b/src/ui/components/ServersView/MarkdownContent.tsx
@@ -205,7 +205,7 @@ const MarkdownContent = ({
         alignItems='center'
         height='100%'
         width='100%'
-        color='default'
+        color='font-default'
       >
         <Throbber size='x16' inheritColor />
       </Box>
@@ -234,7 +234,7 @@ const MarkdownContent = ({
         ref={containerRef}
         className='markdown-body'
         style={{ maxWidth: 980, margin: '0 auto', padding: '48px 40px 64px' }}
-        color='default'
+        color='font-default'
         dangerouslySetInnerHTML={{ __html: htmlContent }}
       />
     </Box>

--- a/src/ui/components/ServersView/PdfContent.tsx
+++ b/src/ui/components/ServersView/PdfContent.tsx
@@ -78,7 +78,7 @@ const PdfContent = ({ url, partition }: { url: string; partition: string }) => {
         height='100%'
         width='100%'
         position='absolute'
-        color='default'
+        color='font-default'
       >
         <Throbber size='x16' inheritColor />
       </Box>

--- a/src/ui/components/SettingsView/GeneralTab.tsx
+++ b/src/ui/components/SettingsView/GeneralTab.tsx
@@ -1,4 +1,6 @@
 import { Box, FieldGroup } from '@rocket.chat/fuselage';
+import type { ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { AvailableBrowsers } from './features/AvailableBrowsers';
 import { ClearPermittedScreenCaptureServers } from './features/ClearPermittedScreenCaptureServers';
@@ -18,26 +20,59 @@ import { TransparentWindow } from './features/TransparentWindow';
 import { TrayIcon } from './features/TrayIcon';
 import { VideoCallWindowPersistence } from './features/VideoCallWindowPersistence';
 
-export const GeneralTab = () => (
-  <Box display='flex' justifyContent='center'>
-    <FieldGroup is='form' maxWidth={600}>
-      <ReportErrors />
-      <FlashFrame />
-      <HardwareAcceleration />
-      {process.platform === 'win32' && <ScreenCaptureFallback />}
-      <InternalVideoChatWindow />
-      <VideoCallWindowPersistence />
-      {process.platform === 'darwin' && <TransparentWindow />}
-      <TrayIcon />
-      {process.platform === 'win32' && <MinimizeOnClose />}
-      <SideBar />
-      {process.platform !== 'darwin' && <MenuBar />}
-      {process.platform === 'win32' && <NTLMCredentials />}
-      <ThemeAppearance />
-      <AvailableBrowsers />
-      <OutlookCalendarSyncInterval />
-      <TelephonyServer />
-      {!process.mas && <ClearPermittedScreenCaptureServers />}
-    </FieldGroup>
+type SectionProps = {
+  title: string;
+  isFirst?: boolean;
+  children: ReactNode;
+};
+
+const Section = ({ title, isFirst, children }: SectionProps) => (
+  <Box mbs={isFirst ? 0 : 32} mbe={16}>
+    <Box fontScale='h4' color='font-default' mbe={16}>
+      {title}
+    </Box>
+    <FieldGroup>{children}</FieldGroup>
   </Box>
 );
+
+export const GeneralTab = () => {
+  const { t } = useTranslation();
+
+  return (
+    <Box display='flex' justifyContent='center'>
+      <Box is='form' maxWidth={600} width='full'>
+        <Section title={t('settings.sections.notifications')} isFirst>
+          <ReportErrors />
+          <FlashFrame />
+        </Section>
+
+        <Section title={t('settings.sections.performance')}>
+          <HardwareAcceleration />
+          {process.platform === 'win32' && <ScreenCaptureFallback />}
+        </Section>
+
+        <Section title={t('settings.sections.callsAndVideo')}>
+          <InternalVideoChatWindow />
+          <VideoCallWindowPersistence />
+          <TelephonyServer />
+          {!process.mas && <ClearPermittedScreenCaptureServers />}
+        </Section>
+
+        <Section title={t('settings.sections.windowAndAppearance')}>
+          {process.platform === 'darwin' && <TransparentWindow />}
+          <TrayIcon />
+          {process.platform === 'win32' && <MinimizeOnClose />}
+          <SideBar />
+          {process.platform !== 'darwin' && <MenuBar />}
+          <ThemeAppearance />
+        </Section>
+
+        <Section title={t('settings.sections.integrations')}>
+          {process.platform === 'win32' && <NTLMCredentials />}
+          <AvailableBrowsers />
+          <OutlookCalendarSyncInterval />
+        </Section>
+      </Box>
+    </Box>
+  );
+};

--- a/src/ui/components/SettingsView/GeneralTab.tsx
+++ b/src/ui/components/SettingsView/GeneralTab.tsx
@@ -1,7 +1,7 @@
-import { Box, FieldGroup } from '@rocket.chat/fuselage';
-import type { ReactNode } from 'react';
+import { Box } from '@rocket.chat/fuselage';
 import { useTranslation } from 'react-i18next';
 
+import { Section } from './Section';
 import { AvailableBrowsers } from './features/AvailableBrowsers';
 import { ClearPermittedScreenCaptureServers } from './features/ClearPermittedScreenCaptureServers';
 import { FlashFrame } from './features/FlashFrame';
@@ -19,21 +19,6 @@ import { ThemeAppearance } from './features/ThemeAppearance';
 import { TransparentWindow } from './features/TransparentWindow';
 import { TrayIcon } from './features/TrayIcon';
 import { VideoCallWindowPersistence } from './features/VideoCallWindowPersistence';
-
-type SectionProps = {
-  title: string;
-  isFirst?: boolean;
-  children: ReactNode;
-};
-
-const Section = ({ title, isFirst, children }: SectionProps) => (
-  <Box mbs={isFirst ? 0 : 32} mbe={16}>
-    <Box fontScale='h4' color='font-default' mbe={16}>
-      {title}
-    </Box>
-    <FieldGroup>{children}</FieldGroup>
-  </Box>
-);
 
 export const GeneralTab = () => {
   const { t } = useTranslation();

--- a/src/ui/components/SettingsView/Section.tsx
+++ b/src/ui/components/SettingsView/Section.tsx
@@ -1,0 +1,17 @@
+import { Box, FieldGroup } from '@rocket.chat/fuselage';
+import type { ReactNode } from 'react';
+
+export type SectionProps = {
+  title: string;
+  isFirst?: boolean;
+  children: ReactNode;
+};
+
+export const Section = ({ title, isFirst, children }: SectionProps) => (
+  <Box mbs={isFirst ? 0 : 32} mbe={16}>
+    <Box fontScale='h4' color='font-default' mbe={16}>
+      {title}
+    </Box>
+    <FieldGroup>{children}</FieldGroup>
+  </Box>
+);

--- a/src/ui/components/SettingsView/SettingsView.tsx
+++ b/src/ui/components/SettingsView/SettingsView.tsx
@@ -76,7 +76,7 @@ export const SettingsView = () => {
         flexWrap='nowrap'
         alignItems='center'
         fontScale='h2'
-        color='default'
+        color='font-default'
       >
         {!isSideBarEnabled && (
           <Box mie={8} display='flex' alignItems='center'>

--- a/src/ui/components/SettingsView/SettingsView.tsx
+++ b/src/ui/components/SettingsView/SettingsView.tsx
@@ -1,6 +1,7 @@
 import { Box, IconButton, Scrollable, Tabs } from '@rocket.chat/fuselage';
 import '@rocket.chat/fuselage-polyfills';
-import { useEffect, useState } from 'react';
+import type { KeyboardEvent } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
@@ -37,12 +38,22 @@ export const SettingsView = () => {
     }
   }, [isDeveloperModeEnabled, currentTab]);
 
-  const handleBackButton = function (): void {
+  const handleBackButton = useCallback((): void => {
     dispatch({
       type: DOWNLOADS_BACK_BUTTON_CLICKED,
       payload: lastSelectedServerUrl,
     });
-  };
+  }, [lastSelectedServerUrl]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === 'Escape') {
+        handleBackButton();
+      }
+    },
+    [handleBackButton]
+  );
+
   return (
     <Box
       display={isVisible ? 'flex' : 'none'}
@@ -52,46 +63,59 @@ export const SettingsView = () => {
       width='full'
       className='rcx-sidebar--main'
       bg='room'
+      onKeyDown={handleKeyDown}
+      tabIndex={isVisible ? -1 : undefined}
     >
       <Box
         width='full'
-        padding={24}
+        pi={24}
+        pbs={24}
+        pbe={16}
         display='flex'
         flexDirection='row'
         flexWrap='nowrap'
-        fontScale='h1'
+        alignItems='center'
+        fontScale='h2'
         color='default'
       >
         {!isSideBarEnabled && (
-          <IconButton icon='arrow-back' onClick={handleBackButton} />
+          <Box mie={8} display='flex' alignItems='center'>
+            <IconButton
+              icon='arrow-back'
+              onClick={handleBackButton}
+              aria-label={t('settings.back')}
+            />
+          </Box>
         )}
         {t('settings.title')}
       </Box>
 
-      <Tabs>
-        <Tabs.Item
-          selected={currentTab === 'general'}
-          onClick={() => setCurrentTab('general')}
-        >
-          {t('settings.general')}
-        </Tabs.Item>
-        <Tabs.Item
-          selected={currentTab === 'certificates'}
-          onClick={() => setCurrentTab('certificates')}
-        >
-          {t('settings.certificates')}
-        </Tabs.Item>
-        {isDeveloperModeEnabled && (
+      <Box pi={24}>
+        <Tabs>
           <Tabs.Item
-            selected={currentTab === 'developer'}
-            onClick={() => setCurrentTab('developer')}
+            selected={currentTab === 'general'}
+            onClick={() => setCurrentTab('general')}
           >
-            {t('settings.developer')}
+            {t('settings.general')}
           </Tabs.Item>
-        )}
-      </Tabs>
+          <Tabs.Item
+            selected={currentTab === 'certificates'}
+            onClick={() => setCurrentTab('certificates')}
+          >
+            {t('settings.certificates')}
+          </Tabs.Item>
+          {isDeveloperModeEnabled && (
+            <Tabs.Item
+              selected={currentTab === 'developer'}
+              onClick={() => setCurrentTab('developer')}
+            >
+              {t('settings.developer')}
+            </Tabs.Item>
+          )}
+        </Tabs>
+      </Box>
       <Scrollable>
-        <Box m='x24'>
+        <Box pi={24} pbs={24} pbe={24}>
           {(currentTab === 'general' && <GeneralTab />) ||
             (currentTab === 'certificates' && <CertificatesTab />) ||
             (currentTab === 'developer' && <DeveloperTab />)}

--- a/src/ui/components/SettingsView/features/AvailableBrowsers.tsx
+++ b/src/ui/components/SettingsView/features/AvailableBrowsers.tsx
@@ -84,7 +84,7 @@ export const AvailableBrowsers = (props: AvailableBrowsersProps) => {
             {t('settings.options.availableBrowsers.description')}
           </FieldHint>
         </Box>
-        <Box display='flex' alignItems='center' style={{ paddingTop: '4px' }}>
+        <Box display='flex' alignItems='center' paddingBlockStart='x4'>
           <Select
             options={options}
             value={selectedBrowser ?? 'system'}

--- a/src/ui/components/SettingsView/features/ClearPermittedScreenCaptureServers.tsx
+++ b/src/ui/components/SettingsView/features/ClearPermittedScreenCaptureServers.tsx
@@ -19,7 +19,6 @@ export const ClearPermittedScreenCaptureServers = (
         <Button
           danger
           onClick={async () => {
-            console.log('Clearing permitted screen capture servers');
             dispatch({
               type: SETTINGS_CLEAR_PERMITTED_SCREEN_CAPTURE_PERMISSIONS,
             });

--- a/src/ui/components/SettingsView/features/OutlookCalendarSyncInterval.tsx
+++ b/src/ui/components/SettingsView/features/OutlookCalendarSyncInterval.tsx
@@ -59,7 +59,7 @@ export const OutlookCalendarSyncInterval = () => {
             {t('settings.options.outlookCalendarSyncInterval.description')}
           </FieldHint>
         </Box>
-        <Box display='flex' alignItems='center' style={{ paddingTop: '4px' }}>
+        <Box display='flex' alignItems='center' paddingBlockStart='x4'>
           <InputBox
             id={fieldId}
             type='number'

--- a/src/ui/components/SettingsView/features/TelephonyServer.tsx
+++ b/src/ui/components/SettingsView/features/TelephonyServer.tsx
@@ -63,7 +63,7 @@ export const TelephonyServer = () => {
             {t('settings.options.telephonyServer.description')}
           </FieldHint>
         </Box>
-        <Box display='flex' alignItems='center' style={{ paddingTop: '4px' }}>
+        <Box display='flex' alignItems='center' paddingBlockStart='x4'>
           <Select
             options={options}
             value={telephonyPreferredServer ?? 'auto'}

--- a/src/ui/components/Shell/styles.tsx
+++ b/src/ui/components/Shell/styles.tsx
@@ -34,7 +34,8 @@ export const GlobalStyles = ({
           -webkit-font-smoothing: antialiased;
           margin: 0;
           padding: 0;
-          font-family: system-ui;
+          font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+            Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
           font-size: 0.875rem;
           line-height: 1rem;
           background-color: ${backgroundColor};

--- a/src/ui/components/Shell/styles.tsx
+++ b/src/ui/components/Shell/styles.tsx
@@ -34,8 +34,17 @@ export const GlobalStyles = ({
           -webkit-font-smoothing: antialiased;
           margin: 0;
           padding: 0;
-          font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-            Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+          font-family:
+            Inter,
+            -apple-system,
+            BlinkMacSystemFont,
+            'Segoe UI',
+            Roboto,
+            Oxygen,
+            Ubuntu,
+            Cantarell,
+            'Helvetica Neue',
+            sans-serif;
           font-size: 0.875rem;
           line-height: 1rem;
           background-color: ${backgroundColor};

--- a/src/ui/components/TopBar/index.tsx
+++ b/src/ui/components/TopBar/index.tsx
@@ -25,7 +25,7 @@ export const TopBar = () => {
       flexDirection='row'
       justifyContent='center'
       alignItems='center'
-      color='default'
+      color='font-default'
       bg={sidebarBg}
       width='100%'
     >


### PR DESCRIPTION
## Summary

Polishes the three full-window panels in the desktop shell (Settings, Certificates, Downloads) so they line up with the Fuselage design system, and captures the design direction in committed `PRODUCT.md` / `DESIGN.md` context files.

The visual contract in `DESIGN.md` was built from the live Fuselage token source (`@rocket.chat/fuselage-tokens` + `PaletteStyleTag`), not from the hardcoded fallbacks scattered through the app, so the documented values match what the runtime actually emits across the light, dark, and high-contrast themes.

## What changed

**Settings**
- GeneralTab's flat list of ~19 features is grouped into 5 labeled sections (Notifications, Performance, Calls & video, Window & appearance, Integrations) via a small reusable `Section` helper, mirroring the existing DeveloperTab pattern.
- SettingsView title steps from `h1` to `h2` with tightened title-to-tabs spacing; Tabs share the content gutter; Scrollable inner uses padding instead of margin. Esc dismisses the view; back IconButton gains an `aria-label`.

**Certificates**
- Extracted a `CertificateSection` with an `h4` title, a hint line, and an empty state. Dropped a stray `<Box is='form'>`, doubled padding, an off-scale `marginBlockStart`, and `Table sticky` (two stacked sticky headers shared one scroll container).
- `<TableRow action>` provides the hover affordance; `striped` removed.

**Downloads**
- Title to `h2`; `bg='light'` to `bg='room'` for theme parity with Settings; filter row trimmed to an even gutter; `SelectLegacy` swapped for the current `Select`; clear-filters icon corrected from `trash` to `cross` with an `aria-label` and a disabled state when no filters are active.
- Empty states for first-run and filtered-empty. Esc-to-close + aria-label.
- DownloadItem: literal widths replaced with flex + min/max so rows reflow; semantic color tokens; per-row actions moved into a `ButtonGroup` with `danger` on destructive ones; progress bar hidden for completed downloads.

**Shared + cleanup**
- Downloads and Certificates lists share one row affordance: a 1px `stroke-extra-light` divider + `surface-hover` hover tint, both theme tokens.
- Anchor-as-button (`<a href='#'>`) replaced with the Fuselage `Button` primitive in both ActionButtons.
- Swept every `color` prop onto semantic token names (`font-default`, `font-hint`, `font-secondary-info`, etc.) across the touched views plus ServerInfoContent, ServersView, TopBar.
- Replaced raw `style={{ paddingTop: '4px' }}` with `paddingBlockStart='x4'` in the affected settings features.
- Body font stack in `Shell/styles.tsx` switched from `system-ui` to the Fuselage Inter-first stack. The pre-hydration overlays (`loading.css` / `error.css`) intentionally keep `system-ui`; documented in `DESIGN.md`.

**Design context**
- `PRODUCT.md`, `DESIGN.md`, and `.impeccable/design.json` capture register, users, anti-references, principles, and the Fuselage-verified token contract for future UI work.

Before:
<img width="1073" height="892" alt="image" src="https://github.com/user-attachments/assets/41936d8e-1a1e-4afb-bb60-0b6a5491cf97" />
After:
<img width="1187" height="880" alt="image" src="https://github.com/user-attachments/assets/ee19f6a9-30ed-433d-bb92-07e1828048fc" />

Before:
<img width="1184" height="704" alt="image" src="https://github.com/user-attachments/assets/72bbb369-f4fa-4d97-b903-31e9e9531e4d" />
After:
<img width="1273" height="793" alt="image" src="https://github.com/user-attachments/assets/dd1bcf0e-432a-465f-a14b-4c57b9d6f7f1" />

Before:
<img width="1166" height="454" alt="image" src="https://github.com/user-attachments/assets/a66066d2-4124-4fcf-a48a-eb9c2b071e23" />
After:
<img width="1259" height="428" alt="image" src="https://github.com/user-attachments/assets/948caed4-317d-442e-a448-8a0640249060" />



## Notes for reviewers

- Verified with `npx tsc --noEmit` (clean) on every commit; GitNexus upstream impact analysis was LOW on each touched surface.
- Theme verification (light / dark / high-contrast) in a running build is still pending; the code is token-based so it should follow the active theme, but a visual pass is worth doing before merge.
- `.impeccable/design.json` is agent-context tooling output. If the team would rather not track it, it can move to `.gitignore` and drop from this PR.

## Test plan

- [ ] Open Settings; confirm the five sections render and group correctly per platform
- [ ] Open Certificates; confirm hover affordance and empty states; scroll with both tables populated
- [ ] Open Downloads; confirm filters, clear-filters disabled state, empty states, completed-item rows
- [ ] Tab through each view with the keyboard; confirm focus, aria-labels, Esc-to-close
- [ ] Cycle light / dark / high-contrast themes and confirm all three read correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Escape key to go back; Settings reorganized into labeled sections.
  * New reusable UI sections and certificate sections for clearer layout.

* **Style**
  * Downloads UI: compact actions, conditional progress, improved empty states and keyboard support.
  * Visual refinements: typography, color token updates, spacing, global font stack, and subtle top-bar/header color tweaks.

* **Bug Fixes / UX**
  * Action controls standardized to button components; improved row/truncation behavior and keyboard handling.

* **Documentation**
  * Added comprehensive design system and product documentation.

* **Localization**
  * New/updated English strings for downloads, certificates manager, and settings.

* **Chores**
  * Desktop config updated with additional URI/MIME associations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat.Electron/pull/3344?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->