### PR TITLE
Fix: markdown download cancellation logic

### DIFF
--- a/src/ui/main/serverView/index.ts
+++ b/src/ui/main/serverView/index.ts
@@ -176,6 +176,7 @@ const initializeServerWebContentsAfterAttach = (
   webviewSession.on('will-download', (_event, item) => {
     if (item.getFilename().endsWith('.md')) {
       const downloadUrl = item.getURL();
+      if (!downloadUrl.endsWith('download=')) return;
       item.cancel();
       dispatch({
         type: SERVER_DOCUMENT_VIEWER_OPEN_URL,

--- a/src/ui/main/serverView/index.ts
+++ b/src/ui/main/serverView/index.ts
@@ -176,6 +176,8 @@ const initializeServerWebContentsAfterAttach = (
   webviewSession.on('will-download', (_event, item) => {
     if (item.getFilename().endsWith('.md')) {
       const downloadUrl = item.getURL();
+      // Only intercept for viewer URLs; allow normal downloads to proceed.
+      // Rocket.Chat server appends 'download=' for view actions vs. download actions.
       if (!downloadUrl.endsWith('download=')) return;
       item.cancel();
       dispatch({

--- a/src/ui/main/serverView/index.ts
+++ b/src/ui/main/serverView/index.ts
@@ -48,6 +48,7 @@ import {
 } from '../../actions';
 import { handleMediaPermissionRequest } from '../mediaPermissions';
 import { getRootWindow } from '../rootWindow';
+import { isMarkdownViewerDownloadUrl } from './isMarkdownViewerDownloadUrl';
 import { createPopupMenuForServerView } from './popupMenu';
 
 const t = i18next.t.bind(i18next);
@@ -174,21 +175,17 @@ const initializeServerWebContentsAfterAttach = (
 
   // Intercept markdown file downloads and open in document viewer
   webviewSession.on('will-download', (_event, item) => {
-    if (item.getFilename().endsWith('.md')) {
-      const downloadUrl = item.getURL();
-      // Only intercept for viewer URLs; allow normal downloads to proceed.
-      // Rocket.Chat server appends 'download=' for view actions vs. download actions.
-      if (!downloadUrl.endsWith('download=')) return;
-      item.cancel();
-      dispatch({
-        type: SERVER_DOCUMENT_VIEWER_OPEN_URL,
-        payload: {
-          server: serverUrl,
-          documentUrl: downloadUrl,
-          documentFormat: 'markdown',
-        },
-      });
-    }
+    const downloadUrl = item.getURL();
+    if (!isMarkdownViewerDownloadUrl(downloadUrl, item.getFilename())) return;
+    item.cancel();
+    dispatch({
+      type: SERVER_DOCUMENT_VIEWER_OPEN_URL,
+      payload: {
+        server: serverUrl,
+        documentUrl: downloadUrl,
+        documentFormat: 'markdown',
+      },
+    });
   });
 
   guestWebContents.addListener('destroyed', () => {

--- a/src/ui/main/serverView/isMarkdownViewerDownloadUrl.main.spec.ts
+++ b/src/ui/main/serverView/isMarkdownViewerDownloadUrl.main.spec.ts
@@ -1,0 +1,45 @@
+import { isMarkdownViewerDownloadUrl } from './isMarkdownViewerDownloadUrl';
+
+describe('isMarkdownViewerDownloadUrl', () => {
+  it('intercepts a title-link view URL (URLSearchParams trailing "download=")', () => {
+    expect(
+      isMarkdownViewerDownloadUrl(
+        'https://srv/file-upload/x/doc.md?download=',
+        'doc.md'
+      )
+    ).toBe(true);
+  });
+
+  it('lets a download-button URL pass through (bare "?download", no "=")', () => {
+    expect(
+      isMarkdownViewerDownloadUrl(
+        'https://srv/file-upload/x/doc.md?download',
+        'doc.md'
+      )
+    ).toBe(false);
+  });
+
+  it('does not intercept non-markdown files even with "download="', () => {
+    expect(
+      isMarkdownViewerDownloadUrl(
+        'https://srv/file-upload/x/doc.pdf?download=',
+        'doc.pdf'
+      )
+    ).toBe(false);
+  });
+
+  it('intercepts when "download=" follows another query param', () => {
+    expect(
+      isMarkdownViewerDownloadUrl(
+        'https://srv/file-upload/x/doc.md?foo=bar&download=',
+        'doc.md'
+      )
+    ).toBe(true);
+  });
+
+  it('lets a plain URL with no query pass through', () => {
+    expect(
+      isMarkdownViewerDownloadUrl('https://srv/file-upload/x/doc.md', 'doc.md')
+    ).toBe(false);
+  });
+});

--- a/src/ui/main/serverView/isMarkdownViewerDownloadUrl.ts
+++ b/src/ui/main/serverView/isMarkdownViewerDownloadUrl.ts
@@ -1,0 +1,10 @@
+/**
+ * Distinguishes a Rocket.Chat title-link (view intent) from a download button.
+ * Title-link builds the URL with URLSearchParams, serializing the empty value as
+ * `?download=` (trailing `=`). The download button concatenates a bare `?download`
+ * with no `=`. The trailing `=` is the only signal separating view from download.
+ */
+export const isMarkdownViewerDownloadUrl = (
+  url: string,
+  filename: string
+): boolean => filename.endsWith('.md') && url.endsWith('download=');


### PR DESCRIPTION
Closes #3345

<img width="318" height="102" alt="image" src="https://github.com/user-attachments/assets/22bbbe37-5388-4727-b430-4de5962bbcf1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved markdown download handling: non-download links are no longer canceled or opened in the document viewer; only viewer-eligible markdown downloads are intercepted and handled.

* **Tests**
  * Added unit tests validating detection logic for markdown viewer download URLs, covering query parameter variants and non-markdown cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->