### PR TITLE
chore: add test coverage measurement

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -41,7 +41,14 @@ jobs:
       - name: Lint
         run: yarn lint
       - name: Test
-        run: yarn test
+        run: yarn test:coverage
+      - name: Upload coverage report
+        if: ${{ always() && matrix.os == 'ubuntu-latest' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: coverage-report
+          path: coverage/
+          if-no-files-found: warn
       - name: Build app/
         run: yarn build
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ supportedVersions.jwt
 localdev/
 
 # caches and temp
+/coverage
 jest_dx/
 node-compile-cache/
 coderabbit-update-*/

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,15 @@
 module.exports = {
+  collectCoverageFrom: [
+    'src/**/*.{ts,tsx}',
+    '!src/**/*.spec.{ts,tsx}',
+    '!src/**/*.test.{ts,tsx}',
+    '!src/**/*.d.ts',
+    '!src/.jest/**',
+    '!src/public/**',
+  ],
+  coverageReporters: ['text-summary', 'lcov', 'json-summary'],
+  coverageDirectory: 'coverage',
+  coveragePathIgnorePatterns: ['/node_modules/', '/app/', '/dist/'],
   projects: [
     {
       preset: 'ts-jest',

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "release": "yarn electron-builder --publish onTagOrDraft --x64",
     "install-app-deps": "electron-builder install-app-deps",
     "test": "xvfb-maybe jest --forceExit --detectOpenHandles --maxWorkers=1",
+    "test:coverage": "xvfb-maybe jest --coverage --forceExit --detectOpenHandles --maxWorkers=1",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
     "lint": "run-s .:lint:eslint .:lint:tsc",
     ".:lint:eslint": "eslint .",


### PR DESCRIPTION
## What

Wires test coverage collection and reporting to establish a baseline. **Measurement only** — no threshold gate, so coverage never blocks a merge.

## Starting coverage (baseline)

Measured locally with the new `yarn test:coverage` (282 pass, 2 skip):

| Metric | Coverage |
|--------|----------|
| Statements | **17.67%** (1929/10911) |
| Branches | **13.18%** (676/5128) |
| Functions | **11.87%** (272/2290) |
| Lines | **17.15%** (1749/10195) |

The denominator includes currently-untested directories (`src/store/`, `src/ipc/`, `src/logging/`, etc.), so this is a real coverage figure, not a tested-files ratio.

## Changes

- **`jest.config.js`** — root-level `collectCoverageFrom` across `src/**/*.{ts,tsx}` (excludes specs, `.d.ts`, `.jest`, `public`); reporters `text-summary` + `lcov` + `json-summary`; output to `coverage/`. No `coverageThreshold` — deliberate.
- **`package.json`** — adds `test:coverage` (same flags as `test` + `--coverage`). `test` left untouched so the default path stays fast.
- **`.github/workflows/validate-pr.yml`** — runs `yarn test:coverage`; uploads `coverage/` as an artifact (Linux-only, `always()`, non-blocking).
- **`.gitignore`** — ignores `/coverage`.

## Notes

- Coverage instrumentation verified working under `@kayahr/jest-electron-runner` (both main + renderer projects) — no v8 fallback needed.
- Artifact upload chosen over Codecov to avoid requiring a `CODECOV_TOKEN` secret. Swap to `codecov-action` later if inline PR deltas / trend graphs are wanted.

## Follow-ups (out of scope here)

- Add tests for pure-logic quick wins (`store/`, `ipc/`, `logging/privacy`, `utils/versionUtils`, navigation reducers).
- Once the baseline lands, add a `coverageThreshold` floor and ratchet it up per PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Implemented automated code coverage reporting in the continuous integration pipeline.

* **Chores**
  * Updated test configuration to collect and track code coverage metrics during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->