### PR TITLE
fix(build): move linux desktop MimeType into entry for electron-builder 26 schema

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -123,12 +123,12 @@
     "executableName": "rocketchat-desktop",
     "category": "GNOME;GTK;Network;InstantMessaging",
     "desktop": {
-      "MimeType": "x-scheme-handler/rocketchat;x-scheme-handler/callto;x-scheme-handler/tel;",
       "entry": {
         "Name": "Rocket.Chat",
         "Comment": "Official Rocket.Chat Desktop Client",
         "GenericName": "Rocket.Chat",
-        "Categories": "GNOME;GTK;Network;InstantMessaging"
+        "Categories": "GNOME;GTK;Network;InstantMessaging",
+        "MimeType": "x-scheme-handler/rocketchat;x-scheme-handler/callto;x-scheme-handler/tel;"
       }
     },
     "artifactName": "rocketchat-${version}-${os}-${arch}.${ext}"


### PR DESCRIPTION
## Summary

Fixes a Linux build failure caused by an invalid `electron-builder` configuration.

`electron-builder` 26 tightened its schema for `linux.desktop`, which now accepts only `{ desktopActions?, entry? }`. The `MimeType` key — added alongside the telephony deep-linking feature — was placed directly under `linux.desktop`, so 26.0.3's stricter validation rejects it and aborts the build:

```
⨯ Invalid configuration object. electron-builder 26.0.3 has been initialized using a
  configuration object that does not match the API schema.
 - configuration.linux.desktop has an unknown property 'MimeType'. These properties are valid:
   object { desktopActions?, entry? }
```

## Change

Moved `MimeType` into `linux.desktop.entry`, where freedesktop desktop-entry keys belong. The generated `.desktop` file is unchanged — `MimeType` still lands in the desktop entry, registering the `rocketchat:`, `callto:`, and `tel:` scheme handlers as before.

## Verification

- `electron-builder` config validation passes locally (the schema error is gone).
- Diff is a single two-line move in `electron-builder.json`; no behavioral change to the produced artifact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced Linux desktop integration with support for additional URL scheme handlers, including rocketchat, callto, and tel protocols.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat.Electron/pull/3347?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->