### PR TITLE
chore: salvage remaining UI polish from #3344

### DIFF
--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,287 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-05-26T00:00:00Z",
+  "title": "Design System: Rocket.Chat Desktop",
+  "extensions": {
+    "colorMeta": {
+      "primary-500": {
+        "role": "primary",
+        "displayName": "Action Blue",
+        "canonical": "oklch(57% 0.21 257)",
+        "fuselageToken": "primary-500 (p500)",
+        "tonalRamp": [
+          "#012247",
+          "#01336B",
+          "#10529E",
+          "#095AD2",
+          "#156FF5",
+          "#549DF9",
+          "#76B7FC",
+          "#D1EBFE"
+        ]
+      },
+      "neutral-100": {
+        "role": "neutral",
+        "displayName": "Wall Cream",
+        "canonical": "oklch(98% 0.004 250)",
+        "fuselageToken": "neutral-100 (n100)",
+        "tonalRamp": [
+          "#1f2329",
+          "#2f343d",
+          "#6c727a",
+          "#9ea2a8",
+          "#cbced1",
+          "#d7dbe0",
+          "#e4e7ea",
+          "#f7f8fa"
+        ]
+      },
+      "neutral-450": {
+        "role": "neutral",
+        "displayName": "Active Tone",
+        "canonical": "oklch(88% 0.006 256)",
+        "fuselageToken": "neutral-450 (n450)",
+        "tonalRamp": [
+          "#1f2329",
+          "#2f343d",
+          "#6c727a",
+          "#9ea2a8",
+          "#cbced1",
+          "#d7dbe0",
+          "#e4e7ea",
+          "#f7f8fa"
+        ]
+      },
+      "neutral-600": {
+        "role": "neutral",
+        "displayName": "Mention Slate",
+        "canonical": "oklch(68% 0.012 256)",
+        "fuselageToken": "neutral-600 (n600) — Badge level-1 / variant=secondary background",
+        "tonalRamp": [
+          "#1f2329",
+          "#2f343d",
+          "#6c727a",
+          "#9ea2a8",
+          "#cbced1",
+          "#d7dbe0",
+          "#e4e7ea",
+          "#f7f8fa"
+        ]
+      },
+      "neutral-800": {
+        "role": "neutral",
+        "displayName": "Workshop Slate",
+        "canonical": "oklch(31% 0.014 256)",
+        "fuselageToken": "neutral-800 (n800)",
+        "tonalRamp": [
+          "#1f2329",
+          "#2f343d",
+          "#6c727a",
+          "#9ea2a8",
+          "#cbced1",
+          "#d7dbe0",
+          "#e4e7ea",
+          "#f7f8fa"
+        ]
+      },
+      "service-1-500": {
+        "role": "tertiary",
+        "displayName": "Caution Orange",
+        "canonical": "oklch(72% 0.16 51)",
+        "fuselageToken": "service-1-500 (s1-500) — Badge level-3 / variant=warning background",
+        "tonalRamp": [
+          "#713607",
+          "#974809",
+          "#BD5A0B",
+          "#E26D0E",
+          "#F38C39",
+          "#F59B53",
+          "#F7B27B",
+          "#FAD1B0"
+        ]
+      },
+      "danger-500": {
+        "role": "tertiary",
+        "displayName": "Destructive Red",
+        "canonical": "oklch(57% 0.23 24)",
+        "fuselageToken": "danger-500 (d500) — Button danger background",
+        "tonalRamp": [
+          "#8B0719",
+          "#9B1325",
+          "#BB0B21",
+          "#D40C26",
+          "#EC0D2A",
+          "#F5495F",
+          "#F98F9D",
+          "#FFC1C9"
+        ]
+      },
+      "danger-550": {
+        "role": "tertiary",
+        "displayName": "Alert Crimson",
+        "canonical": "oklch(65% 0.22 18)",
+        "fuselageToken": "danger-550 (d550) — Badge level-4 / variant=danger background",
+        "tonalRamp": [
+          "#8B0719",
+          "#9B1325",
+          "#BB0B21",
+          "#D40C26",
+          "#EC0D2A",
+          "#F5455C",
+          "#F98F9D",
+          "#FFC1C9"
+        ]
+      }
+    },
+    "typographyMeta": {
+      "hero": { "displayName": "Hero", "purpose": "Splash / pre-hydration only." },
+      "h1": { "displayName": "H1", "purpose": "Settings view title, About title." },
+      "h2": { "displayName": "H2", "purpose": "Section headers, dialog titles." },
+      "h3": { "displayName": "H3", "purpose": "Subsection titles." },
+      "h4": { "displayName": "H4", "purpose": "Form group labels." },
+      "h5": { "displayName": "H5", "purpose": "Compact list-item titles." },
+      "p1": { "displayName": "P1", "purpose": "Primary dialog copy." },
+      "p2": { "displayName": "P2", "purpose": "Default shell body. Tooltips, form rows, dropdown items." },
+      "c1": { "displayName": "C1", "purpose": "Server initials, badge numbers, metadata." },
+      "c2": { "displayName": "C2 bold", "purpose": "Emphasized micro-labels." },
+      "micro": { "displayName": "Micro", "purpose": "Extreme density labels. Not currently used." }
+    },
+    "shadows": [
+      { "name": "elevation-1", "value": "rgba(31, 35, 41, 0.10)", "purpose": "Default tile lift. Authored by Fuselage." },
+      { "name": "elevation-2x", "value": "rgba(31, 35, 41, 0.08)", "purpose": "Modal-tier x-axis shadow. Authored by Fuselage Dialog." },
+      { "name": "elevation-2y", "value": "rgba(31, 35, 41, 0.12)", "purpose": "Modal-tier y-axis shadow. Authored by Fuselage Dialog." },
+      { "name": "elevation-border", "value": "stroke-extra-light hairline", "purpose": "Edge accent on elevated surfaces." }
+    ],
+    "motion": [
+      { "name": "selection-stripe", "value": "height var(--transitions-duration), opacity var(--transitions-duration)", "purpose": "Animates the 4px selection stripe on server buttons." }
+    ],
+    "breakpoints": [
+      { "name": "xs", "value": "0" },
+      { "name": "sm", "value": "600px" },
+      { "name": "md", "value": "768px" },
+      { "name": "lg", "value": "1024px" },
+      { "name": "xl", "value": "1280px" },
+      { "name": "xxl", "value": "1600px" },
+      { "name": "xxxl", "value": "1920px" }
+    ]
+  },
+  "components": [
+    {
+      "name": "Server Button (Selected)",
+      "kind": "custom",
+      "refersTo": "server-button-selected",
+      "description": "44px rail item with 28px square avatar and the canonical 4px selection stripe to its left.",
+      "html": "<li class=\"ds-server-btn ds-server-btn--selected\"><button class=\"ds-server-btn__avatar\"><span class=\"ds-server-btn__initials\">RC</span></button></li>",
+      "css": ".ds-server-btn { position: relative; display: flex; list-style: none; padding: 4px 0; } .ds-server-btn::before { position: absolute; content: ''; left: -8px; width: 4px; height: 0; border-radius: 0 4px 4px 0; background-color: var(--rcx-color-neutral-450, #d7dbe0); transition: height 0.2s, opacity 0.2s; } .ds-server-btn--selected::before { height: 28px; opacity: 1; } .ds-server-btn__avatar { width: 36px; height: 36px; border-radius: 4px; background: var(--rcx-color-neutral-100, #f7f8fa); border: none; cursor: pointer; display: flex; align-items: center; justify-content: center; font: 400 12px/16px Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: var(--rcx-color-neutral-900, #1f2329); } .ds-server-btn__avatar:hover { background: var(--rcx-color-neutral-450, #d7dbe0); }"
+    },
+    {
+      "name": "Mention Count Badge (variant=secondary)",
+      "kind": "chip",
+      "refersTo": "badge-mention-count",
+      "description": "Unread mention count anchored top-right of avatar. Fuselage Badge variant='secondary' — gray, not red. Restraint is intentional.",
+      "html": "<span class=\"ds-badge-secondary\">3</span>",
+      "css": ".ds-badge-secondary { display: inline-flex; align-items: center; justify-content: center; min-width: 16px; height: 16px; padding: 0 5px; background: var(--rcx-color-neutral-600, #9ea2a8); color: #fff; font: 700 12px/16px Inter, -apple-system, sans-serif; border-radius: 9999px; transform: translate(30%, -30%); }"
+    },
+    {
+      "name": "Warning Badge (variant=warning)",
+      "kind": "chip",
+      "refersTo": "badge-not-logged-in",
+      "description": "Not-logged-in state. Fuselage Badge variant='warning' — orange.",
+      "html": "<span class=\"ds-badge-warning\">!</span>",
+      "css": ".ds-badge-warning { display: inline-flex; align-items: center; justify-content: center; min-width: 16px; height: 16px; padding: 0 5px; background: var(--rcx-color-service-1-500, #f38c39); color: #fff; font: 700 12px/16px Inter, -apple-system, sans-serif; border-radius: 9999px; transform: translate(30%, -30%); }"
+    },
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "Dominant action inside dialogs. Fuselage primary-500.",
+      "html": "<button class=\"ds-btn-primary\">Save</button>",
+      "css": ".ds-btn-primary { display: inline-flex; align-items: center; justify-content: center; padding: 8px 16px; background: var(--rcx-color-primary-500, #156ff5); color: #fff; border: none; border-radius: 4px; font: 400 14px/20px Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; cursor: pointer; transition: background 0.15s; } .ds-btn-primary:hover { background: var(--rcx-color-primary-600, #095ad2); } .ds-btn-primary:active { background: var(--rcx-color-primary-700, #10529e); } .ds-btn-primary:focus-visible { outline: 2px solid var(--rcx-color-primary-500, #156ff5); outline-offset: 2px; }"
+    },
+    {
+      "name": "Danger Button",
+      "kind": "button",
+      "refersTo": "button-danger",
+      "description": "Destructive confirmation (Remove server, Clear cache). Fuselage danger-500.",
+      "html": "<button class=\"ds-btn-danger\">Remove</button>",
+      "css": ".ds-btn-danger { display: inline-flex; align-items: center; justify-content: center; padding: 8px 16px; background: var(--rcx-color-danger-500, #ec0d2a); color: #fff; border: none; border-radius: 4px; font: 400 14px/20px Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; cursor: pointer; transition: background 0.15s; } .ds-btn-danger:hover { background: var(--rcx-color-danger-600, #d40c26); } .ds-btn-danger:active { background: var(--rcx-color-danger-700, #bb0b21); } .ds-btn-danger:focus-visible { outline: 2px solid var(--rcx-color-danger-500, #ec0d2a); outline-offset: 2px; }"
+    },
+    {
+      "name": "Dialog",
+      "kind": "card",
+      "refersTo": "dialog",
+      "description": "Centered modal with title, body, action row. Used for About, Update, Clear Cache, Screen Sharing.",
+      "html": "<div class=\"ds-dialog\"><div class=\"ds-dialog__title\">Remove workspace</div><div class=\"ds-dialog__body\">This removes the workspace from this device. Your messages on the server are unaffected.</div><div class=\"ds-dialog__actions\"><button class=\"ds-btn-ghost\">Cancel</button><button class=\"ds-btn-danger\">Remove</button></div></div>",
+      "css": ".ds-dialog { background: var(--rcx-color-white, #fff); color: var(--rcx-color-neutral-800, #2f343d); border-radius: 4px; padding: 24px; max-width: 480px; font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; box-shadow: 0 4px 12px rgba(31,35,41,0.08), 0 12px 28px rgba(31,35,41,0.12); } .ds-dialog__title { font: 700 24px/32px inherit; margin-bottom: 8px; color: var(--rcx-color-neutral-900, #1f2329); } .ds-dialog__body { font: 400 16px/24px inherit; color: var(--rcx-color-neutral-700, #6c727a); margin-bottom: 24px; max-width: 65ch; } .ds-dialog__actions { display: flex; gap: 8px; justify-content: flex-end; } .ds-btn-ghost { background: transparent; color: var(--rcx-color-neutral-900, #1f2329); border: 1px solid var(--rcx-color-neutral-400, #e4e7ea); border-radius: 4px; padding: 8px 16px; font: 400 14px/20px inherit; cursor: pointer; } .ds-btn-ghost:hover { background: var(--rcx-color-neutral-100, #f7f8fa); } .ds-btn-danger { background: var(--rcx-color-danger-500, #ec0d2a); color: #fff; border: none; border-radius: 4px; padding: 8px 16px; font: 400 14px/20px inherit; cursor: pointer; } .ds-btn-danger:hover { background: var(--rcx-color-danger-600, #d40c26); }"
+    },
+    {
+      "name": "Sidebar Rail",
+      "kind": "nav",
+      "refersTo": "sidebar",
+      "description": "44-pixel vertical workshop wall holding server buttons and bottom-anchored controls.",
+      "html": "<aside class=\"ds-rail\"><ul class=\"ds-rail__servers\"><li class=\"ds-server-btn ds-server-btn--selected\"><button class=\"ds-server-btn__avatar\">RC</button><span class=\"ds-badge-secondary ds-badge-secondary--anchored\">3</span></li><li class=\"ds-server-btn\"><button class=\"ds-server-btn__avatar\">OS</button></li><li class=\"ds-server-btn\"><button class=\"ds-server-btn__avatar\">DV</button><span class=\"ds-badge-warning ds-badge-warning--anchored\">!</span></li></ul><div class=\"ds-rail__footer\"><button class=\"ds-rail__icon\" aria-label=\"Add server\">+</button></div></aside>",
+      "css": ".ds-rail { width: 44px; height: 100%; background: var(--rcx-color-neutral-100, #f7f8fa); padding: 8px 0; display: flex; flex-direction: column; justify-content: space-between; align-items: center; font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; } .ds-rail__servers { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 4px; align-items: center; } .ds-server-btn { position: relative; } .ds-server-btn::before { position: absolute; content: ''; left: -8px; width: 4px; height: 0; border-radius: 0 4px 4px 0; background: var(--rcx-color-neutral-450, #d7dbe0); transition: height 0.2s; } .ds-server-btn--selected::before { height: 28px; } .ds-server-btn__avatar { width: 36px; height: 36px; border-radius: 4px; background: #fff; border: none; cursor: pointer; display: flex; align-items: center; justify-content: center; font: 400 12px/16px inherit; color: var(--rcx-color-neutral-900, #1f2329); } .ds-server-btn__avatar:hover { background: var(--rcx-color-neutral-450, #d7dbe0); } .ds-badge-secondary--anchored, .ds-badge-warning--anchored { position: absolute; top: 0; right: 0; transform: translate(30%, -30%); } .ds-badge-secondary { display: inline-flex; align-items: center; justify-content: center; min-width: 16px; height: 16px; padding: 0 5px; background: var(--rcx-color-neutral-600, #9ea2a8); color: #fff; font: 700 12px/16px inherit; border-radius: 9999px; } .ds-badge-warning { display: inline-flex; align-items: center; justify-content: center; min-width: 16px; height: 16px; padding: 0 5px; background: var(--rcx-color-service-1-500, #f38c39); color: #fff; font: 700 12px/16px inherit; border-radius: 9999px; } .ds-rail__icon { width: 36px; height: 36px; border-radius: 4px; background: transparent; border: none; cursor: pointer; color: var(--rcx-color-neutral-700, #6c727a); font-size: 18px; } .ds-rail__icon:hover { background: var(--rcx-color-neutral-450, #d7dbe0); color: var(--rcx-color-neutral-900, #1f2329); }"
+    },
+    {
+      "name": "Dropdown / Context Menu",
+      "kind": "card",
+      "refersTo": "dropdown",
+      "description": "Right-click menu on a server button. Carries Fuselage overlay shadow, the only allowed shadow in the shell.",
+      "html": "<div class=\"ds-dropdown\"><div class=\"ds-dropdown__title\">Workspace</div><button class=\"ds-option\"><svg width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\"><polyline points=\"23 4 23 10 17 10\"/><polyline points=\"1 20 1 14 7 14\"/><path d=\"M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15\"/></svg><span>Reload</span></button><button class=\"ds-option\"><svg width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\"><rect x=\"9\" y=\"9\" width=\"13\" height=\"13\" rx=\"2\"/><path d=\"M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1\"/></svg><span>Copy URL</span></button><hr class=\"ds-divider\"/><button class=\"ds-option ds-option--danger\"><svg width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\"><polyline points=\"3 6 5 6 21 6\"/><path d=\"M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6\"/></svg><span>Remove</span></button></div>",
+      "css": ".ds-dropdown { background: var(--rcx-color-white, #fff); border-radius: 4px; padding: 4px; min-width: 200px; box-shadow: 0 4px 12px rgba(31,35,41,0.08), 0 12px 28px rgba(31,35,41,0.12); font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; } .ds-dropdown__title { padding: 8px 12px; font: 700 12px/16px inherit; color: var(--rcx-color-neutral-700, #6c727a); text-transform: uppercase; letter-spacing: 0.04em; } .ds-option { display: flex; align-items: center; gap: 8px; width: 100%; padding: 8px 12px; background: transparent; border: none; border-radius: 4px; color: var(--rcx-color-neutral-900, #1f2329); font: 400 14px/20px inherit; text-align: left; cursor: pointer; } .ds-option:hover { background: var(--rcx-color-neutral-100, #f7f8fa); } .ds-option--danger { color: var(--rcx-color-danger-600, #d40c26); } .ds-option--danger:hover { background: var(--rcx-color-danger-100, #fde8d7); } .ds-divider { border: none; border-top: 1px solid var(--rcx-color-neutral-400, #e4e7ea); margin: 4px 0; }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Workshop Wall",
+    "overview": "The desktop shell is a tool rail: a quiet 44-pixel column of workspaces hung along the side of a screen, each one sized for instant reach. Tokens trace back to @rocket.chat/fuselage-tokens: primary uses the p ramp, neutral the n ramp, danger the d ramp, badges resolve through the SCSS badge() function (level-1 for unread count = gray, level-3 for warning = orange, level-4 for true alert = crimson). The Electron shell does not invent colors, weights, radii, or spacing values outside that scheme.",
+    "keyCharacteristics": [
+      "44-pixel server rail as the signature surface.",
+      "Flat by default, depth through tonal tint shifts (neutral-100 -> white -> neutral-450).",
+      "Inter primary, system stack fallback.",
+      "One accent gesture: the 4-pixel selection stripe to the left of the active server in neutral-450.",
+      "Color follows Fuselage CSS variables (--rcx-color-*), themed light / dark / auto via PaletteStyleTag.",
+      "Native per-platform: macOS vibrancy + 22-pixel drag bar, Windows Mica, Linux fallback."
+    ],
+    "rules": [
+      { "name": "The Fuselage Truth Rule", "body": "Every color in the desktop shell resolves to a --rcx-color-* custom property emitted by PaletteStyleTag. Hardcoded fallbacks exist only for pre-hydration backstops.", "section": "colors" },
+      { "name": "The One Stripe Rule", "body": "The 4-pixel left stripe on the selected server button is the entire decorative vocabulary of the rail. Repeat it if a new affordance needs the gesture.", "section": "colors" },
+      { "name": "The Quiet Mention Rule", "body": "The mention-count badge is Badge variant=secondary: gray on the avatar, not red. The badge is a number, not an alarm. Red is reserved for variant=danger on confirmation buttons and true alerts. Warning state (not-logged-in) uses variant=warning: orange.", "section": "colors" },
+      { "name": "The Token-First Rule", "body": "When adding a color, look up the role in fuselage-tokens/src/<role>/base.json (status, font, surface, button, stroke, background). If no role token exists, raise it as a Fuselage proposal.", "section": "colors" },
+      { "name": "The fontScale Rule", "body": "Use Fuselage fontScale='p2' / 'h1' / 'c1' on Box rather than raw font-size literals.", "section": "typography" },
+      { "name": "The Inter-First Rule", "body": "Add Inter at the front of the family stack. Do not strip back to system-ui.", "section": "typography" },
+      { "name": "The Sentence Case Rule", "body": "All shell strings are sentence case in source. Fuselage applies title case or uppercase at the component layer when needed.", "section": "typography" },
+      { "name": "The Tonal Step Rule", "body": "Adjacent shell surfaces differ by exactly one tint step. Stacking two surfaces of the same tint is a layout bug.", "section": "elevation" },
+      { "name": "The Shadow Tenancy Rule", "body": "Shadows belong to Fuselage's transient overlays and the OS-native layer. The shell does not author box-shadow in any CSS it owns.", "section": "elevation" }
+    ],
+    "dos": [
+      "Do import primitives from @rocket.chat/fuselage first.",
+      "Do reference colors via --rcx-color-* custom properties, never literal hex.",
+      "Do use Fuselage fontScale on Box rather than raw font-size literals.",
+      "Do keep the 44-pixel rail width sacred.",
+      "Do use the 4-pixel left selection stripe as the only selected-state decoration.",
+      "Do respect prefers-reduced-motion on every shell transition.",
+      "Do keep Badge variant=secondary (gray) for unread counts and variant=warning (orange) for not-logged-in.",
+      "Do keep mention-count and warning badges at translate(30%, -30%) top-right of the avatar.",
+      "Do verify both light and dark PaletteStyleTag themes hit WCAG 2.2 AA contrast.",
+      "Do use sentence case in source strings."
+    ],
+    "donts": [
+      "Don't use Discord/gamer aesthetics: no neon accents, no drenched dark purple, no playful microcopy.",
+      "Don't revive old Skype or legacy Teams chrome: no heavy gradients, no decorative iconography in titlebars.",
+      "Don't use generic SaaS marketing patterns: no hero metric tiles, no identical icon-and-title card grids, no gradient accents on numbers.",
+      "Don't pursue Linear-empty minimalism at the cost of sidebar density.",
+      "Don't use border-left or border-right greater than 1px as a colored stripe anywhere other than the canonical 4-pixel server selection stripe.",
+      "Don't use background-clip: text gradient text. Solid Fuselage tokens only.",
+      "Don't introduce glassmorphism as a stylistic choice. OS-provided vibrancy is acceptable; CSS backdrop-filter is forbidden.",
+      "Don't author box-shadow in shell-owned CSS.",
+      "Don't strip Inter out of the font stack.",
+      "Don't wrap shell content in card grids.",
+      "Don't use modals as the first thought; the sidebar context menu and inline settings tabs are better.",
+      "Don't rename, recolor, or re-style Fuselage Badge, Option, Tabs, Dropdown, IconButton primitives.",
+      "Don't confuse the Badge variants: unread is secondary (gray), not-logged-in is warning (orange), danger (red) is reserved for true alerts.",
+      "Don't invent border-radius outside 2 / 4 / 8 / 9999 pixels or spacing outside Fuselage's 4-multiple scale.",
+      "Don't add a settings divergence between light and dark themes.",
+      "Don't use em dashes anywhere in shell copy."
+    ]
+  }
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,363 @@
+---
+name: Rocket.Chat Desktop
+description: Native desktop shell around one or more Rocket.Chat server webviews.
+colors:
+  primary-500: "#156ff5"
+  primary-600: "#095ad2"
+  primary-700: "#10529e"
+  primary-200: "#d1ebfe"
+  info-500: "#156ff5"
+  danger-500: "#ec0d2a"
+  danger-550: "#f5455c"
+  danger-600: "#d40c26"
+  warning-500: "#ffd031"
+  warning-650: "#ac892f"
+  success-500: "#2de0a5"
+  success-650: "#158d65"
+  service-1-500: "#f38c39"
+  neutral-100: "#f7f8fa"
+  neutral-200: "#f2f3f5"
+  neutral-400: "#e4e7ea"
+  neutral-450: "#d7dbe0"
+  neutral-500: "#cbced1"
+  neutral-600: "#9ea2a8"
+  neutral-700: "#6c727a"
+  neutral-800: "#2f343d"
+  neutral-850: "#2f343d80"
+  neutral-900: "#1f2329"
+  white: "#ffffff"
+  badge-level-0: "#e4e7ea"
+  badge-level-1: "#9ea2a8"
+  badge-level-2: "#1d74f5"
+  badge-level-3: "#f38c39"
+  badge-level-4: "#f5455c"
+typography:
+  hero:
+    fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+    fontSize: "48px"
+    fontWeight: 800
+    lineHeight: "64px"
+    letterSpacing: "0"
+  h1:
+    fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+    fontSize: "32px"
+    fontWeight: 700
+    lineHeight: "40px"
+    letterSpacing: "0"
+  h2:
+    fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+    fontSize: "24px"
+    fontWeight: 700
+    lineHeight: "32px"
+    letterSpacing: "0"
+  h3:
+    fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+    fontSize: "20px"
+    fontWeight: 700
+    lineHeight: "28px"
+    letterSpacing: "0"
+  h4:
+    fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+    fontSize: "16px"
+    fontWeight: 700
+    lineHeight: "24px"
+    letterSpacing: "0"
+  h5:
+    fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+    fontSize: "14px"
+    fontWeight: 700
+    lineHeight: "20px"
+    letterSpacing: "0"
+  p1:
+    fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+    fontSize: "16px"
+    fontWeight: 400
+    lineHeight: "24px"
+    letterSpacing: "0"
+  p2:
+    fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+    fontSize: "14px"
+    fontWeight: 400
+    lineHeight: "20px"
+    letterSpacing: "0"
+  c1:
+    fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+    fontSize: "12px"
+    fontWeight: 400
+    lineHeight: "16px"
+    letterSpacing: "0"
+  c2:
+    fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+    fontSize: "12px"
+    fontWeight: 700
+    lineHeight: "16px"
+    letterSpacing: "0"
+  micro:
+    fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+    fontSize: "10px"
+    fontWeight: 700
+    lineHeight: "12px"
+    letterSpacing: "0"
+rounded:
+  none: "0"
+  small: "2px"
+  medium: "4px"
+  large: "8px"
+  full: "9999px"
+spacing:
+  x1: "1px"
+  x2: "2px"
+  x4: "4px"
+  x8: "8px"
+  x12: "12px"
+  x16: "16px"
+  x24: "24px"
+  x28: "28px"
+  x32: "32px"
+  x44: "44px"
+components:
+  sidebar:
+    backgroundColor: "{colors.neutral-100}"
+    width: "44px"
+    padding: "8px 0"
+  server-button:
+    backgroundColor: "{colors.neutral-100}"
+    rounded: "{rounded.medium}"
+    size: "28px"
+  server-button-selected:
+    backgroundColor: "{colors.neutral-450}"
+  badge-mention-count:
+    backgroundColor: "{colors.badge-level-1}"
+    textColor: "{colors.white}"
+    rounded: "{rounded.full}"
+  badge-not-logged-in:
+    backgroundColor: "{colors.badge-level-3}"
+    textColor: "{colors.white}"
+    rounded: "{rounded.full}"
+  dialog:
+    backgroundColor: "{colors.white}"
+    textColor: "{colors.neutral-800}"
+    rounded: "{rounded.medium}"
+    padding: "24px"
+  topbar:
+    backgroundColor: "{colors.neutral-100}"
+    height: "22px"
+  button-primary:
+    backgroundColor: "{colors.primary-500}"
+    textColor: "{colors.white}"
+    rounded: "{rounded.medium}"
+    padding: "8px 16px"
+  button-primary-hover:
+    backgroundColor: "{colors.primary-600}"
+  button-primary-press:
+    backgroundColor: "{colors.primary-700}"
+  button-danger:
+    backgroundColor: "{colors.danger-500}"
+    textColor: "{colors.white}"
+    rounded: "{rounded.medium}"
+    padding: "8px 16px"
+  button-danger-hover:
+    backgroundColor: "{colors.danger-600}"
+---
+
+# Design System: Rocket.Chat Desktop
+
+## 1. Overview
+
+**Creative North Star: "The Workshop Wall"**
+
+The desktop shell is a tool rail: a quiet 44-pixel column of workspaces hung along the side of a screen, each one sized for instant reach. Like a workshop wall, every tool has its place, density is the point, and the rail itself is invisible during work. Users move through the rail without thinking; they only notice it when a server badge calls them back, when they drag a workspace to reorder it, or when a dialog steps forward to handle something the browser cannot.
+
+The visual system inherits directly from Fuselage, the Rocket.Chat web design system. This is deliberate: users move between web and desktop daily, and visual continuity is part of the trust contract. Tokens trace back to `@rocket.chat/fuselage-tokens`: primary uses the `p` ramp, neutral the `n` ramp, danger the `d` ramp, badges resolve through the SCSS `badge()` function (`level-1` for unread count, `level-3` for warning, `level-4` for true alert). The Electron shell does not invent colors, weights, radii, or spacing values outside that scheme.
+
+This system explicitly rejects four neighbors. It is not Discord (no neon, no drenched purple, no playful microcopy). It is not legacy Skype or Teams (no heavy gradients, no decorative iconography in the titlebar, no busy toolbar). It is not generic SaaS marketing (no hero metric tiles, no identical card grids, no gradient accents on numbers). And it is not Linear-minimalism for its own sake (sidebar density matters; sparse-when-it-could-be-useful is a regression).
+
+**Key Characteristics:**
+
+- 44-pixel server rail as the signature surface.
+- Flat by default, depth through tonal tint shifts (`neutral-100` → `neutral-450` → `white`).
+- Inter primary, system stack fallback (`-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, ...`).
+- One accent gesture: the 4-pixel selection stripe to the left of the active server, in `neutral-450`.
+- Color follows Fuselage CSS variables (`--rcx-color-*`), themed light / dark / auto via `PaletteStyleTag` (resolved against `machineTheme` and `userThemePreference`).
+- Native per-platform: macOS vibrancy + 22-pixel drag bar, Windows Mica, Linux fallback.
+
+## 2. Colors
+
+A small palette of muted tints with a precise role assignment for every accent. Every color resolves to a Fuselage CSS variable; the SCSS pipeline (`primary($grade)`, `neutral($grade)`, `danger($grade)`, `badge($level)`) is the source of truth and the React `getPaletteColor` helper mirrors it. The desktop shell never invents colors outside the Fuselage palette.
+
+### Primary
+- **Action Blue** (`#156ff5`, oklch(57% 0.21 257), Fuselage `primary-500`): The dominant action color. Primary buttons, focus rings, inline links inside dialogs. Hover steps to `primary-600` (`#095ad2`), press to `primary-700` (`#10529e`). Disabled background is `primary-200` (`#d1ebfe`).
+
+### Secondary
+- **Mention Slate** (`#9ea2a8`, oklch(68% 0.012 256), Fuselage `badge-level-1` resolving to `neutral-600`): The unread-mention count badge background. Fuselage's `Badge variant='secondary'` is a muted gray, not red. Restraint is intentional; the badge is a count, not an alarm.
+
+### Tertiary
+- **Caution Orange** (`#f38c39`, oklch(72% 0.16 51), Fuselage `badge-level-3` resolving to `service-1-500`): The warning-state badge ServerButton paints over a server avatar when the user is not logged in (Fuselage `Badge variant='warning'`). Used as a state signal, never as a button background.
+- **Alert Crimson** (`#f5455c`, oklch(65% 0.22 18), Fuselage `badge-level-4` resolving to `danger-550`): Reserved for true alerts requiring user response. If introduced into the shell, it lives only on the destructive button family and `Badge variant='danger'`. Not currently in the rail vocabulary.
+
+### Neutral
+- **Workshop Slate** (`#2f343d`, oklch(31% 0.014 256), Fuselage `neutral-800`): The deep neutral behind webviews when transparent-window mode is not engaged on darwin. Also the dark text color for body copy in the dialog surface.
+- **Ink** (`#1f2329`, oklch(25% 0.013 256), Fuselage `neutral-900`): Titles and labels on light surfaces.
+- **Annotation** (`#6c727a`, oklch(52% 0.012 256), Fuselage `neutral-700`): Secondary info, hint text, dropdown section labels.
+- **Wall Cream** (`#f7f8fa`, oklch(98% 0.004 250), Fuselage `neutral-100`): The light sidebar background. Quiet enough to disappear next to webview content.
+- **Active Tone** (`#d7dbe0`, oklch(88% 0.006 256), Fuselage `neutral-450`): The 4-pixel selection stripe fill and the hover background on rail items.
+- **Hairline** (`#e4e7ea`, oklch(92% 0.005 250), Fuselage `neutral-400`): Dividers and ghost-button borders. One pixel, never offset.
+
+### Named Rules
+
+**The Fuselage Truth Rule.** Every color in the desktop shell resolves to a `--rcx-color-*` custom property emitted by `PaletteStyleTag`. The hardcoded fallbacks (`#2f343d`, `#d7dbe0`) inside `src/ui/components/SideBar/styles.tsx` and `Shell/styles.tsx` exist only as last-resort backstops for the moment before the palette tag hydrates. Do not reuse those literal hex codes anywhere else; reference the CSS variable.
+
+**The One Stripe Rule.** The 4-pixel left stripe on the selected server button is the entire decorative vocabulary of the rail. Do not add second stripes, glows, halos, or contrast borders to indicate selection elsewhere. If a new affordance needs to signal selection, repeat the stripe.
+
+**The Quiet Mention Rule.** The mention-count badge is Fuselage `Badge variant='secondary'`: gray on the avatar, white text. Not red. The badge is a number, not an alarm. Red is reserved for `variant='danger'` on confirmation buttons and true alerts. Warning state (not-logged-in) uses `variant='warning'`: orange, also not red.
+
+**The Token-First Rule.** When adding a color, look up the role in `fuselage-tokens/src/<role>/base.json` (status, font, surface, button, stroke, background). If no role token exists, do not add one in the shell; raise it as a Fuselage proposal.
+
+## 3. Typography
+
+**Display Font:** Inter (with fallback `-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif`).
+**Body Font:** Inter (same stack).
+**Mono Font:** `Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace`. Reserved for code surfaces.
+
+**Character:** Inter is the Fuselage standard. The shell prefers Inter where available and falls back through the system stack to remove font-loading flash on cold Electron start. The current shell's `system-ui`-only stylesheet (`Shell/styles.tsx` line 37) predates the Inter migration and should be brought in line with the Fuselage scale.
+
+### Hierarchy
+
+Use Fuselage `fontScale` props on `Box` and components rather than raw CSS. Each scale below is the exact `@rocket.chat/fuselage-tokens/typography.json` entry.
+
+- **hero** (800, 48 / 64): Splash screens, marketing-style hero blocks. Not used inside the shell after first paint.
+- **h1** (700, 32 / 40): Settings view title, About title.
+- **h2** (700, 24 / 32): Section headers within Settings tabs, dialog titles in About / Update.
+- **h3** (700, 20 / 28): Subsection titles, large dialog titles where h2 is too dominant.
+- **h4** (700, 16 / 24): Form group labels, dropdown section labels (uppercase via Fuselage `Option.title`).
+- **h5** (700, 14 / 20): Compact list-item titles.
+- **p1** (400, 16 / 24): Primary running copy in dialogs. Also `p1m` (500) for medium emphasis, `p1b` (700) for bold inline.
+- **p2** (400, 14 / 20): Default shell body. Sidebar tooltips, settings form rows, dropdown item text. `p2m` and `p2b` available.
+- **c1** (400, 12 / 16): Server initials, badge numbers, metadata, micro-labels.
+- **c2** (700, 12 / 16): Emphasized micro-labels (badge counts when emphasized).
+- **micro** (700, 10 / 12): Extreme density labels. Not currently used in the shell.
+
+### Named Rules
+
+**The fontScale Rule.** Use Fuselage `fontScale='p2'` (or other key) on Box rather than raw `font-size`. The scale tag is the contract; pixel literals drift.
+
+**The Inter-First Rule.** Add Inter at the front of the family stack. Do not strip it back to `system-ui` even if local Electron versions render fine without it; cross-platform parity with the Fuselage web app depends on Inter where the font is available.
+
+**The Sentence Case Rule.** All shell strings are sentence case in source. Title case appears only when the host OS demands it (macOS menu items). The single exception is `Option.title` in dropdowns, which Fuselage uppercases at the component level (uppercased CSS, sentence-case source).
+
+## 4. Elevation
+
+This system is **flat by default with tonal layering**. Depth steps through neutrals (`neutral-100` → `white` → `neutral-450`). The single sanctioned shadow vocabulary lives inside Fuselage's `shadow-colors` map (`elevation-1`, `elevation-2x`, `elevation-2y`, `elevation-border`, all built from `neutral-800` at low alpha) and is applied by Fuselage's transient-overlay components. The desktop shell never composes shadows directly; it relies on Fuselage `Dropdown`, `Dialog`, `Tile` to bring their own.
+
+### Shadow Vocabulary (inherited, not authored)
+- **elevation-1** (`neutral-800` at 10% alpha): Default lift on tiles and contextual surfaces inside Fuselage components.
+- **elevation-2** (split x/y at 8% / 12% alpha): Modal-tier lift on dialogs and menus.
+- **elevation-border** (`stroke(extra-light)`): One-pixel hairline used as the bottom edge of elevated surfaces.
+
+### Named Rules
+
+**The Tonal Step Rule.** Adjacent shell surfaces differ by exactly one tint step (`neutral-100` rail → `white` dialog → `neutral-450` selection accent). Skipping a step or stacking two surfaces of the same tint is a layout bug, not a depth choice.
+
+**The Shadow Tenancy Rule.** Shadows belong to Fuselage's transient overlays and to the OS-native layer (window chrome, vibrancy backdrops). The shell does not author `box-shadow` in any CSS it owns. If a thing looks like it wants a shadow, it wants a tonal step or a hairline.
+
+## 5. Components
+
+### Server Button (signature)
+
+- **Shape:** Fuselage `IconButton small secondary` (28-pixel square hit target with 4-pixel radius), wrapped in a 44-pixel-wide list item.
+- **Default:** Favicon or two-letter `Initials` on `neutral-100`. Initials use `c1` typography.
+- **Hover:** Background steps to `neutral-450`.
+- **Selected:** A 4-pixel-wide, 28-pixel-tall vertical bar in `neutral-450` positioned `left: -8px` outside the button, right-edge radius `0 4px 4px 0`. Height transitions on `var(--transitions-duration)`. (`src/ui/components/SideBar/styles.tsx` lines 22 to 49 is the canonical implementation.) This is the entire selected-state vocabulary.
+- **Unread count:** Fuselage `Badge variant='secondary'` (gray, `badge-level-1` = `#9ea2a8`) anchored top-right with `translate(30%, -30%)`.
+- **Not logged in:** Fuselage `Badge variant='warning'` (orange, `badge-level-3` = `#f38c39`), same anchor.
+- **Drag:** Opacity 0.5 while dragged. No border highlight on the drop target.
+- **Context menu:** Fuselage `Dropdown` with `Option`s: Reload, Copy URL, Open Dev Tools, Server Info, Reload Clearing Cache, divider, Remove (`variant='danger'`).
+
+### Sidebar Rail
+
+- **Width:** Exactly 44 pixels. Never grows, never collapses, never shows labels inline; labels live in tooltips.
+- **Background:** `neutral-100` in opaque mode; `undefined` on macOS when `isTransparentWindowEnabled` (vibrancy passes through).
+- **Padding:** `paddingBlockStart={8} paddingBlockEnd={8}`.
+- **Layout:** Vertical `ButtonGroup large` of server buttons at the top, `MenuV2` (Downloads, Settings) anchored at the bottom.
+
+### TopBar (macOS only)
+
+- **Render:** `process.platform === 'darwin'` only. Hidden on Windows and Linux.
+- **Background:** `neutral-100` (or `undefined` for vibrancy).
+- **Height:** 22-pixel drag bar above the rail. Carries the macOS traffic-light spacing.
+
+### Dialogs (About, Update, Clear Cache, Screen Sharing, Outlook Credentials, Server Info, Supported Version)
+
+- **Surface:** Fuselage `Dialog` on `white`.
+- **Corner:** `rounded.medium` (4px) at the Dialog level.
+- **Internal padding:** 24px on the outer Box; tighter inside form rows.
+- **Title:** Fuselage `fontScale='h2'` (700, 24 / 32) or `h3` (700, 20 / 28).
+- **Body:** `p1` (400, 16 / 24) for primary copy. Max 65 to 75 characters per line.
+- **Actions:** Right-aligned `ButtonGroup` at the dialog bottom. Primary uses `button-primary` (Action Blue). Destructive uses `button-danger` (`danger-500` = `#ec0d2a`).
+
+### Settings View
+
+- **Layout:** Full-window panel layered over the webview. Fuselage `Tabs` at the top (General / Certificates / optional Developer). Scrollable content inside `Box m='x24'`.
+- **Title:** `Box fontScale='h1' color='default' padding={24}` with optional back arrow (Fuselage `IconButton icon='arrow-back'`) when sidebar is disabled.
+- **Background:** `bg='room'` (resolves to `neutral-800` in light theme). Matches webview canvas to prevent flash on transition.
+
+### Buttons (Fuselage `Button`, exact mapping)
+
+- **Primary:** `backgroundPrimaryDefault` = `primary-500` (`#156ff5`). Hover `primary-600`, press `primary-700`, focus `primary-500`. Disabled background `primary-200`. Font `white`.
+- **Secondary:** `backgroundSecondaryDefault` = `neutral-400`. Hover `neutral-500`, press `neutral-600`. Font `neutral-900`.
+- **Danger:** `backgroundDangerDefault` = `danger-500` (`#ec0d2a`). Hover `danger-600`, press `danger-700`. Font `white`. Used for Remove Server, Clear Cache, equivalent confirmations.
+- **Warning:** `backgroundWarningDefault` = `warning-400`. Hover `w500`, press `w600`. Font `neutral-900` (dark text on yellow).
+- **Success:** `backgroundSuccessDefault` = `success-500`. Font `neutral-900`.
+- **Icon buttons:** Fuselage `IconButton small secondary` is the rail and chrome default. No labels alongside icons in chrome; tooltips carry meaning.
+
+### Dropdowns and Menus (Fuselage `Dropdown`, `Option`, `MenuV2`)
+
+- **Surface:** `white` with Fuselage's `elevation-2` shadow (the only allowed shadow in the shell).
+- **Items:** `OptionIcon` + `OptionContent`, single line, `p2` body typography.
+- **Section labels:** `rcx-option__title` uppercased by Fuselage; source is sentence case ("Workspace").
+- **Dangerous items:** `variant='danger'` (Fuselage colors `font-danger` text on hover background `danger-100`).
+- **Dividers:** `OptionDivider` paints `neutral-400` hairline.
+
+### Badges (Fuselage `Badge`, exact level mapping)
+
+- **`level-0` / variant unset:** `neutral-400` background (disabled state).
+- **`level-1` / `variant='secondary'`:** `neutral-600` (`#9ea2a8`) background, white text. Unread count.
+- **`level-2` / `variant='primary'`:** `primary-550` (`#1d74f5`) background. Not used in the rail.
+- **`level-3` / `variant='warning'`:** `service-1-500` (`#f38c39`) orange background. Not-logged-in state.
+- **`level-4` / `variant='danger'`:** `danger-550` (`#f5455c`) background. Reserved.
+
+All badges use `rounded.full` and white text.
+
+## 6. Do's and Don'ts
+
+### Do:
+
+- **Do** import primitives from `@rocket.chat/fuselage` first. Compose `Box`, `Button`, `IconButton`, `Badge`, `Dialog`, `Tabs`, `Dropdown`, `Option`, `MenuV2`, `Scrollable` before reaching for `styled` or `@emotion/css`. Acceptable web-only divergences: server rail, native dialogs, platform-specific affordances.
+- **Do** reference colors via `--rcx-color-*` CSS custom properties (emitted by `PaletteStyleTag`). The hardcoded `#2f343d` / `#d7dbe0` fallbacks in `SideBar/styles.tsx` and `Shell/styles.tsx` exist for hydration races, not for reuse.
+- **Do** use Fuselage `fontScale='h1'` / `'p2'` / `'c1'` etc. on `Box` and components rather than raw `font-size` literals.
+- **Do** keep the 44-pixel rail width sacred. Tooltips carry labels; the rail does not widen.
+- **Do** use the 4-pixel left selection stripe as the only selected-state decoration. Repeat it if a new affordance needs the gesture.
+- **Do** respect `prefers-reduced-motion` on every shell transition (sidebar selection slide, dialog enter, badge appearance).
+- **Do** keep `Badge variant='secondary'` (gray) for unread counts and `variant='warning'` (orange) for not-logged-in. Never recolor a Badge by overriding its CSS.
+- **Do** keep mention-count and warning badges in their existing positions: top-right of the avatar at `translate(30%, -30%)`.
+- **Do** verify both light and dark themes (`PaletteStyleTag` resolves against `machineTheme` + `userThemePreference`) hit WCAG 2.2 AA contrast before merging a color change.
+- **Do** use sentence case in source strings; Fuselage applies title or uppercase at the component layer when needed.
+
+### Don't:
+
+- **Don't** use Discord/gamer aesthetics: no neon accents, no drenched dark purple, no playful microcopy, no animated reactions in chrome.
+- **Don't** revive old Skype or legacy Teams chrome: no heavy gradients, no layered drop shadows, no decorative iconography in titlebars, no busy multi-row toolbars.
+- **Don't** use generic SaaS marketing patterns inside the app: no hero metric tiles, no identical icon-and-title card grids, no gradient accents on numbers.
+- **Don't** pursue pure brand minimalism (Linear-empty) at the cost of sidebar density. The shell's value is showing many servers at once.
+- **Don't** use `border-left` or `border-right` greater than 1px as a colored stripe anywhere other than the canonical 4-pixel server selection stripe. That stripe is the entire vocabulary.
+- **Don't** use `background-clip: text` gradient text. Solid Fuselage tokens only.
+- **Don't** introduce glassmorphism as a stylistic choice. macOS vibrancy is OS-provided and acceptable; CSS `backdrop-filter` on rendered surfaces is forbidden.
+- **Don't** author `box-shadow` in shell-owned CSS. Depth through tonal stepping; rely on Fuselage's overlay shadow on `Dropdown` and `Dialog`.
+- **Don't** strip Inter out of the font stack. Inter first, system fallback behind it. The current `Shell/styles.tsx` `font-family: system-ui` line predates the Fuselage Inter migration and should be aligned.
+- **Don't** wrap shell content in card grids. The shell is a rail, a webview canvas, and dialogs.
+- **Don't** use modals as the first thought for new flows. The sidebar context menu (`Dropdown`) and inline settings tabs are better placements; reach for `Dialog` only when interruption is genuinely required.
+- **Don't** rename, recolor, or re-style Fuselage `Badge`, `Option`, `Tabs`, `Dropdown`, `IconButton` primitives. Override only via accepted Fuselage props.
+- **Don't** confuse the Badge variants: unread count is `secondary` (gray), not-logged-in is `warning` (orange), and `danger` (red) is reserved for true alerts. Red mention badges are not part of this design system.
+- **Don't** invent a `border-radius` value outside `2 / 4 / 8 / 9999` pixels. Spacing literals outside Fuselage's 4-multiple scale (plus 1 and 2) are also disallowed.
+- **Don't** add a settings divergence between light and dark themes. Both themes must offer the same affordances; only the palette resolves differently.
+- **Don't** use em dashes anywhere in shell copy. Commas, colons, semicolons, periods, parentheses only.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,52 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Enterprise knowledge workers who keep Rocket.Chat open all day, often in the background. Many work inside regulated or self-hosted environments (government, healthcare, finance, on-prem IT). A meaningful subset are power users juggling multiple Rocket.Chat workspaces (work + community + customer tenants) and depend on the desktop client for fast cross-server switching, OS-level notifications, and native integrations the browser cannot offer.
+
+Primary context: long-session use on a work machine, alongside other native apps. Users alt-tab in and out; they do not study the chrome, they reach for it.
+
+## Product Purpose
+
+Rocket.Chat Desktop is the native shell around one or more Rocket.Chat server webviews. Its job is to make managing multiple workspaces fast: server list switching, notification badges, deep links, certificate handling, screen sharing, downloads, tray presence, auto-update. The webview is the chat product; the desktop client is the connective tissue that makes running several at once feel like one tool instead of several browser tabs.
+
+Success looks like: users forget the shell exists during normal use, and reach for it instinctively the moment they need to switch servers, recover from a stuck webview, or configure something the browser cannot do.
+
+## Brand Personality
+
+Reliable, professional, focused. Voice is plain and unornamented: short labels, no marketing flourishes, no playful microcopy. The interface should feel like a tool an IT admin would trust on a regulated network, while remaining warm enough for end users who live in it eight hours a day. Confident, not loud. Capable, not clever.
+
+## Anti-references
+
+- **Discord / gamer chat aesthetics.** Neon accents, drenched dark purple, playful empty states, animated reactions in chrome. Wrong register for enterprise and public sector.
+- **Old Skype / legacy Teams chrome.** Heavy gradients, layered drop shadows, busy toolbars, decorative iconography in titlebars. Dated, visually noisy, undermines trust.
+- **Generic SaaS marketing patterns inside the app.** Gradient hero numbers, identical icon-and-title card grids, "modern dashboard" aesthetics. The desktop shell is not a marketing surface.
+- **Pure brand minimalism (Linear-empty for its own sake).** Multi-server power users need information density in the sidebar. Sparse-for-sparseness-sake hides the value of the shell.
+
+## Design Principles
+
+1. **Shell disappears, servers shine.** Desktop chrome must not compete with the webview. Sidebar, titlebar, and dialogs exist to switch, notify, and configure, then recede. If a chrome element draws the eye during normal chat use, it is wrong.
+
+2. **Density without clutter.** Multi-workspace power users need many servers and signals visible at once. Earn every pixel: tight rhythm, considered hierarchy, no decorative padding. Density and clarity are compatible; sparse is not automatically better.
+
+3. **Native, not web-pretending.** Respect OS conventions per platform: macOS traffic lights and vibrancy, Windows titlebar buttons and Mica, Linux menubar fallbacks. The desktop edge over the browser IS the native feel. Cross-platform consistency matters less than per-platform correctness.
+
+4. **Trust through restraint.** Enterprise, government, and healthcare users need confidence. No surprises, no flourishes, no theatrical motion. Predictable beats clever. Errors are quiet and actionable, not dramatic.
+
+5. **Fuselage first, custom last.** Visual coherence with the Rocket.Chat web app is a feature for users who move between web and desktop. Use `@rocket.chat/fuselage` primitives by default. Introduce custom components only where the desktop shell has no web equivalent (server sidebar, native dialogs, platform-specific affordances).
+
+## Accessibility & Inclusion
+
+Target: **WCAG 2.2 AA**, with attention to extras commonly required by Rocket.Chat's public sector and healthcare deployments.
+
+- Full keyboard navigation across the shell (sidebar, menus, dialogs). No mouse-only affordances.
+- Screen reader labels on every interactive shell element, including server sidebar entries and notification badges.
+- Honor `prefers-reduced-motion` for all shell motion (sidebar transitions, dialog enters, badge animations).
+- Honor system-level high contrast and forced colors on Windows.
+- Contrast meets 2.2 AA against the active theme; verify against both light and dark.
+- Do not rely on color alone to convey state (unread, error, connecting). Always pair with shape, icon, or text.
+- Color-vision-deficient safe accent choices when introducing new status colors.

