### PR TITLE
fix: only open screen-share picker on a user-initiated request

### DIFF
--- a/src/screenSharing/main/serverViewScreenSharing.spec.ts
+++ b/src/screenSharing/main/serverViewScreenSharing.spec.ts
@@ -157,3 +157,46 @@ describe('setupServerViewDisplayMedia — cache warming gate', () => {
     expect(prewarmMock).not.toHaveBeenCalled();
   });
 });
+
+describe('setupServerViewDisplayMedia — user gesture gate', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it('denies getDisplayMedia requests that have no user gesture (startup probe)', async () => {
+    detectPickerType.mockReturnValue('internal');
+    const { setupServerViewDisplayMedia } = await loadModule();
+
+    const guest = createGuestWebContents();
+    setupServerViewDisplayMedia(guest.webContents);
+
+    await flushPromises();
+    await flushPromises();
+
+    const handler = guest.setDisplayMediaRequestHandler.mock.calls[0][0];
+    const cb = jest.fn();
+    handler({ userGesture: false }, cb);
+
+    expect(cb).toHaveBeenCalledWith({ video: false });
+    expect(internalProvider.handleDisplayMediaRequest).not.toHaveBeenCalled();
+  });
+
+  it('delegates to the provider when the request has a user gesture', async () => {
+    detectPickerType.mockReturnValue('internal');
+    const { setupServerViewDisplayMedia } = await loadModule();
+
+    const guest = createGuestWebContents();
+    setupServerViewDisplayMedia(guest.webContents);
+
+    await flushPromises();
+    await flushPromises();
+
+    const handler = guest.setDisplayMediaRequestHandler.mock.calls[0][0];
+    const cb = jest.fn();
+    handler({ userGesture: true }, cb);
+
+    expect(internalProvider.handleDisplayMediaRequest).toHaveBeenCalledWith(cb);
+    expect(cb).not.toHaveBeenCalled();
+  });
+});

--- a/src/screenSharing/serverViewScreenSharing.ts
+++ b/src/screenSharing/serverViewScreenSharing.ts
@@ -69,7 +69,13 @@ export const setupServerViewDisplayMedia = (
     const currentProvider = provider;
     try {
       guestWebContents.session.setDisplayMediaRequestHandler(
-        (_request, cb) => {
+        (request, cb) => {
+          // Ignore the automatic, gesture-less getDisplayMedia() probe the web app fires on
+          // load; only open the picker for a genuine user-initiated share (regression #3308).
+          if (!request.userGesture) {
+            cb({ video: false } as any);
+            return;
+          }
           try {
             currentProvider.handleDisplayMediaRequest(cb);
           } catch (error) {


### PR DESCRIPTION
Closes #3308

## What changed

The desktop-capturer **source picker opened on every app launch** (regression since 4.14.0, introduced by #3266 which added screen-sharing support for the server view).

Root cause: the web app calls `navigator.mediaDevices.getDisplayMedia()` during page load to probe capabilities. Because the app runs with `--autoplay-policy=no-user-gesture-required`, that automatic, gesture-less probe is not rejected as it would be in a browser — it reaches the `setDisplayMediaRequestHandler` that #3266 now registers on every server-view webview, which opens the picker.

This adds a guard so the handler **ignores requests that carry no user gesture** (`request.userGesture === false`), and only delegates to the provider for a genuine, user-initiated screen share. Real shares always originate from a click, so they are unaffected.

This complements the earlier partial fix #3320, which only gated the Linux/portal cache-prewarm path — the picker still opened on every launch on all platforms via the handler itself, which is why this issue remained open.

## Why this approach

`request.userGesture` is the documented Electron signal for whether a display-media request came from a user interaction; gating on it is the minimal change that restores the pre-4.14.0 behaviour (no picker on launch) without reverting #3266's feature. The denial uses the same `cb({ video: false })` shape as the other deny paths in this module for consistency.

## Tests

Added two cases to `src/screenSharing/main/serverViewScreenSharing.spec.ts`:
- a gesture-less request is denied with `{ video: false }` and the provider's `handleDisplayMediaRequest` is **not** invoked;
- a request with a user gesture is delegated to the provider.

Run with `yarn test`.

## Manual verification

1. Launch the app, connect to a workspace, then **close and relaunch** → no picker appears on startup (the reported regression).
2. Start a screen share from a server-view share button → the picker still opens and a source can be selected.
3. Start a screen share inside a video call → the picker still works (the call-window handler is separate and untouched).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed screen-picker incorrectly opening from automatic probe calls without user gestures. The handler now detects and rejects such requests immediately.

* **Tests**
  * Added test coverage for user gesture validation, verifying correct handling of both user-initiated and automatic request scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->