### PR TITLE
fix: keep the window on its last position when parked at a screen edge

### DIFF
--- a/src/ui/main/rootWindow.spec.ts
+++ b/src/ui/main/rootWindow.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-import { app } from 'electron';
+import { app, screen } from 'electron';
 
 jest.mock('electron', () => ({
   app: {
@@ -19,6 +19,7 @@ jest.mock('electron', () => ({
     getPrimaryDisplay: jest.fn(() => ({
       workAreaSize: { width: 1920, height: 1080 },
     })),
+    getAllDisplays: jest.fn(() => []),
   },
 }));
 
@@ -472,5 +473,46 @@ describe('rootWindow close event handler', () => {
 
       expect(() => setupRootWindow()).not.toThrow();
     });
+  });
+});
+
+describe('isInsideSomeScreen', () => {
+  const { isInsideSomeScreen } = require('./rootWindow');
+
+  const setDisplays = (
+    displays: {
+      bounds: { x: number; y: number; width: number; height: number };
+    }[]
+  ) => (screen.getAllDisplays as jest.Mock).mockReturnValue(displays);
+
+  it('returns true when the window is fully inside a display', () => {
+    setDisplays([{ bounds: { x: 0, y: 0, width: 1920, height: 1080 } }]);
+    expect(
+      isInsideSomeScreen({ x: 100, y: 100, width: 800, height: 600 })
+    ).toBe(true);
+  });
+
+  it('returns true when the window is only partially visible at a screen edge', () => {
+    setDisplays([{ bounds: { x: 0, y: 0, width: 1920, height: 1080 } }]);
+    expect(
+      isInsideSomeScreen({ x: 1800, y: 1000, width: 800, height: 600 })
+    ).toBe(true);
+  });
+
+  it('returns true when the window spans two displays', () => {
+    setDisplays([
+      { bounds: { x: 0, y: 0, width: 1920, height: 1080 } },
+      { bounds: { x: 1920, y: 0, width: 1920, height: 1080 } },
+    ]);
+    expect(
+      isInsideSomeScreen({ x: 1800, y: 100, width: 400, height: 600 })
+    ).toBe(true);
+  });
+
+  it('returns false when the window is entirely off every display', () => {
+    setDisplays([{ bounds: { x: 0, y: 0, width: 1920, height: 1080 } }]);
+    expect(
+      isInsideSomeScreen({ x: 3000, y: 2000, width: 800, height: 600 })
+    ).toBe(false);
   });
 });

--- a/src/ui/main/rootWindow.ts
+++ b/src/ui/main/rootWindow.ts
@@ -137,6 +137,9 @@ export const createRootWindow = (): void => {
 export const normalizeNumber = (value: number | undefined): number =>
   value && isFinite(1 / value) ? value : 0;
 
+// A window counts as on-screen if it overlaps any display, rather than being fully contained
+// by one. This preserves the saved bounds for windows parked at a screen edge or spanning two
+// monitors, which were previously discarded and re-centered on the primary display (#2714).
 export const isInsideSomeScreen = ({
   x,
   y,
@@ -147,10 +150,10 @@ export const isInsideSomeScreen = ({
     .getAllDisplays()
     .some(
       ({ bounds }) =>
-        x >= bounds.x &&
-        y >= bounds.y &&
-        x + width <= bounds.x + bounds.width &&
-        y + height <= bounds.y + bounds.height
+        x < bounds.x + bounds.width &&
+        x + width > bounds.x &&
+        y < bounds.y + bounds.height &&
+        y + height > bounds.y
     );
 
 export const applyRootWindowState = (browserWindow: BrowserWindow): void => {


### PR DESCRIPTION
Closes #2714

## What changed

The app didn't reopen at its last window position when the window had been left **at a screen edge** (or spanning two monitors) — it was re-centered on the primary display instead.

Root cause: `isInsideSomeScreen` (`src/ui/main/rootWindow.ts`) required the window to be **fully contained** within a single display:

```ts
x >= bounds.x && y >= bounds.y &&
x + width <= bounds.x + bounds.width &&
y + height <= bounds.y + bounds.height
```

A window parked so that any part crosses a display boundary fails this check, so `applyRootWindowState` falls into the re-center branch and discards the saved bounds.

This changes the check to treat a window as on-screen when it **overlaps** any display (the standard "window within bounds" heuristic used by e.g. `electron-window-state`), rather than requiring full containment:

```ts
x < bounds.x + bounds.width && x + width > bounds.x &&
y < bounds.y + bounds.height && y + height > bounds.y
```

A window entirely off every display (e.g. a monitor was disconnected) still fails the check and is correctly re-centered. Because the video-call window restore path (`src/videoCallWindow/ipc.ts`) reuses this same helper, it gets the same fix.

## Tests

Added a unit-test block for `isInsideSomeScreen` in `src/ui/main/rootWindow.spec.ts` covering: fully-inside, partially-visible-at-edge, spanning-two-displays (all preserved), and entirely-off-screen (re-centered). `yarn test` and `yarn lint` (ESLint + `tsc`) pass locally.

## Steps to reproduce

1. Move the window so part of it sits past a screen edge (or across two monitors), then quit.
2. Relaunch. Before this change the window re-centers on the primary display; after it, it reopens where you left it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed window positioning to properly preserve previously saved locations, especially those at screen edges or spanning multiple displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->