### PR TITLE
feat: expose supportedDocumentViewerFormats on the desktop API

### DIFF
--- a/src/servers/preload/api.ts
+++ b/src/servers/preload/api.ts
@@ -18,7 +18,10 @@ import { onTelephonyCallRequested } from '../../telephony/preload';
 import { setUserPresenceDetection } from '../../userPresence/preload';
 import { setBadge } from './badge';
 import { writeTextToClipboard } from './clipboard';
-import { openDocumentViewer } from './documentViewer';
+import {
+  openDocumentViewer,
+  supportedDocumentViewerFormats,
+} from './documentViewer';
 import { getE2ePdfPreviewSizeLimit } from './e2ePdfPreviewSizeLimit';
 import { setFavicon } from './favicon';
 import { setGitCommitHash } from './gitCommitHash';
@@ -55,6 +58,7 @@ type ExtendedIRocketChatDesktop = IRocketChatDesktop & {
   onTelephonyCallRequested: (
     callback: (payload: { phoneNumber: string; rawUri: string }) => void
   ) => void;
+  supportedDocumentViewerFormats: () => string[];
 };
 
 declare global {
@@ -99,6 +103,7 @@ export const RocketChatDesktop: Window['RocketChatDesktop'] = {
   setUserToken,
   setSidebarCustomTheme,
   openDocumentViewer,
+  supportedDocumentViewerFormats,
   openInBrowser,
   reloadServer,
   getE2ePdfPreviewSizeLimit,

--- a/src/servers/preload/documentViewer.ts
+++ b/src/servers/preload/documentViewer.ts
@@ -7,3 +7,8 @@ export const openDocumentViewer = (
 ): void => {
   ipcRenderer.invoke('document-viewer/open-window', url, format, options);
 };
+
+export const supportedDocumentViewerFormats = (): string[] => [
+  'pdf',
+  'markdown',
+];


### PR DESCRIPTION
## What

Adds a `supportedDocumentViewerFormats(): string[]` method to the `RocketChatDesktop` preload API, returning `['pdf', 'markdown']`.

## Why

The web client needs to feature-detect whether the desktop document viewer can render markdown. `openDocumentViewer` has existed since the PDF viewer, so checking for the method's existence cannot distinguish desktop builds that also render markdown from older ones that only render PDF.

With this capability exposed, the server web client can open markdown attachments directly in the document viewer (the same flow PDFs use today) instead of relying on `will-download` interception. Companion server PR follows.

## Related

- #3345 (markdown download bug)
- #3348 (transitional fix: interception guard for older servers)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Document viewer API now exposes supported formats. Applications can query which document types are supported for in-app viewing.
  * Initial supported formats include PDF and Markdown, improving format detection and integration with viewer workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->