--- a/src/ui/components/CertificatesManager/ActionButton.tsx
+++ b/src/ui/components/CertificatesManager/ActionButton.tsx
@@ -1,14 +1,10 @@
-import { Box } from '@rocket.chat/fuselage';
-import type { AllHTMLAttributes } from 'react';
+import { Button } from '@rocket.chat/fuselage';
+import type { ComponentProps } from 'react';
 
-type ActionButtonProps = AllHTMLAttributes<HTMLAnchorElement>;
+type ActionButtonProps = ComponentProps<typeof Button>;
 
 const ActionButton = (props: ActionButtonProps) => (
-  <>
-    <Box marginInline={4} withRichContent>
-      <a href='#' {...props} />
-    </Box>
-  </>
+  <Button small secondary mi='x4' {...props} />
 );
 
 export default ActionButton;

--- a/src/ui/components/ServerInfoContent.tsx
+++ b/src/ui/components/ServerInfoContent.tsx
@@ -124,7 +124,7 @@ const ServerInfoContent = ({
         <OptionContent style={{ minWidth: 0, overflow: 'visible' }}>
           <Box>
             <Box fontWeight='bold'>{t('serverInfo.urlLabel')}</Box>
-            <Box fontSize='x12' color='hint' style={textWrapStyle}>
+            <Box fontSize='x12' color='font-hint' style={textWrapStyle}>
               {url}
             </Box>
           </Box>
@@ -135,7 +135,7 @@ const ServerInfoContent = ({
         <OptionContent style={{ minWidth: 0, overflow: 'visible' }}>
           <Box>
             <Box fontWeight='bold'>{t('serverInfo.versionLabel')}</Box>
-            <Box fontSize='x12' color='hint' style={textWrapStyle}>
+            <Box fontSize='x12' color='font-hint' style={textWrapStyle}>
               {version || t('serverInfo.unknown')}
             </Box>
           </Box>
@@ -147,7 +147,7 @@ const ServerInfoContent = ({
           <OptionContent style={{ minWidth: 0, overflow: 'visible' }}>
             <Box>
               <Box fontWeight='bold'>{t('serverInfo.exchangeUrlLabel')}</Box>
-              <Box fontSize='x12' color='hint' style={textWrapStyle}>
+              <Box fontSize='x12' color='font-hint' style={textWrapStyle}>
                 {exchangeUrl}
               </Box>
             </Box>
@@ -181,7 +181,7 @@ const ServerInfoContent = ({
                   color={
                     supportedVersionsFetchState === 'error'
                       ? 'status-font-on-danger'
-                      : 'hint'
+                      : 'font-hint'
                   }
                   style={textWrapStyle}
                 >
@@ -257,7 +257,7 @@ const ServerInfoContent = ({
             <OptionContent style={{ minWidth: 0, overflow: 'visible' }}>
               <Box>
                 <Box fontWeight='bold'>Timestamp:</Box>
-                <Box fontSize='x12' color='hint' style={textWrapStyle}>
+                <Box fontSize='x12' color='font-hint' style={textWrapStyle}>
                   {new Date(supportedVersions.timestamp).toLocaleString()}
                 </Box>
               </Box>
@@ -270,7 +270,7 @@ const ServerInfoContent = ({
                 <Box fontWeight='bold'>Exceptions:</Box>
                 {supportedVersions.exceptions?.versions &&
                 supportedVersions.exceptions.versions.length > 0 ? (
-                  <Box fontSize='x12' color='hint' marginBlockStart='x4'>
+                  <Box fontSize='x12' color='font-hint' marginBlockStart='x4'>
                     <Box fontWeight='bold'>Exception Versions:</Box>
                     {supportedVersions.exceptions.versions
                       .slice(0, 3)
@@ -279,7 +279,7 @@ const ServerInfoContent = ({
                           <Box style={textWrapStyle}>• {version.version}</Box>
                           <Box
                             fontSize='x10'
-                            color='annotation'
+                            color='font-annotation'
                             style={textWrapStyle}
                           >
                             Expires:{' '}
@@ -290,7 +290,7 @@ const ServerInfoContent = ({
                     {supportedVersions.exceptions.versions.length > 3 && (
                       <Box
                         fontSize='x10'
-                        color='annotation'
+                        color='font-annotation'
                         marginInlineStart='x8'
                         style={textWrapStyle}
                       >
@@ -300,7 +300,7 @@ const ServerInfoContent = ({
                     )}
                   </Box>
                 ) : (
-                  <Box fontSize='x12' color='hint' style={textWrapStyle}>
+                  <Box fontSize='x12' color='font-hint' style={textWrapStyle}>
                     No version exceptions configured
                   </Box>
                 )}
@@ -325,7 +325,7 @@ const ServerInfoContent = ({
                   {expirationData.message && (
                     <Box
                       fontSize='x10'
-                      color='annotation'
+                      color='font-annotation'
                       marginBlockStart='x4'
                     >
                       {expirationData.message.title && (
@@ -345,7 +345,11 @@ const ServerInfoContent = ({
                       )}
                     </Box>
                   )}
-                  <Box fontSize='x10' color='annotation' style={textWrapStyle}>
+                  <Box
+                    fontSize='x10'
+                    color='font-annotation'
+                    style={textWrapStyle}
+                  >
                     {(() => {
                       const expirationDate = new Date(
                         expirationData.expiration

--- a/src/ui/components/ServersView/DocumentViewer.tsx
+++ b/src/ui/components/ServersView/DocumentViewer.tsx
@@ -32,7 +32,7 @@ const DocumentViewer = ({
       <Box
         display='flex'
         alignItems='center'
-        color='default'
+        color='font-default'
         pbe='x8'
         pbs='x8'
         pis='x8'

--- a/src/ui/components/ServersView/MarkdownContent.tsx
+++ b/src/ui/components/ServersView/MarkdownContent.tsx
@@ -205,7 +205,7 @@ const MarkdownContent = ({
         alignItems='center'
         height='100%'
         width='100%'
-        color='default'
+        color='font-default'
       >
         <Throbber size='x16' inheritColor />
       </Box>
@@ -234,7 +234,7 @@ const MarkdownContent = ({
         ref={containerRef}
         className='markdown-body'
         style={{ maxWidth: 980, margin: '0 auto', padding: '48px 40px 64px' }}
-        color='default'
+        color='font-default'
         dangerouslySetInnerHTML={{ __html: htmlContent }}
       />
     </Box>

--- a/src/ui/components/ServersView/PdfContent.tsx
+++ b/src/ui/components/ServersView/PdfContent.tsx
@@ -78,7 +78,7 @@ const PdfContent = ({ url, partition }: { url: string; partition: string }) => {
         height='100%'
         width='100%'
         position='absolute'
-        color='default'
+        color='font-default'
       >
         <Throbber size='x16' inheritColor />
       </Box>

--- a/src/ui/components/Shell/styles.tsx
+++ b/src/ui/components/Shell/styles.tsx
@@ -34,7 +34,17 @@ export const GlobalStyles = ({
           -webkit-font-smoothing: antialiased;
           margin: 0;
           padding: 0;
-          font-family: system-ui;
+          font-family:
+            Inter,
+            -apple-system,
+            BlinkMacSystemFont,
+            'Segoe UI',
+            Roboto,
+            Oxygen,
+            Ubuntu,
+            Cantarell,
+            'Helvetica Neue',
+            sans-serif;
           font-size: 0.875rem;
           line-height: 1rem;
           background-color: ${backgroundColor};

--- a/src/ui/components/TopBar/index.tsx
+++ b/src/ui/components/TopBar/index.tsx
@@ -25,7 +25,7 @@ export const TopBar = () => {
       flexDirection='row'
       justifyContent='center'
       alignItems='center'
-      color='default'
+      color='font-default'
       bg={sidebarBg}
       width='100%'
     >


### PR DESCRIPTION
## Summary

#3349 absorbed most of #3344's UI polish, but a set of changes never made it to `master`. This PR ports the remainder, verified file-by-file against the merged state:

- **Explicit `font-*` color tokens** — `color='hint' | 'default' | 'annotation'` → `'font-hint' | 'font-default' | 'font-annotation'` in `ServerInfoContent`, `DocumentViewer`, `MarkdownContent`, `PdfContent`, and `TopBar`, matching the token names in Fuselage's `Theme.d.ts`.
- **CertificatesManager action button** — replaces the `<a href='#'>` fake-link wrapped in a `Box` with a proper Fuselage `<Button small secondary>`, fixing semantics and keyboard accessibility.
- **Font stack** — `GlobalStyles` now uses the Inter-first stack instead of bare `system-ui`.
- **Design context files** — commits `DESIGN.md`, `PRODUCT.md`, and `.impeccable/design.json` introduced by #3344 (current versions, updated after the Fuselage 0.78 migration).

Deliberately **not** ported from #3344: the `Section`/`CertificateSection` component restructure and its i18n keys — #3349 shipped a different design for those views, and porting them would revert it.

## Verification

- `yarn lint` and `npx tsc --noEmit` pass on this branch.
- Token fixes and font stack are presentation-only; no logic changes.

Supersedes the remaining scope of #3344.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive design system documentation with design principles, typography standards, color tokens, component specifications, and UI guidelines.
  * Added product requirements documentation covering brand, accessibility, and inclusion standards.

* **Style**
  * Updated typography with an improved font stack featuring Inter and system font fallbacks.
  * Refined text color tokens for better visual consistency and accessibility.

* **Refactor**
  * Simplified button component in Certificates Manager.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->