### PR TITLE
test: add pure-logic unit tests + coverage ratchet gate (Phase 1)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,14 @@ module.exports = {
   coverageReporters: ['text-summary', 'lcov', 'json-summary'],
   coverageDirectory: 'coverage',
   coveragePathIgnorePatterns: ['/node_modules/', '/app/', '/dist/'],
+  coverageThreshold: {
+    global: {
+      lines: 21,
+      statements: 21,
+      branches: 19,
+      functions: 15,
+    },
+  },
   projects: [
     {
       preset: 'ts-jest',

--- a/src/errors/main/criticalError.spec.ts
+++ b/src/errors/main/criticalError.spec.ts
@@ -1,0 +1,342 @@
+/**
+ * Unit tests for the critical-error matcher and global error-handler setup in
+ * src/errors.ts.
+ *
+ * `setupGlobalErrorHandlers` is guarded by a module-level `_globalHandlersBound`
+ * flag, so each test that needs a fresh registration uses `jest.resetModules()`
+ * + dynamic `import()` to reset that flag.
+ *
+ * `electron` and `./store` are mocked so the module under test does not touch
+ * the real Electron app or the Redux store.
+ */
+import type * as ErrorsModuleType from '../../errors';
+import { SETTINGS_SET_REPORT_OPT_IN_CHANGED } from '../../ui/actions';
+
+type ErrorsModule = typeof ErrorsModuleType;
+
+type ProcessEventHandler = (...args: unknown[]) => void;
+
+const TEST_APP_VERSION = '4.13.0';
+
+let appQuitMock: jest.Mock;
+let bugsnagIsStartedMock: jest.Mock;
+let bugsnagNotifyMock: jest.Mock;
+
+const loadErrorsModule = async (): Promise<ErrorsModule> => {
+  jest.resetModules();
+
+  appQuitMock = jest.fn();
+  bugsnagIsStartedMock = jest.fn(() => false);
+  bugsnagNotifyMock = jest.fn();
+
+  jest.doMock('electron', () => ({
+    app: {
+      quit: appQuitMock,
+      getVersion: jest.fn(() => TEST_APP_VERSION),
+    },
+  }));
+
+  jest.doMock('../../store', () => ({
+    select: jest.fn(() => ({
+      appVersion: TEST_APP_VERSION,
+      isReportEnabled: false,
+    })),
+    listen: jest.fn(() => () => undefined),
+  }));
+
+  jest.doMock('@bugsnag/js', () => ({
+    __esModule: true,
+    default: {
+      isStarted: bugsnagIsStartedMock,
+      notify: bugsnagNotifyMock,
+      start: jest.fn(() => ({
+        startSession: jest.fn(),
+        pauseSession: jest.fn(),
+      })),
+    },
+  }));
+
+  return import('../../errors');
+};
+
+/**
+ * Registers the global error handlers and returns the captured process event
+ * handlers keyed by event name. Uses a spy on `process.on` to intercept the
+ * registrations performed by `setupMainErrorHandling`.
+ */
+const captureHandlers = async (): Promise<{
+  errorsModule: ErrorsModule;
+  handlers: Record<string, ProcessEventHandler>;
+}> => {
+  const errorsModule = await loadErrorsModule();
+  const handlers: Record<string, ProcessEventHandler> = {};
+
+  const onSpy = jest
+    .spyOn(process, 'on')
+    .mockImplementation((event: string | symbol, listener: any) => {
+      if (event === 'uncaughtException' || event === 'unhandledRejection') {
+        handlers[event as string] = listener;
+      }
+      return process;
+    });
+
+  await errorsModule.setupMainErrorHandling();
+
+  onSpy.mockRestore();
+
+  return { errorsModule, handlers };
+};
+
+afterEach(() => {
+  jest.resetModules();
+  jest.restoreAllMocks();
+});
+
+describe('errors/setupMainErrorHandling', () => {
+  it('registers uncaughtException and unhandledRejection handlers once', async () => {
+    const errorsModule = await loadErrorsModule();
+    const onSpy = jest
+      .spyOn(process, 'on')
+      .mockImplementation(() => process as any);
+
+    await errorsModule.setupMainErrorHandling();
+
+    const registeredEvents = onSpy.mock.calls.map((call) => call[0]);
+    expect(registeredEvents).toContain('uncaughtException');
+    expect(registeredEvents).toContain('unhandledRejection');
+
+    const callsAfterFirst = onSpy.mock.calls.length;
+
+    // A second call must be a no-op because handlers are already bound.
+    await errorsModule.setupMainErrorHandling();
+    expect(onSpy.mock.calls.length).toBe(callsAfterFirst);
+  });
+});
+
+describe('errors uncaughtException handler', () => {
+  it('logs the error without quitting for a non-critical error', async () => {
+    const errorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    const { handlers } = await captureHandlers();
+
+    handlers.uncaughtException(new Error('something minor'));
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Uncaught Exception:',
+      expect.any(Error)
+    );
+    expect(appQuitMock).not.toHaveBeenCalled();
+  });
+
+  it('quits the app when a critical pattern is in the message', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { handlers } = await captureHandlers();
+
+    handlers.uncaughtException(new Error('FATAL crash in render'));
+
+    expect(appQuitMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('quits the app when a critical pattern is in the stack', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { handlers } = await captureHandlers();
+
+    const error = new Error('innocuous message');
+    error.stack = 'Error: innocuous message\n  at Electron internal error';
+
+    handlers.uncaughtException(error);
+
+    expect(appQuitMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('notifies Bugsnag when it is started', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { handlers } = await captureHandlers();
+    bugsnagIsStartedMock.mockReturnValue(true);
+
+    const error = new Error('reportable error');
+    handlers.uncaughtException(error);
+
+    expect(bugsnagNotifyMock).toHaveBeenCalledWith(error);
+  });
+});
+
+describe('errors unhandledRejection handler', () => {
+  it('wraps a non-Error reason into an Error and does not quit', async () => {
+    const errorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    const { handlers } = await captureHandlers();
+
+    handlers.unhandledRejection('a plain string reason');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Unhandled Promise Rejection:',
+      expect.any(Error)
+    );
+    const loggedError = errorSpy.mock.calls.find(
+      (call) => call[0] === 'Unhandled Promise Rejection:'
+    )?.[1] as Error;
+    expect(loggedError.message).toContain('a plain string reason');
+    expect(appQuitMock).not.toHaveBeenCalled();
+  });
+
+  it('quits the app when an Error reason matches a critical pattern', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { handlers } = await captureHandlers();
+
+    handlers.unhandledRejection(new Error('Cannot access native module foo'));
+
+    expect(appQuitMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('notifies Bugsnag for a rejection when it is started', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { handlers } = await captureHandlers();
+    bugsnagIsStartedMock.mockReturnValue(true);
+
+    handlers.unhandledRejection(new Error('reportable rejection'));
+
+    expect(bugsnagNotifyMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('errors/setCriticalErrorMatcher', () => {
+  it('uses a custom matcher that classifies an error as critical', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { errorsModule, handlers } = await captureHandlers();
+
+    const restore = errorsModule.setCriticalErrorMatcher(
+      (error) => error.message === 'custom-critical'
+    );
+
+    handlers.uncaughtException(new Error('custom-critical'));
+    expect(appQuitMock).toHaveBeenCalledTimes(1);
+
+    restore();
+  });
+
+  it('uses a custom matcher that classifies an error as non-critical', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { errorsModule, handlers } = await captureHandlers();
+
+    // Without the custom matcher this message would match the default FATAL
+    // pattern; the custom matcher overrides that and returns false.
+    const restore = errorsModule.setCriticalErrorMatcher(() => false);
+
+    handlers.uncaughtException(new Error('FATAL but overridden'));
+    expect(appQuitMock).not.toHaveBeenCalled();
+
+    restore();
+  });
+
+  it('restores the previous matcher when the cleanup function is called', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { errorsModule, handlers } = await captureHandlers();
+
+    const restore = errorsModule.setCriticalErrorMatcher(() => false);
+    restore();
+
+    // After restore, the default FATAL pattern matching applies again.
+    handlers.uncaughtException(new Error('FATAL crash'));
+    expect(appQuitMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls through to the default matcher when the custom matcher throws', async () => {
+    const errorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    const { errorsModule, handlers } = await captureHandlers();
+
+    const restore = errorsModule.setCriticalErrorMatcher(() => {
+      throw new Error('matcher exploded');
+    });
+
+    handlers.uncaughtException(new Error('FATAL crash'));
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Critical error matcher failed:',
+      expect.any(Error)
+    );
+    // Default behavior still applies after the matcher throws.
+    expect(appQuitMock).toHaveBeenCalledTimes(1);
+
+    restore();
+  });
+
+  it('resets to the default matcher when passed null', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { errorsModule, handlers } = await captureHandlers();
+
+    const restore = errorsModule.setCriticalErrorMatcher(() => false);
+    errorsModule.setCriticalErrorMatcher(null);
+
+    handlers.uncaughtException(new Error('FATAL crash'));
+    expect(appQuitMock).toHaveBeenCalledTimes(1);
+
+    restore();
+  });
+});
+
+describe('errors/setupRendererErrorHandling', () => {
+  it('returns without error when BUGSNAG_API_KEY is not set', async () => {
+    const errorsModule = await loadErrorsModule();
+    const original = process.env.BUGSNAG_API_KEY;
+    delete process.env.BUGSNAG_API_KEY;
+
+    await expect(
+      errorsModule.setupRendererErrorHandling('main')
+    ).resolves.toBeUndefined();
+
+    if (original !== undefined) {
+      process.env.BUGSNAG_API_KEY = original;
+    }
+  });
+
+  it('registers a settings listener when reporting is enabled', async () => {
+    jest.resetModules();
+    const original = process.env.BUGSNAG_API_KEY;
+    process.env.BUGSNAG_API_KEY = '12345678901234567890123456789012';
+
+    appQuitMock = jest.fn();
+    const listenMock = jest.fn(() => () => undefined);
+    const startSessionMock = jest.fn();
+
+    jest.doMock('electron', () => ({
+      app: { quit: appQuitMock, getVersion: jest.fn(() => TEST_APP_VERSION) },
+    }));
+    jest.doMock('../../store', () => ({
+      select: jest.fn(() => ({
+        appVersion: TEST_APP_VERSION,
+        isReportEnabled: true,
+      })),
+      listen: listenMock,
+    }));
+    jest.doMock('@bugsnag/js', () => ({
+      __esModule: true,
+      default: {
+        isStarted: jest.fn(() => false),
+        notify: jest.fn(),
+        start: jest.fn(() => ({
+          startSession: startSessionMock,
+          pauseSession: jest.fn(),
+        })),
+      },
+    }));
+
+    const errorsModule: ErrorsModule = await import('../../errors');
+    await errorsModule.setupRendererErrorHandling('rootWindow');
+
+    expect(listenMock).toHaveBeenCalledWith(
+      SETTINGS_SET_REPORT_OPT_IN_CHANGED,
+      expect.any(Function)
+    );
+
+    if (original !== undefined) {
+      process.env.BUGSNAG_API_KEY = original;
+    } else {
+      delete process.env.BUGSNAG_API_KEY;
+    }
+  });
+});

--- a/src/i18n/__tests__/common.spec.ts
+++ b/src/i18n/__tests__/common.spec.ts
@@ -1,0 +1,157 @@
+import { fallbackLng, interpolation } from '../common';
+
+// The byte/speed/percentage/duration formatters are not exported directly;
+// they are reachable through interpolation.format(value, format, lng).
+// Output of Intl formatters is locale-dependent, so assertions target stable
+// structural markers (units, signs, magnitude) using the 'en' locale.
+const format = (value: unknown, fmt?: string) =>
+  interpolation!.format!(value, fmt, 'en');
+
+describe('fallbackLng', () => {
+  it('is "en"', () => {
+    expect(fallbackLng).toBe('en');
+  });
+});
+
+describe('interpolation', () => {
+  it('disables HTML escaping', () => {
+    expect(interpolation!.escapeValue).toBe(false);
+  });
+
+  describe('Date values', () => {
+    it('formats a valid Date regardless of the requested format', () => {
+      const date = new Date(2023, 0, 15);
+      const out = format(date, 'byteSize');
+      expect(typeof out).toBe('string');
+      expect(out).toMatch(/2023/);
+    });
+
+    it('falls through to String() for an invalid Date', () => {
+      const invalid = new Date('not-a-date');
+      const out = format(invalid, 'byteSize');
+      // Invalid Date is not handled by the Date branch; passes to formatBytes
+      // (NaN bytes) which yields the '???' sentinel.
+      expect(out).toBe('???');
+    });
+  });
+
+  describe('byteSize', () => {
+    it.each<[number, RegExp]>([
+      // Intl compact/narrow form emits "byte" for the base unit, "kB"/"MB"/... above.
+      [512, /byte|B/i],
+      [1024, /kB/i],
+      [1536, /kB/i],
+      [1024 * 1024, /MB/i],
+      [1024 * 1024 * 1024, /GB/i],
+      [1024 ** 4, /TB/i],
+      [1024 ** 5, /PB/i],
+    ])('formats %d bytes with a unit matching %s', (bytes, unitRe) => {
+      const out = format(bytes, 'byteSize');
+      expect(typeof out).toBe('string');
+      expect(out).toMatch(unitRe);
+    });
+
+    it('clamps orders beyond the largest unit to petabytes', () => {
+      const huge = 1024 ** 8;
+      expect(format(huge, 'byteSize')).toMatch(/PB/i);
+    });
+
+    it('returns the ??? sentinel for 0 bytes (log(0) yields no valid unit)', () => {
+      // Math.log(0) === -Infinity → order === -Infinity → byteUnits[order] undefined
+      expect(format(0, 'byteSize')).toBe('???');
+    });
+
+    it('returns the ??? sentinel for non-finite input', () => {
+      expect(format(NaN, 'byteSize')).toBe('???');
+    });
+  });
+
+  describe('byteSpeed', () => {
+    it.each<[number, RegExp]>([
+      [512, /byte|B/i],
+      [1024, /kB/i],
+      [1024 * 1024, /MB/i],
+      [1024 * 1024 * 1024, /GB/i],
+    ])('formats %d B/s including a per-second unit', (bps, unitRe) => {
+      const out = format(bps, 'byteSpeed');
+      expect(out).toMatch(unitRe);
+      expect(out).toMatch(/\/s|per second/i);
+    });
+
+    it('returns the ??? sentinel for non-finite input', () => {
+      expect(format(NaN, 'byteSpeed')).toBe('???');
+    });
+  });
+
+  describe('percentage', () => {
+    it.each<[number, RegExp]>([
+      [0, /0\s*%/],
+      [0.5, /50\s*%/],
+      [1, /100\s*%/],
+    ])('formats ratio %d as %s', (ratio, expectedRe) => {
+      expect(format(ratio, 'percentage')).toMatch(expectedRe);
+    });
+
+    it('rounds to whole percent (no fraction digits)', () => {
+      const out = format(0.123, 'percentage');
+      expect(out).toMatch(/12\s*%/);
+      expect(out).not.toMatch(/\./);
+    });
+  });
+
+  // formatDuration uses RelativeTimeFormat narrow style with fixed cumulative
+  // divisors (s→/60, min→/60, h→/24, day→/7, week→/30, month→/12). Narrow 'en'
+  // output uses single-letter units (5s, 5m, 5h, 3d, 2w) and 'mo'/'yr'.
+  const DAY = 24 * 60 * 60 * 1000;
+  describe('duration', () => {
+    it('formats sub-minute durations in seconds', () => {
+      const out = format(5000, 'duration'); // 5 s
+      expect(out).toMatch(/\b5s\b|sec/i);
+    });
+
+    it('formats minute-scale durations in minutes', () => {
+      const out = format(5 * 60 * 1000, 'duration'); // 5 min
+      expect(out).toMatch(/\b5m\b|min/i);
+    });
+
+    it('formats hour-scale durations in hours', () => {
+      const out = format(5 * 60 * 60 * 1000, 'duration'); // 5 h
+      expect(out).toMatch(/\b5h\b|hr|hour/i);
+    });
+
+    it('formats day-scale durations in days', () => {
+      const out = format(3 * DAY, 'duration'); // 3 days
+      expect(out).toMatch(/\b3d\b|day/i);
+    });
+
+    it('formats week-scale durations in weeks', () => {
+      const out = format(2 * 7 * DAY, 'duration'); // 2 weeks
+      expect(out).toMatch(/\b2w\b|wk|week/i);
+    });
+
+    it('formats month-scale durations in months', () => {
+      // 300 days: 300/7 ≈ 42.86 weeks, /30 ≈ 1.43 → month bucket
+      const out = format(300 * DAY, 'duration');
+      expect(out).toMatch(/mo|mth|month/i);
+    });
+
+    it('formats year-scale durations in years', () => {
+      // 5000 days falls through all buckets into the year branch
+      const out = format(5000 * DAY, 'duration');
+      expect(out).toMatch(/\b[\d.]+y\b|yr|year/i);
+    });
+
+    it('formats a zero duration as seconds', () => {
+      const out = format(0, 'duration');
+      expect(out).toMatch(/\b0s\b|sec/i);
+    });
+  });
+
+  describe('default branch', () => {
+    it('stringifies values with no matching format', () => {
+      expect(format(42)).toBe('42');
+      expect(format('hello', 'unknownFormat')).toBe('hello');
+      expect(format(true, 'byteSizeX')).toBe('true');
+    });
+  });
+});

--- a/src/logging/__tests__/dedup.spec.ts
+++ b/src/logging/__tests__/dedup.spec.ts
@@ -1,0 +1,148 @@
+import { LogDeduplicator } from '../dedup';
+
+describe('LogDeduplicator', () => {
+  describe('shouldLog', () => {
+    it('logs the first occurrence', () => {
+      const d = new LogDeduplicator();
+      expect(d.shouldLog('info', '[ctx]', ['hello'])).toBe(true);
+    });
+
+    it('suppresses an identical consecutive message', () => {
+      const d = new LogDeduplicator();
+      d.shouldLog('info', '[ctx]', ['hello']);
+      expect(d.shouldLog('info', '[ctx]', ['hello'])).toBe(false);
+    });
+
+    it('treats messages differing only by a 4+ digit number as duplicates', () => {
+      const d = new LogDeduplicator();
+      expect(d.shouldLog('info', '[ctx]', ['msg 12345'])).toBe(true);
+      expect(d.shouldLog('info', '[ctx]', ['msg 67890'])).toBe(false);
+    });
+
+    it('treats messages differing only by a decimal as duplicates', () => {
+      const d = new LogDeduplicator();
+      expect(d.shouldLog('info', '[c]', ['x 1.5'])).toBe(true);
+      expect(d.shouldLog('info', '[c]', ['x 9.9'])).toBe(false);
+    });
+
+    it('logs messages that differ by content', () => {
+      const d = new LogDeduplicator();
+      expect(d.shouldLog('info', '[c]', ['alpha'])).toBe(true);
+      expect(d.shouldLog('info', '[c]', ['beta'])).toBe(true);
+    });
+
+    it('keys include the level — same text at different levels both log', () => {
+      const d = new LogDeduplicator();
+      expect(d.shouldLog('info', '[c]', ['same'])).toBe(true);
+      expect(d.shouldLog('warn', '[c]', ['same'])).toBe(true);
+    });
+
+    it('always returns true for error level, even repeated', () => {
+      const d = new LogDeduplicator();
+      expect(d.shouldLog('error', '[c]', ['boom'])).toBe(true);
+      expect(d.shouldLog('error', '[c]', ['boom'])).toBe(true);
+    });
+
+    it('an error resets the last key so the prior message logs again', () => {
+      const d = new LogDeduplicator();
+      d.shouldLog('info', '[c]', ['a']);
+      expect(d.shouldLog('info', '[c]', ['a'])).toBe(false);
+      d.shouldLog('error', '[c]', ['e']);
+      expect(d.shouldLog('info', '[c]', ['a'])).toBe(true);
+    });
+
+    it('serializes object args via JSON.stringify for the key', () => {
+      const d = new LogDeduplicator();
+      expect(d.shouldLog('info', '[c]', [{ x: 1 }])).toBe(true);
+      expect(d.shouldLog('info', '[c]', [{ x: 1 }])).toBe(false);
+    });
+
+    it('falls back to String() for circular args without throwing', () => {
+      const d = new LogDeduplicator();
+      const circular: any = {};
+      circular.self = circular;
+      expect(d.shouldLog('info', '[c]', [circular])).toBe(true);
+      expect(d.shouldLog('info', '[c]', [circular])).toBe(false);
+    });
+
+    it('different contextStr produces different keys', () => {
+      const d = new LogDeduplicator();
+      expect(d.shouldLog('info', '[a]', ['msg'])).toBe(true);
+      expect(d.shouldLog('info', '[b]', ['msg'])).toBe(true);
+    });
+  });
+
+  describe('createFileHook', () => {
+    it('passes non-file transports through unchanged', () => {
+      const hook = new LogDeduplicator().createFileHook();
+      const msg = { level: 'info', data: ['x'] };
+      expect(hook(msg, {}, 'console')).toBe(msg);
+    });
+
+    it('passes falsy messages through unchanged', () => {
+      const hook = new LogDeduplicator().createFileHook();
+      expect(hook(null, {}, 'file')).toBeNull();
+    });
+
+    it('returns the first file message and suppresses the duplicate', () => {
+      const hook = new LogDeduplicator().createFileHook();
+      const first = hook({ level: 'info', data: ['dup'] }, {}, 'file');
+      expect(first).toEqual({ level: 'info', data: ['dup'] });
+      expect(hook({ level: 'info', data: ['dup'] }, {}, 'file')).toBeNull();
+    });
+
+    it('never suppresses error messages and resets the key', () => {
+      const hook = new LogDeduplicator().createFileHook();
+      hook({ level: 'info', data: ['dup'] }, {}, 'file');
+      const err = hook({ level: 'error', data: ['e'] }, {}, 'file');
+      expect(err).toEqual({ level: 'error', data: ['e'] });
+      // After the error reset, the previously-suppressed message logs again.
+      expect(hook({ level: 'info', data: ['dup'] }, {}, 'file')).toEqual({
+        level: 'info',
+        data: ['dup'],
+      });
+    });
+
+    it('normalizes 4+ digit numbers so they dedup', () => {
+      const hook = new LogDeduplicator().createFileHook();
+      expect(
+        hook({ level: 'info', data: ['n 12345'] }, {}, 'file')
+      ).not.toBeNull();
+      expect(hook({ level: 'info', data: ['n 67890'] }, {}, 'file')).toBeNull();
+    });
+
+    it('handles messages with no data array', () => {
+      const hook = new LogDeduplicator().createFileHook();
+      const msg = { level: 'info' };
+      expect(hook(msg, {}, 'file')).toBe(msg);
+    });
+
+    it('serializes object data items via JSON.stringify', () => {
+      const hook = new LogDeduplicator().createFileHook();
+      expect(
+        hook({ level: 'info', data: [{ a: 1 }] }, {}, 'file')
+      ).not.toBeNull();
+      expect(hook({ level: 'info', data: [{ a: 1 }] }, {}, 'file')).toBeNull();
+    });
+
+    it('falls back to String() for circular data items', () => {
+      const hook = new LogDeduplicator().createFileHook();
+      const circular: any = {};
+      circular.self = circular;
+      expect(
+        hook({ level: 'info', data: [circular] }, {}, 'file')
+      ).not.toBeNull();
+      expect(hook({ level: 'info', data: [circular] }, {}, 'file')).toBeNull();
+    });
+
+    it('tracks IPC and file keys independently', () => {
+      const d = new LogDeduplicator();
+      const hook = d.createFileHook();
+      // shouldLog sets lastIpcKey only; file hook unaffected.
+      d.shouldLog('info', '[c]', ['shared']);
+      expect(
+        hook({ level: 'info', data: ['shared'] }, {}, 'file')
+      ).not.toBeNull();
+    });
+  });
+});

--- a/src/logging/__tests__/privacy.spec.ts
+++ b/src/logging/__tests__/privacy.spec.ts
@@ -1,0 +1,257 @@
+import { createPrivacyHook, redactSensitiveData } from '../privacy';
+
+describe('redactSensitiveData', () => {
+  describe('key-value credential patterns', () => {
+    it.each([
+      ['password: hunter2longpass', 'password: [REDACTED]'],
+      // The value-portion regex stops at the closing quote, leaving it behind.
+      ['password="supersecretvalue"', 'password: [REDACTED]"'],
+      ['passwd: anotherlongpass', 'passwd: [REDACTED]'],
+      ['secret: supersecretvalue', 'secret: [REDACTED]'],
+      ['api_key: abcd1234efgh5678', 'api_key: [REDACTED]'],
+      ['apikey: abcd1234efgh5678', 'api_key: [REDACTED]'],
+      ['api-key: abcd1234efgh5678', 'api_key: [REDACTED]'],
+      ['auth_token: abcd1234efgh5678', 'auth_token: [REDACTED]'],
+      ['access_token: abcd1234efgh5678', 'access_token: [REDACTED]'],
+      ['refresh_token: abcd1234efgh5678', 'refresh_token: [REDACTED]'],
+      // The generic auth[_-]?token pattern matches first, leaving the "x-" prefix
+      // and rewriting the dash to an underscore in the emitted label.
+      ['x-auth-token: abcd1234efgh5678', 'x-auth_token: [REDACTED]'],
+      ['authorization: Bearer abcd1234efgh5678', 'authorization: [REDACTED]'],
+      // The "secret" KV pattern (label "secret") matches the value first and
+      // emits "[REDACTED]"; the broader "client_secret" pass then re-runs over
+      // the residual text, appending a trailing "]" from the placeholder.
+      ['client_secret: abcd1234efgh5678', 'client_secret: [REDACTED]]'],
+      ['private_key: abcd1234efgh5678', 'private_key: [REDACTED]'],
+      ['webhook_url: https://hooks.example', 'webhook_url: [REDACTED]'],
+    ])('redacts %s', (input, expected) => {
+      expect(redactSensitiveData(input)).toBe(expected);
+    });
+
+    it.each([
+      // Values shorter than 8 chars must NOT match (avoids "secret: no").
+      ['secret: no', 'secret: no'],
+      ['password: short', 'password: short'],
+      ['token expired', 'token expired'],
+    ])('leaves short credential value %s untouched', (input, expected) => {
+      expect(redactSensitiveData(input)).toBe(expected);
+    });
+
+    it('is case-insensitive for credential keys', () => {
+      expect(redactSensitiveData('PASSWORD: hunter2longpass')).toBe(
+        'password: [REDACTED]'
+      );
+    });
+  });
+
+  describe('standalone token patterns', () => {
+    it('partially masks Bearer tokens', () => {
+      expect(
+        redactSensitiveData('Bearer abcdefghijklmnopqrstuvwxyz123456')
+      ).toBe('Bearer abcd...3456');
+    });
+
+    it('does not mask short Bearer tokens (under 20 chars)', () => {
+      expect(redactSensitiveData('Bearer shorttoken')).toBe(
+        'Bearer shorttoken'
+      );
+    });
+
+    it('masks JWT tokens keeping 6 chars on each side', () => {
+      const jwt =
+        'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+      expect(redactSensitiveData(`token ${jwt}`)).toBe('token eyJhbG...Qssw5c');
+    });
+
+    it('redacts credentials embedded in URLs', () => {
+      expect(redactSensitiveData('https://user:pass@example.com/path')).toBe(
+        'https://[REDACTED]:[REDACTED]@example.com/path'
+      );
+    });
+
+    it('masks long hex strings (32+ chars)', () => {
+      expect(redactSensitiveData('hash 0123456789abcdef0123456789abcdef')).toBe(
+        'hash 012345...abcdef'
+      );
+    });
+
+    it('leaves short hex strings untouched', () => {
+      expect(redactSensitiveData('hex deadbeef')).toBe('hex deadbeef');
+    });
+  });
+
+  describe('PII — emails', () => {
+    it.each([
+      ['email john.doe@example.com here', 'email j***@example.com here'],
+      ['contact ab@test.io', 'contact a***@test.io'],
+    ])('masks local part of %s', (input, expected) => {
+      expect(redactSensitiveData(input)).toBe(expected);
+    });
+
+    it.each([
+      ['scope @rocket/chat ok', 'scope @rocket/chat ok'],
+      // The pattern itself requires a TLD so npm scopes do not match;
+      // these assert no accidental redaction of non-email tokens.
+      ['file index@2.0.ts', 'file index@2.0.ts'],
+    ])('does not mask non-email token %s', (input, expected) => {
+      expect(redactSensitiveData(input)).toBe(expected);
+    });
+  });
+
+  describe('PII — credit cards (Luhn-gated)', () => {
+    it.each([
+      ['card 4111 1111 1111 1111 ok', 'card ****1111 ok'],
+      ['card 4111111111111111 ok', 'card ****1111 ok'],
+      ['mc 5500005555555559 ok', 'mc ****5559 ok'],
+    ])('redacts valid Luhn card %s', (input, expected) => {
+      expect(redactSensitiveData(input)).toBe(expected);
+    });
+
+    it.each([
+      // Fails Luhn — must not be redacted.
+      ['card 4111111111111112 invalid', 'card 4111111111111112 invalid'],
+    ])('leaves invalid-Luhn card %s untouched', (input, expected) => {
+      expect(redactSensitiveData(input)).toBe(expected);
+    });
+  });
+
+  describe('PII — IPv4 addresses', () => {
+    it.each([
+      ['ip 8.8.8.8 here', 'ip 8.8.*.* here'],
+      ['ip 1.2.3.4 here', 'ip 1.2.*.* here'],
+    ])('masks last two octets of public IP %s', (input, expected) => {
+      expect(redactSensitiveData(input)).toBe(expected);
+    });
+
+    it.each([
+      ['ip 127.0.0.1 local', 'ip 127.0.0.1 local'],
+      ['ip 0.0.0.0 any', 'ip 0.0.0.0 any'],
+      ['ip 192.168.1.1 private', 'ip 192.168.1.1 private'],
+      ['ip 10.0.0.5 private', 'ip 10.0.0.5 private'],
+      ['ip 172.16.0.1 private', 'ip 172.16.0.1 private'],
+      ['ip 172.31.255.1 private', 'ip 172.31.255.1 private'],
+    ])('does not mask reserved/private IP %s', (input, expected) => {
+      expect(redactSensitiveData(input)).toBe(expected);
+    });
+
+    it('still masks public IPs outside the private 172 range', () => {
+      expect(redactSensitiveData('ip 172.32.0.1 here')).toBe(
+        'ip 172.32.*.* here'
+      );
+    });
+  });
+
+  it('returns plain text unchanged when nothing matches', () => {
+    expect(redactSensitiveData('nothing sensitive here')).toBe(
+      'nothing sensitive here'
+    );
+  });
+
+  it('is idempotent across repeated calls (lastIndex reset)', () => {
+    const input = 'password: hunter2longpass';
+    expect(redactSensitiveData(input)).toBe('password: [REDACTED]');
+    expect(redactSensitiveData(input)).toBe('password: [REDACTED]');
+  });
+});
+
+describe('createPrivacyHook', () => {
+  const hook = createPrivacyHook();
+
+  it('redacts string data entries', () => {
+    const result = hook(
+      { data: ['password: hunter2longpass'], level: 'info', date: 0 },
+      {},
+      'file'
+    );
+    expect(result.data).toEqual(['password: [REDACTED]']);
+  });
+
+  it('wraps non-array message.data into an array', () => {
+    const result = hook({ data: 'secret: longsecretvalue' }, {});
+    expect(result.data).toEqual(['secret: [REDACTED]']);
+  });
+
+  it('partially masks sensitive object keys (long values)', () => {
+    const result = hook(
+      { data: [{ token: 'abcdefghijklmnop', user: 'bob' }] },
+      {}
+    );
+    expect(result.data[0]).toEqual({ token: 'abcd...mnop', user: 'bob' });
+  });
+
+  it('fully redacts short sensitive values', () => {
+    const result = hook({ data: [{ password: 'short' }] }, {});
+    expect(result.data[0]).toEqual({ password: '[REDACTED]' });
+  });
+
+  it('does not redact allowlisted safe keys', () => {
+    const result = hook({ data: [{ token_type: 'Bearer' }] }, {});
+    expect(result.data[0]).toEqual({ token_type: 'Bearer' });
+  });
+
+  it('redacts a top-level Redux state dump', () => {
+    const result = hook(
+      { data: [{ appPath: 'x', appVersion: '1', servers: [], other: 1 }] },
+      {}
+    );
+    expect(result.data).toEqual(['[Redux State Redacted]']);
+  });
+
+  it('redacts a nested state property while keeping siblings', () => {
+    const result = hook(
+      {
+        data: [
+          { type: 'X', state: { appPath: 'x', appVersion: '1', servers: [] } },
+        ],
+      },
+      {}
+    );
+    expect(result.data[0]).toEqual({
+      type: 'X',
+      state: '[Redux State Redacted]',
+    });
+  });
+
+  it('preserves and redacts Error message/stack/name', () => {
+    const err = new Error('password: hunter2longpass failed');
+    const result = hook({ data: [err] }, {});
+    expect(result.data[0].name).toBe('Error');
+    expect(result.data[0].message).toBe('password: [REDACTED] failed');
+    expect(typeof result.data[0].stack).toBe('string');
+  });
+
+  it('handles circular references without throwing', () => {
+    const circular: any = { a: 1 };
+    circular.self = circular;
+    const result = hook({ data: [circular] }, {});
+    expect(result.data[0]).toEqual({ a: 1, self: '[Circular]' });
+  });
+
+  it('truncates objects nested beyond the depth limit', () => {
+    let deep: any = 'leaf';
+    for (let i = 0; i < 12; i++) deep = { next: deep };
+    const result = hook({ data: [deep] }, {});
+    const serialized = JSON.stringify(result);
+    expect(serialized).toContain('[Nested Object Redacted]');
+  });
+
+  it('passes through primitive (non-string, non-object) data', () => {
+    const result = hook({ data: [42, null, true] }, {});
+    expect(result.data).toEqual([42, null, true]);
+  });
+
+  it('falls back to a placeholder when redaction throws', () => {
+    const evil: any = { level: 'warn', date: new Date(0) };
+    Object.defineProperty(evil, 'data', {
+      get() {
+        throw new Error('boom');
+      },
+    });
+    const result = hook(evil, {});
+    expect(result).toEqual({
+      level: 'warn',
+      date: evil.date,
+      data: ['[Privacy redaction failed]'],
+    });
+  });
+});

--- a/src/logging/main/context.main.spec.ts
+++ b/src/logging/main/context.main.spec.ts
@@ -1,0 +1,294 @@
+import {
+  cleanupServerContext,
+  formatLogContext,
+  getComponentContext,
+  getHost,
+  getLogContext,
+  getProcessContext,
+  getServerContext,
+  registerWebContentsServer,
+  type ILogContext,
+} from '../context';
+
+type StubWebContents = {
+  id: number;
+  getType: () => string;
+};
+
+const makeWebContents = (id: number, type = 'window'): StubWebContents => ({
+  id,
+  getType: () => type,
+});
+
+describe('logging/context', () => {
+  describe('getProcessContext', () => {
+    const originalType = process.type;
+
+    afterEach(() => {
+      Object.defineProperty(process, 'type', {
+        value: originalType,
+        configurable: true,
+      });
+      // Clean up any window stub left on globalThis.
+      delete (globalThis as any).window;
+    });
+
+    const setProcessType = (value: string | undefined) => {
+      Object.defineProperty(process, 'type', {
+        value,
+        configurable: true,
+      });
+    };
+
+    it('returns "main" when running in the browser process', () => {
+      setProcessType('browser');
+      expect(getProcessContext()).toBe('main');
+    });
+
+    it('returns "preload" for any non browser/renderer process type', () => {
+      setProcessType('worker');
+      expect(getProcessContext()).toBe('preload');
+    });
+
+    it('returns "renderer:unknown" for renderer without a window', () => {
+      setProcessType('renderer');
+      delete (globalThis as any).window;
+      expect(getProcessContext()).toBe('renderer:unknown');
+    });
+
+    it('returns "renderer:root" when the window points at /index.html', () => {
+      setProcessType('renderer');
+      (globalThis as any).window = {
+        location: { pathname: '/index.html' },
+      };
+      expect(getProcessContext()).toBe('renderer:root');
+    });
+
+    it('returns "renderer:root" when the window points at /', () => {
+      setProcessType('renderer');
+      (globalThis as any).window = { location: { pathname: '/' } };
+      expect(getProcessContext()).toBe('renderer:root');
+    });
+
+    it('returns "renderer:videocall" for the video call window path', () => {
+      setProcessType('renderer');
+      (globalThis as any).window = {
+        location: { pathname: '/video-call-window.html' },
+      };
+      expect(getProcessContext()).toBe('renderer:videocall');
+    });
+
+    it('returns "renderer:webview" for any other renderer path', () => {
+      setProcessType('renderer');
+      (globalThis as any).window = {
+        location: { pathname: '/some-other.html' },
+      };
+      expect(getProcessContext()).toBe('renderer:webview');
+    });
+
+    it('falls back to "renderer:webview" when window has no location', () => {
+      setProcessType('renderer');
+      (globalThis as any).window = {};
+      expect(getProcessContext()).toBe('renderer:webview');
+    });
+  });
+
+  describe('getHost', () => {
+    it('extracts the host from a valid URL', () => {
+      expect(getHost('https://chat.example.com/path')).toBe('chat.example.com');
+    });
+
+    it('includes the port when it is non-default', () => {
+      expect(getHost('http://localhost:3000/foo')).toBe('localhost:3000');
+    });
+
+    it('returns the original string when the URL is invalid', () => {
+      expect(getHost('not a url')).toBe('not a url');
+    });
+  });
+
+  describe('registerWebContentsServer / getServerContext', () => {
+    afterEach(() => {
+      // Reset registry state between tests.
+      cleanupServerContext(1);
+      cleanupServerContext(2);
+      cleanupServerContext(3);
+    });
+
+    it('returns "local" when no webContents is provided', () => {
+      expect(getServerContext(undefined)).toBe('local');
+    });
+
+    it('returns the registered host for a known webContents', () => {
+      registerWebContentsServer(1, 'https://chat.example.com/foo');
+      expect(getServerContext(makeWebContents(1) as any)).toBe(
+        'chat.example.com'
+      );
+    });
+
+    it('returns "local" for an unregistered window type webContents', () => {
+      expect(getServerContext(makeWebContents(2, 'window') as any)).toBe(
+        'local'
+      );
+    });
+
+    it('returns "unknown" for an unregistered non-window webContents', () => {
+      expect(getServerContext(makeWebContents(3, 'webview') as any)).toBe(
+        'unknown'
+      );
+    });
+
+    it('cleanupServerContext removes a registered association', () => {
+      registerWebContentsServer(1, 'https://chat.example.com');
+      expect(getServerContext(makeWebContents(1, 'webview') as any)).toBe(
+        'chat.example.com'
+      );
+
+      cleanupServerContext(1);
+
+      expect(getServerContext(makeWebContents(1, 'webview') as any)).toBe(
+        'unknown'
+      );
+    });
+  });
+
+  describe('getComponentContext', () => {
+    it('returns "general" when stack capture is disabled', () => {
+      expect(getComponentContext(false)).toBe('general');
+    });
+
+    it('returns "general" by default (no argument)', () => {
+      expect(getComponentContext()).toBe('general');
+    });
+
+    const classify = (stack: string): string => {
+      const spy = jest
+        .spyOn(global, 'Error')
+        .mockImplementation(() => ({ stack }) as any);
+      try {
+        return getComponentContext(true);
+      } finally {
+        spy.mockRestore();
+      }
+    };
+
+    it.each([
+      ['login flow stack', 'at Login.handle (login.ts:1)', 'auth'],
+      ['connection stack', 'at websocket.connect (network.ts:1)', 'connection'],
+      ['notification stack', 'at Notification.show (n.ts:1)', 'notifications'],
+      ['update stack', 'at Update.apply (u.ts:1)', 'updates'],
+      ['outlook stack', 'at getOutlookEvents (o.ts:1)', 'outlook'],
+      ['server stack', 'at Server.add (servers.ts:1)', 'servers'],
+      ['video stack', 'at jitsi.join (video.ts:1)', 'videocall'],
+      ['preload stack', 'at preload.run (x.ts:1)', 'preload'],
+      ['ipc stack', 'at IPC.dispatch (x.ts:1)', 'ipc'],
+      ['storage stack', 'at store.set (storage.ts:1)', 'storage'],
+      ['ui stack', 'at component.render (ui.ts:1)', 'ui'],
+      ['app stack', 'at main.boot (app.ts:1)', 'app'],
+    ])('classifies %s as %s', (_label, stack, expected) => {
+      expect(classify(stack)).toBe(expected);
+    });
+
+    it('returns "general" for an unrecognized stack', () => {
+      expect(classify('at xyz.qux (zzz.ts:1)')).toBe('general');
+    });
+
+    it('handles a missing stack string gracefully', () => {
+      const spy = jest
+        .spyOn(global, 'Error')
+        .mockImplementation(() => ({ stack: undefined }) as any);
+      try {
+        expect(getComponentContext(true)).toBe('general');
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  });
+
+  describe('getLogContext', () => {
+    const originalType = process.type;
+
+    beforeEach(() => {
+      Object.defineProperty(process, 'type', {
+        value: 'browser',
+        configurable: true,
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(process, 'type', {
+        value: originalType,
+        configurable: true,
+      });
+      cleanupServerContext(7);
+    });
+
+    it('builds a minimal context without webContents', () => {
+      const context = getLogContext();
+      expect(context).toEqual({
+        processType: 'main',
+        component: 'general',
+      });
+    });
+
+    it('includes webContents and server info when provided', () => {
+      registerWebContentsServer(7, 'https://chat.example.com');
+      const context = getLogContext(makeWebContents(7, 'webview') as any);
+
+      expect(context.processType).toBe('main');
+      expect(context.webContentsType).toBe('webview');
+      expect(context.webContentsId).toBe(7);
+      expect(context.serverInfo).toEqual({
+        url: 'chat.example.com',
+        name: 'chat.example.com',
+      });
+      expect(context.component).toBe('general');
+    });
+
+    it('passes the captureComponentStack flag through', () => {
+      const spy = jest
+        .spyOn(global, 'Error')
+        .mockImplementation(() => ({ stack: 'at Login (login.ts)' }) as any);
+      try {
+        const context = getLogContext(undefined, true);
+        expect(context.component).toBe('auth');
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  });
+
+  describe('formatLogContext', () => {
+    it('formats with only the process type', () => {
+      const context: ILogContext = { processType: 'main' };
+      expect(formatLogContext(context)).toBe('[main]');
+    });
+
+    it('omits a "local" server name', () => {
+      const context: ILogContext = {
+        processType: 'main',
+        serverInfo: { url: 'local', name: 'local' },
+      };
+      expect(formatLogContext(context)).toBe('[main]');
+    });
+
+    it('omits a "general" component', () => {
+      const context: ILogContext = {
+        processType: 'main',
+        component: 'general',
+      };
+      expect(formatLogContext(context)).toBe('[main]');
+    });
+
+    it('includes server name and component when meaningful', () => {
+      const context: ILogContext = {
+        processType: 'renderer:webview',
+        serverInfo: { url: 'chat.example.com', name: 'chat.example.com' },
+        component: 'auth',
+      };
+      expect(formatLogContext(context)).toBe(
+        '[renderer:webview] [chat.example.com] [auth]'
+      );
+    });
+  });
+});

--- a/src/navigation/reducers/__tests__/navigation.spec.ts
+++ b/src/navigation/reducers/__tests__/navigation.spec.ts
@@ -1,0 +1,216 @@
+import type { Certificate } from 'electron';
+
+import { APP_SETTINGS_LOADED } from '../../../app/actions';
+import {
+  CERTIFICATES_CLIENT_CERTIFICATE_REQUESTED,
+  SELECT_CLIENT_CERTIFICATE_DIALOG_CERTIFICATE_SELECTED,
+  SELECT_CLIENT_CERTIFICATE_DIALOG_DISMISSED,
+  TRUSTED_CERTIFICATES_UPDATED,
+  NOT_TRUSTED_CERTIFICATES_UPDATED,
+  CERTIFICATES_CLEARED,
+  CERTIFICATES_LOADED,
+  EXTERNAL_PROTOCOL_PERMISSION_UPDATED,
+} from '../../actions';
+import {
+  clientCertificates,
+  trustedCertificates,
+  notTrustedCertificates,
+  externalProtocols,
+} from '../../reducers';
+
+const unknown = { type: 'UNKNOWN_ACTION' } as any;
+
+describe('clientCertificates reducer', () => {
+  it('should default to empty array', () => {
+    expect(clientCertificates(undefined, unknown)).toEqual([]);
+  });
+
+  it('should set certificates on CERTIFICATES_CLIENT_CERTIFICATE_REQUESTED', () => {
+    const certs = [{ fingerprint: 'a' }] as unknown as Certificate[];
+    expect(
+      clientCertificates([], {
+        type: CERTIFICATES_CLIENT_CERTIFICATE_REQUESTED,
+        payload: certs,
+      } as any)
+    ).toBe(certs);
+  });
+
+  it('should clear on SELECT_CLIENT_CERTIFICATE_DIALOG_CERTIFICATE_SELECTED', () => {
+    const certs = [{ fingerprint: 'a' }] as unknown as Certificate[];
+    expect(
+      clientCertificates(certs, {
+        type: SELECT_CLIENT_CERTIFICATE_DIALOG_CERTIFICATE_SELECTED,
+        payload: 'a',
+      } as any)
+    ).toEqual([]);
+  });
+
+  it('should clear on SELECT_CLIENT_CERTIFICATE_DIALOG_DISMISSED', () => {
+    const certs = [{ fingerprint: 'a' }] as unknown as Certificate[];
+    expect(
+      clientCertificates(certs, {
+        type: SELECT_CLIENT_CERTIFICATE_DIALOG_DISMISSED,
+      } as any)
+    ).toEqual([]);
+  });
+
+  it('should preserve state on unknown action', () => {
+    const certs = [{ fingerprint: 'a' }] as unknown as Certificate[];
+    expect(clientCertificates(certs, unknown)).toBe(certs);
+  });
+});
+
+describe('trustedCertificates reducer', () => {
+  it('should default to empty object', () => {
+    expect(trustedCertificates(undefined, unknown)).toEqual({});
+  });
+
+  it('should set payload on CERTIFICATES_LOADED', () => {
+    const payload = { 'https://a/': 'fp' };
+    expect(
+      trustedCertificates({}, { type: CERTIFICATES_LOADED, payload } as any)
+    ).toBe(payload);
+  });
+
+  it('should set payload on TRUSTED_CERTIFICATES_UPDATED', () => {
+    const payload = { 'https://a/': 'fp' };
+    expect(
+      trustedCertificates({}, {
+        type: TRUSTED_CERTIFICATES_UPDATED,
+        payload,
+      } as any)
+    ).toBe(payload);
+  });
+
+  it('should clear on CERTIFICATES_CLEARED', () => {
+    expect(
+      trustedCertificates({ 'https://a/': 'fp' }, {
+        type: CERTIFICATES_CLEARED,
+      } as any)
+    ).toEqual({});
+  });
+
+  it('should read value from APP_SETTINGS_LOADED', () => {
+    const trusted = { 'https://a/': 'fp' };
+    expect(
+      trustedCertificates({}, {
+        type: APP_SETTINGS_LOADED,
+        payload: { trustedCertificates: trusted },
+      } as any)
+    ).toBe(trusted);
+  });
+
+  it('should fall back to current state when missing in APP_SETTINGS_LOADED', () => {
+    const state = { 'https://a/': 'fp' };
+    expect(
+      trustedCertificates(state, {
+        type: APP_SETTINGS_LOADED,
+        payload: {},
+      } as any)
+    ).toBe(state);
+  });
+
+  it('should preserve state on unknown action', () => {
+    const state = { 'https://a/': 'fp' };
+    expect(trustedCertificates(state, unknown)).toBe(state);
+  });
+});
+
+describe('notTrustedCertificates reducer', () => {
+  it('should default to empty object', () => {
+    expect(notTrustedCertificates(undefined, unknown)).toEqual({});
+  });
+
+  it('should set payload on NOT_TRUSTED_CERTIFICATES_UPDATED', () => {
+    const payload = { 'https://a/': 'fp' };
+    expect(
+      notTrustedCertificates({}, {
+        type: NOT_TRUSTED_CERTIFICATES_UPDATED,
+        payload,
+      } as any)
+    ).toBe(payload);
+  });
+
+  it('should clear on CERTIFICATES_CLEARED', () => {
+    expect(
+      notTrustedCertificates({ 'https://a/': 'fp' }, {
+        type: CERTIFICATES_CLEARED,
+      } as any)
+    ).toEqual({});
+  });
+
+  it('should read value from APP_SETTINGS_LOADED', () => {
+    const notTrusted = { 'https://a/': 'fp' };
+    expect(
+      notTrustedCertificates({}, {
+        type: APP_SETTINGS_LOADED,
+        payload: { notTrustedCertificates: notTrusted },
+      } as any)
+    ).toBe(notTrusted);
+  });
+
+  it('should fall back to current state when missing in APP_SETTINGS_LOADED', () => {
+    const state = { 'https://a/': 'fp' };
+    expect(
+      notTrustedCertificates(state, {
+        type: APP_SETTINGS_LOADED,
+        payload: {},
+      } as any)
+    ).toBe(state);
+  });
+
+  it('should preserve state on unknown action', () => {
+    const state = { 'https://a/': 'fp' };
+    expect(notTrustedCertificates(state, unknown)).toBe(state);
+  });
+});
+
+describe('externalProtocols reducer', () => {
+  it('should default to empty object', () => {
+    expect(externalProtocols(undefined, unknown)).toEqual({});
+  });
+
+  it('should read value from APP_SETTINGS_LOADED', () => {
+    const protocols = { 'tel:': true };
+    expect(
+      externalProtocols({}, {
+        type: APP_SETTINGS_LOADED,
+        payload: { externalProtocols: protocols },
+      } as any)
+    ).toBe(protocols);
+  });
+
+  it('should default to empty object when missing in APP_SETTINGS_LOADED', () => {
+    expect(
+      externalProtocols({ 'tel:': true }, {
+        type: APP_SETTINGS_LOADED,
+        payload: {},
+      } as any)
+    ).toEqual({});
+  });
+
+  it('should set a protocol permission on EXTERNAL_PROTOCOL_PERMISSION_UPDATED', () => {
+    const newState = externalProtocols({ 'tel:': true }, {
+      type: EXTERNAL_PROTOCOL_PERMISSION_UPDATED,
+      payload: { protocol: 'mailto:', allowed: true },
+    } as any);
+
+    expect(newState).toEqual({ 'tel:': true, 'mailto:': true });
+  });
+
+  it('should not mutate the original state on EXTERNAL_PROTOCOL_PERMISSION_UPDATED', () => {
+    const state = { 'tel:': true };
+    const newState = externalProtocols(state, {
+      type: EXTERNAL_PROTOCOL_PERMISSION_UPDATED,
+      payload: { protocol: 'mailto:', allowed: false },
+    } as any);
+
+    expect(newState).not.toBe(state);
+    expect(state).toEqual({ 'tel:': true });
+  });
+
+  it('should preserve state on unknown action', () => {
+    const state = { 'tel:': true };
+    expect(externalProtocols(state, unknown)).toBe(state);
+  });
+});

--- a/src/outlookCalendar/__tests__/errorClassification.spec.ts
+++ b/src/outlookCalendar/__tests__/errorClassification.spec.ts
@@ -1,0 +1,265 @@
+import {
+  classifyError,
+  createClassifiedError,
+  formatErrorForLogging,
+  generateUserFriendlyMessage,
+} from '../errorClassification';
+
+describe('classifyError', () => {
+  describe('pattern matching by message string', () => {
+    it.each<[string, string]>([
+      [
+        "Cannot read properties of undefined (reading 'headers')",
+        'EWS_NTLM_AUTH_FAILED',
+      ],
+      [
+        'The remote server returned an error: (401) Unauthorized',
+        'EWS_UNAUTHORIZED',
+      ],
+      [
+        'The remote server returned an error: (404) Not Found',
+        'EWS_SERVER_NOT_FOUND',
+      ],
+      ['getaddrinfo ENOTFOUND mail.example.com', 'NETWORK_CONNECTION_FAILED'],
+      ['connect ECONNREFUSED 10.0.0.1:443', 'NETWORK_CONNECTION_FAILED'],
+      ['socket hang up due to timeout', 'NETWORK_CONNECTION_FAILED'],
+      ['SSL_ERROR_BAD_CERT_DOMAIN', 'SSL_CERTIFICATE_ERROR'],
+      ['UNABLE_TO_VERIFY_LEAF_SIGNATURE', 'SSL_CERTIFICATE_ERROR'],
+      ['CERT_HAS_EXPIRED', 'SSL_CERTIFICATE_ERROR'],
+      ['ERR_TLS_CERT_ALTNAME_INVALID', 'SSL_CERTIFICATE_ERROR'],
+      ['self-signed certificate in chain', 'SSL_CERTIFICATE_ERROR'],
+      ['certificate has expired', 'SSL_CERTIFICATE_ERROR'],
+      [
+        'Request failed with status code 401 from rocket.chat server',
+        'RC_UNAUTHORIZED',
+      ],
+      [
+        'Request failed with status code 500 from rocket.chat server',
+        'RC_SERVER_ERROR',
+      ],
+      ['calendar is not enabled on this workspace', 'RC_CALENDAR_DISABLED'],
+      ['the calendar feature is disabled', 'RC_CALENDAR_DISABLED'],
+      ['Missing required Outlook credentials', 'MISSING_CREDENTIALS'],
+      ['Failed to decrypt credentials', 'CREDENTIAL_DECRYPTION_FAILED'],
+      ['Invalid Exchange server URL configuration', 'INVALID_EXCHANGE_URL'],
+      ['NTLM authentication failed for user', 'NTLM_AUTH_FAILED'],
+    ])('classifies %j as %s', (message, expectedCode) => {
+      expect(classifyError(message).code).toBe(expectedCode);
+    });
+  });
+
+  it('matches patterns case-insensitively', () => {
+    expect(
+      classifyError('THE REMOTE SERVER RETURNED AN ERROR: (401) UNAUTHORIZED')
+        .code
+    ).toBe('EWS_UNAUTHORIZED');
+  });
+
+  it('accepts an Error instance and reads its message', () => {
+    const result = classifyError(
+      new Error('Missing required Outlook credentials')
+    );
+    expect(result.code).toBe('MISSING_CREDENTIALS');
+    expect(result.source).toBe('desktop_app');
+    expect(result.severity).toBe('medium');
+  });
+
+  it('matches against the Error stack as well as the message', () => {
+    const error = new Error('wrapper failure');
+    error.stack = 'Error: wrapper failure\n  at x getaddrinfo ENOTFOUND host\n';
+    expect(classifyError(error).code).toBe('NETWORK_CONNECTION_FAILED');
+  });
+
+  it('returns the UNKNOWN_ERROR fallback for unmatched input', () => {
+    const result = classifyError('something totally unrelated happened');
+    expect(result.code).toBe('UNKNOWN_ERROR');
+    expect(result.source).toBe('desktop_app');
+    expect(result.severity).toBe('medium');
+    expect(result.suggestedActions).toEqual(
+      expect.arrayContaining(['Try the operation again'])
+    );
+  });
+
+  it('returns the expected classification shape including suggestedActions', () => {
+    const result = classifyError(
+      'The remote server returned an error: (404) Not Found'
+    );
+    expect(result.source).toBe('exchange');
+    expect(result.severity).toBe('high');
+    expect(Array.isArray(result.suggestedActions)).toBe(true);
+    expect(result.suggestedActions!.length).toBeGreaterThan(0);
+  });
+
+  it('prefers the first matching pattern when multiple could match', () => {
+    // 401 + rocket.chat: the EWS 401 pattern appears earlier in the list
+    const result = classifyError(
+      'The remote server returned an error: (401) Unauthorized from rocket.chat'
+    );
+    expect(result.code).toBe('EWS_UNAUTHORIZED');
+  });
+});
+
+describe('createClassifiedError', () => {
+  it('wraps classification with technical message, timestamp and context', () => {
+    const error = new Error('Failed to decrypt credentials');
+    const result = createClassifiedError(error, { userId: 'abc' });
+
+    expect(result.code).toBe('CREDENTIAL_DECRYPTION_FAILED');
+    expect(result.technicalMessage).toBe('Failed to decrypt credentials');
+    expect(result.context.userId).toBe('abc');
+    expect(typeof result.timestamp).toBe('string');
+    expect(result.context.timestamp).toBe(result.timestamp);
+    expect(result.context.stack).toBe(error.stack);
+  });
+
+  it('handles a string error with undefined stack in context', () => {
+    const result = createClassifiedError(
+      'Missing required Outlook credentials'
+    );
+    expect(result.technicalMessage).toBe(
+      'Missing required Outlook credentials'
+    );
+    expect(result.context.stack).toBeUndefined();
+  });
+
+  it('defaults context to an empty object', () => {
+    const result = createClassifiedError('unmatched message');
+    expect(result.code).toBe('UNKNOWN_ERROR');
+    expect(result.context).toBeDefined();
+  });
+});
+
+describe('formatErrorForLogging', () => {
+  it('renders source, severity, code, messages and actions', () => {
+    const classified = createClassifiedError(
+      'The remote server returned an error: (401) Unauthorized',
+      { server: 'mail.example.com' }
+    );
+    const out = formatErrorForLogging(classified, 'syncEvents');
+
+    expect(out).toContain('[OutlookCalendar] syncEvents failed');
+    expect(out).toContain('EXCHANGE ERROR');
+    expect(out).toContain('Source: exchange');
+    expect(out).toContain('Severity: high');
+    expect(out).toContain('Code: EWS_UNAUTHORIZED');
+    expect(out).toContain('mail.example.com');
+    expect(out).toContain('Suggested Actions:');
+  });
+
+  it('redacts sensitive context keys', () => {
+    const classified = createClassifiedError('unmatched', {
+      password: 'hunter2',
+      token: 'abc',
+      accessToken: 'xyz',
+      cookie: 'c',
+      authorization: 'Bearer z',
+      secret: 's',
+      safeField: 'visible',
+    });
+    const out = formatErrorForLogging(classified, 'op');
+
+    expect(out).toContain('[REDACTED]');
+    expect(out).not.toContain('hunter2');
+    expect(out).not.toContain('Bearer z');
+    expect(out).toContain('visible');
+  });
+
+  it('redacts sensitive keys nested in objects and arrays', () => {
+    const classified = createClassifiedError('unmatched', {
+      nested: { password: 'p', ok: 1 },
+      list: [{ secret: 's', keep: 2 }],
+    });
+    const out = formatErrorForLogging(classified, 'op');
+    expect(out).toContain('[REDACTED]');
+    expect(out).not.toContain('"p"');
+    expect(out).not.toContain('"s"');
+    expect(out).toContain('"keep": 2');
+  });
+
+  it('handles circular references in context without throwing', () => {
+    const circular: Record<string, unknown> = { name: 'root' };
+    circular.self = circular;
+    const arr: unknown[] = [];
+    arr.push(arr);
+    circular.arr = arr;
+
+    const classified = createClassifiedError('unmatched', circular);
+    let out = '';
+    expect(() => {
+      out = formatErrorForLogging(classified, 'op');
+    }).not.toThrow();
+    expect(out).toContain('[Circular]');
+  });
+
+  it('falls back to a default suggested action when none present', () => {
+    const classified = createClassifiedError('unmatched');
+    classified.suggestedActions = undefined;
+    const out = formatErrorForLogging(classified, 'op');
+    expect(out).toContain('Contact support');
+  });
+});
+
+describe('generateUserFriendlyMessage', () => {
+  it.each<
+    [
+      (
+        | 'exchange'
+        | 'rocket_chat'
+        | 'desktop_app'
+        | 'network'
+        | 'authentication'
+        | 'configuration'
+      ),
+      string,
+    ]
+  >([
+    ['exchange', 'Exchange Server'],
+    ['rocket_chat', 'Rocket.Chat Server'],
+    ['desktop_app', 'Desktop Application'],
+    ['network', 'Network Connection'],
+    ['authentication', 'Authentication'],
+    ['configuration', 'Configuration'],
+  ])('maps source %s to label %s', (source, label) => {
+    const message = generateUserFriendlyMessage({
+      source,
+      severity: 'medium',
+      code: 'X',
+      technicalMessage: 't',
+      userMessage: 'A problem occurred.',
+      context: {},
+      timestamp: 'now',
+      suggestedActions: ['Do thing'],
+    });
+    expect(message).toContain(`${label} Error: A problem occurred.`);
+    expect(message).toContain('What you can try:');
+    expect(message).toContain('• Do thing');
+  });
+
+  it('falls back to Unknown Source for an unexpected source value', () => {
+    const message = generateUserFriendlyMessage({
+      source: 'something_else' as never,
+      severity: 'low',
+      code: 'X',
+      technicalMessage: 't',
+      userMessage: 'msg',
+      context: {},
+      timestamp: 'now',
+    });
+    expect(message).toContain('Unknown Source Error: msg');
+  });
+
+  it('omits the actions block when there are no suggested actions', () => {
+    const message = generateUserFriendlyMessage({
+      source: 'network',
+      severity: 'low',
+      code: 'X',
+      technicalMessage: 't',
+      userMessage: 'msg',
+      context: {},
+      timestamp: 'now',
+      suggestedActions: [],
+    });
+    expect(message).toBe('Network Connection Error: msg');
+    expect(message).not.toContain('What you can try:');
+  });
+});

--- a/src/screenSharing/main/desktopCapturerCache.main.spec.ts
+++ b/src/screenSharing/main/desktopCapturerCache.main.spec.ts
@@ -1,0 +1,333 @@
+import { desktopCapturer } from 'electron';
+
+import { handle } from '../../ipc/main';
+import {
+  clearDesktopCapturerCache,
+  getDesktopCapturerCacheStatus,
+  handleDesktopCapturerGetSources,
+  prewarmDesktopCapturerCache,
+  refreshDesktopCapturerCache,
+} from '../desktopCapturerCache';
+
+jest.mock('electron', () => ({
+  desktopCapturer: {
+    getSources: jest.fn(),
+  },
+}));
+
+jest.mock('../../ipc/main', () => ({
+  handle: jest.fn(),
+}));
+
+const getSourcesMock = desktopCapturer.getSources as jest.MockedFunction<
+  typeof desktopCapturer.getSources
+>;
+const handleMock = handle as jest.MockedFunction<typeof handle>;
+
+type SourceStub = {
+  id: string;
+  name: string;
+  thumbnail: { isEmpty: () => boolean };
+};
+
+const makeSource = (id: string, name: string, empty = false): SourceStub => ({
+  id,
+  name,
+  thumbnail: { isEmpty: () => empty },
+});
+
+const flushPromises = () =>
+  new Promise<void>((resolve) => setImmediate(resolve));
+
+const OPTIONS = { types: ['window', 'screen'] } as Electron.SourcesOptions;
+
+// Registers the IPC handler and returns the captured callback. Filtered
+// results are only observable through this handler (it returns the cache).
+const getHandler = () => {
+  handleDesktopCapturerGetSources();
+  const lastCall = handleMock.mock.calls[handleMock.mock.calls.length - 1];
+  expect(lastCall[0]).toBe('desktop-capturer-get-sources');
+  return lastCall[1] as (webContents: unknown, opts: unknown) => Promise<any>;
+};
+
+describe('screenSharing/desktopCapturerCache', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+    clearDesktopCapturerCache();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    clearDesktopCapturerCache();
+  });
+
+  describe('refreshDesktopCapturerCache', () => {
+    it('fetches sources and populates the cache with valid sources', async () => {
+      getSourcesMock.mockResolvedValueOnce([
+        makeSource('1', 'Screen 1') as any,
+        makeSource('2', 'Window 2') as any,
+      ]);
+
+      refreshDesktopCapturerCache(OPTIONS);
+      await flushPromises();
+
+      expect(getSourcesMock).toHaveBeenCalledWith(OPTIONS);
+      const status = getDesktopCapturerCacheStatus();
+      expect(status.cached).toBe(true);
+      expect(status.pending).toBe(false);
+    });
+
+    it('does not start a second fetch while one is pending', async () => {
+      let resolveFetch: (value: any) => void = () => undefined;
+      getSourcesMock.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        }) as any
+      );
+
+      refreshDesktopCapturerCache(OPTIONS);
+      // Second call should short-circuit because a promise is in flight.
+      refreshDesktopCapturerCache(OPTIONS);
+
+      expect(getSourcesMock).toHaveBeenCalledTimes(1);
+      expect(getDesktopCapturerCacheStatus().pending).toBe(true);
+
+      resolveFetch([makeSource('1', 'Screen 1') as any]);
+      await flushPromises();
+
+      expect(getDesktopCapturerCacheStatus().pending).toBe(false);
+    });
+
+    it('filters out sources with empty or whitespace names', async () => {
+      getSourcesMock.mockResolvedValueOnce([
+        makeSource('1', '') as any,
+        makeSource('2', '   ') as any,
+        makeSource('3', 'Valid') as any,
+      ]);
+
+      refreshDesktopCapturerCache(OPTIONS);
+      await flushPromises();
+
+      // Filtered results are observable through the cache via the handler.
+      const handler = getHandler();
+      const result = (await handler({ id: 1 }, OPTIONS)) as any[];
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('3');
+    });
+
+    it('filters out sources with an empty thumbnail', async () => {
+      getSourcesMock.mockResolvedValueOnce([
+        makeSource('1', 'Empty thumb', true) as any,
+        makeSource('2', 'Good thumb', false) as any,
+      ]);
+
+      refreshDesktopCapturerCache(OPTIONS);
+      await flushPromises();
+
+      const handler = getHandler();
+      const result = (await handler({ id: 1 }, OPTIONS)) as any[];
+
+      expect(result.map((s) => s.id)).toEqual(['2']);
+    });
+
+    it('serves a cached validation hit without re-checking the thumbnail', async () => {
+      // First refresh caches source "2" as valid.
+      getSourcesMock.mockResolvedValueOnce([
+        makeSource('2', 'Good thumb', false) as any,
+      ]);
+      refreshDesktopCapturerCache(OPTIONS);
+      await flushPromises();
+
+      // Second refresh: same id, now reports an empty thumbnail, but the
+      // validation cache should still treat it as valid (within TTL).
+      const emptyThumbSource = makeSource('2', 'Good thumb', true);
+      const isEmptySpy = jest.spyOn(emptyThumbSource.thumbnail, 'isEmpty');
+      getSourcesMock.mockResolvedValueOnce([emptyThumbSource as any]);
+
+      refreshDesktopCapturerCache(OPTIONS);
+      await flushPromises();
+
+      const handler = getHandler();
+      const result = (await handler({ id: 1 }, OPTIONS)) as any[];
+
+      expect(result.map((s) => s.id)).toEqual(['2']);
+      expect(isEmptySpy).not.toHaveBeenCalled();
+    });
+
+    it('keeps the previous cached sources when a background fetch rejects', async () => {
+      // Seed a cache first.
+      getSourcesMock.mockResolvedValueOnce([makeSource('1', 'Seeded') as any]);
+      refreshDesktopCapturerCache(OPTIONS);
+      await flushPromises();
+
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      getSourcesMock.mockRejectedValueOnce(new Error('boom'));
+
+      refreshDesktopCapturerCache(OPTIONS);
+      await flushPromises();
+
+      // Cache untouched: handler still serves the seeded source.
+      const handler = getHandler();
+      const result = (await handler({ id: 1 }, OPTIONS)) as any[];
+
+      expect(result.map((s) => s.id)).toEqual(['1']);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Background cache refresh failed:',
+        expect.any(Error)
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it('leaves the cache empty when the fetch rejects with no prior cache', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      getSourcesMock.mockRejectedValueOnce(new Error('boom'));
+
+      refreshDesktopCapturerCache(OPTIONS);
+      await flushPromises();
+
+      expect(getDesktopCapturerCacheStatus()).toEqual({
+        cached: false,
+        pending: false,
+      });
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Background cache refresh failed:',
+        expect.any(Error)
+      );
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('prewarmDesktopCapturerCache', () => {
+    it('refreshes with window and screen source types', async () => {
+      getSourcesMock.mockResolvedValueOnce([]);
+      prewarmDesktopCapturerCache();
+      await flushPromises();
+
+      expect(getSourcesMock).toHaveBeenCalledWith({
+        types: ['window', 'screen'],
+      });
+    });
+  });
+
+  describe('clearDesktopCapturerCache', () => {
+    it('resets cache and pending state', async () => {
+      getSourcesMock.mockResolvedValueOnce([
+        makeSource('1', 'Screen 1') as any,
+      ]);
+      refreshDesktopCapturerCache(OPTIONS);
+      await flushPromises();
+      expect(getDesktopCapturerCacheStatus().cached).toBe(true);
+
+      clearDesktopCapturerCache();
+
+      expect(getDesktopCapturerCacheStatus()).toEqual({
+        cached: false,
+        pending: false,
+      });
+    });
+  });
+
+  describe('getDesktopCapturerCacheStatus', () => {
+    it('reports no cache and no pending work initially', () => {
+      expect(getDesktopCapturerCacheStatus()).toEqual({
+        cached: false,
+        pending: false,
+      });
+    });
+  });
+
+  describe('handleDesktopCapturerGetSources', () => {
+    it('registers the IPC handler on the expected channel', () => {
+      getHandler();
+    });
+
+    it('returns cached sources immediately when a fresh cache exists', async () => {
+      getSourcesMock.mockResolvedValueOnce([makeSource('1', 'Cached') as any]);
+      refreshDesktopCapturerCache(OPTIONS);
+      await flushPromises();
+
+      const handler = getHandler();
+      const result = await handler({ id: 1 }, OPTIONS);
+
+      expect(result.map((s: SourceStub) => s.id)).toEqual(['1']);
+    });
+
+    it('unwraps an array-wrapped options argument', async () => {
+      const handler = getHandler();
+      getSourcesMock.mockResolvedValueOnce([makeSource('1', 'Cached') as any]);
+
+      await handler({ id: 1 }, [OPTIONS]);
+
+      expect(getSourcesMock).toHaveBeenCalledWith(OPTIONS);
+    });
+
+    it('triggers a background refresh when the cache is stale', async () => {
+      jest.useFakeTimers();
+      getSourcesMock.mockResolvedValue([makeSource('1', 'Cached') as any]);
+
+      refreshDesktopCapturerCache(OPTIONS);
+      // Allow the initial fetch to settle under fake timers.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Advance beyond the 3000ms stale threshold.
+      jest.advanceTimersByTime(3001);
+
+      const handler = getHandler();
+      const result = await handler({ id: 1 }, OPTIONS);
+
+      // Still returns the (stale) cached sources synchronously.
+      expect(result.map((s: SourceStub) => s.id)).toEqual(['1']);
+      // A background refresh was kicked off (second getSources call).
+      expect(getSourcesMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not refresh when a fresh cache is within the stale threshold', async () => {
+      jest.useFakeTimers();
+      getSourcesMock.mockResolvedValue([makeSource('1', 'Cached') as any]);
+
+      refreshDesktopCapturerCache(OPTIONS);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      jest.advanceTimersByTime(1000);
+
+      const handler = getHandler();
+      await handler({ id: 1 }, OPTIONS);
+
+      expect(getSourcesMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('awaits the in-flight promise when one is pending and no cache exists', async () => {
+      let resolveFetch: (value: any) => void = () => undefined;
+      getSourcesMock.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        }) as any
+      );
+
+      // Start a fetch so a promise is pending but cache is still null.
+      refreshDesktopCapturerCache(OPTIONS);
+
+      const handler = getHandler();
+      const handlerPromise = handler({ id: 1 }, OPTIONS);
+
+      resolveFetch([makeSource('9', 'Pending') as any]);
+      const result = await handlerPromise;
+
+      expect(result.map((s: SourceStub) => s.id)).toEqual(['9']);
+    });
+
+    it('refreshes then awaits when there is neither cache nor pending promise', async () => {
+      getSourcesMock.mockResolvedValueOnce([makeSource('5', 'Fresh') as any]);
+
+      const handler = getHandler();
+      const result = await handler({ id: 1 }, OPTIONS);
+
+      expect(getSourcesMock).toHaveBeenCalledWith(OPTIONS);
+      expect(result.map((s: SourceStub) => s.id)).toEqual(['5']);
+    });
+  });
+});

--- a/src/servers/reducers/__tests__/servers.spec.ts
+++ b/src/servers/reducers/__tests__/servers.spec.ts
@@ -1,0 +1,493 @@
+import { APP_SETTINGS_LOADED } from '../../../app/actions';
+import { DEEP_LINKS_SERVER_ADDED } from '../../../deepLinks/actions';
+import { OUTLOOK_CALENDAR_SAVE_CREDENTIALS } from '../../../outlookCalendar/actions';
+import {
+  ADD_SERVER_VIEW_SERVER_ADDED,
+  SIDE_BAR_REMOVE_SERVER_CLICKED,
+  SIDE_BAR_SERVERS_SORTED,
+  WEBVIEW_PAGE_TITLE_CHANGED,
+  WEBVIEW_DID_NAVIGATE,
+  WEBVIEW_SIDEBAR_STYLE_CHANGED,
+  WEBVIEW_SIDEBAR_CUSTOM_THEME_CHANGED,
+  WEBVIEW_TITLE_CHANGED,
+  WEBVIEW_UNREAD_CHANGED,
+  WEBVIEW_USER_LOGGED_IN,
+  WEBVIEW_FAVICON_CHANGED,
+  WEBVIEW_DID_START_LOADING,
+  WEBVIEW_DID_FAIL_LOAD,
+  WEBVIEW_READY,
+  WEBVIEW_ATTACHED,
+  WEBVIEW_GIT_COMMIT_HASH_CHANGED,
+  WEBVIEW_ALLOWED_REDIRECTS_CHANGED,
+  WEBVIEW_SERVER_SUPPORTED_VERSIONS_UPDATED,
+  WEBVIEW_SERVER_SUPPORTED_VERSIONS_LOADING,
+  WEBVIEW_SERVER_SUPPORTED_VERSIONS_ERROR,
+  WEBVIEW_SERVER_UNIQUE_ID_UPDATED,
+  WEBVIEW_SERVER_IS_SUPPORTED_VERSION,
+  WEBVIEW_SERVER_VERSION_UPDATED,
+  SUPPORTED_VERSION_DIALOG_DISMISS,
+} from '../../../ui/actions';
+import { SERVERS_LOADED, SERVER_DOCUMENT_VIEWER_OPEN_URL } from '../../actions';
+import type { Server } from '../../common';
+import { servers } from '../../reducers';
+
+const url = 'https://open.rocket.chat/';
+const existing: Server = { url, title: 'Open' };
+
+describe('servers reducer', () => {
+  it('should return initial state as empty array', () => {
+    expect(servers(undefined, { type: 'UNKNOWN_ACTION' } as any)).toEqual([]);
+  });
+
+  it('should return current state on unknown action', () => {
+    const state = [existing];
+    expect(servers(state, { type: 'UNKNOWN_ACTION' } as any)).toBe(state);
+  });
+
+  describe('ADD_SERVER_VIEW_SERVER_ADDED / DEEP_LINKS_SERVER_ADDED (upsert insert)', () => {
+    it('should add a new server with url as title', () => {
+      const newState = servers([], {
+        type: ADD_SERVER_VIEW_SERVER_ADDED,
+        payload: url,
+      } as any);
+
+      expect(newState).toEqual([{ url, title: url }]);
+    });
+
+    it('should handle DEEP_LINKS_SERVER_ADDED the same way', () => {
+      const newState = servers([], {
+        type: DEEP_LINKS_SERVER_ADDED,
+        payload: url,
+      } as any);
+
+      expect(newState).toEqual([{ url, title: url }]);
+    });
+
+    it('should merge into an existing server (upsert update path)', () => {
+      const newState = servers([existing], {
+        type: ADD_SERVER_VIEW_SERVER_ADDED,
+        payload: url,
+      } as any);
+
+      expect(newState).toEqual([{ url, title: url }]);
+      expect(newState).not.toBe([existing]);
+    });
+  });
+
+  describe('SIDE_BAR_REMOVE_SERVER_CLICKED', () => {
+    it('should remove the server with matching url', () => {
+      const other: Server = { url: 'https://other.rocket.chat/' };
+      const newState = servers([existing, other], {
+        type: SIDE_BAR_REMOVE_SERVER_CLICKED,
+        payload: url,
+      } as any);
+
+      expect(newState).toEqual([other]);
+    });
+  });
+
+  describe('SIDE_BAR_SERVERS_SORTED', () => {
+    it('should sort servers by the order of urls in payload', () => {
+      const a: Server = { url: 'https://a/' };
+      const b: Server = { url: 'https://b/' };
+      const c: Server = { url: 'https://c/' };
+
+      const newState = servers([c, a, b], {
+        type: SIDE_BAR_SERVERS_SORTED,
+        payload: ['https://a/', 'https://b/', 'https://c/'],
+      } as any);
+
+      expect(newState.map((s) => s.url)).toEqual([
+        'https://a/',
+        'https://b/',
+        'https://c/',
+      ]);
+    });
+  });
+
+  describe('WEBVIEW_TITLE_CHANGED', () => {
+    it('should upsert the title', () => {
+      const newState = servers([existing], {
+        type: WEBVIEW_TITLE_CHANGED,
+        payload: { url, title: 'New Title' },
+      } as any);
+
+      expect(newState[0].title).toBe('New Title');
+    });
+
+    it('should fall back to url when title is missing', () => {
+      const newState = servers([], {
+        type: WEBVIEW_TITLE_CHANGED,
+        payload: { url },
+      } as any);
+
+      expect(newState[0].title).toBe(url);
+    });
+  });
+
+  describe('WEBVIEW_PAGE_TITLE_CHANGED', () => {
+    it('should upsert the pageTitle', () => {
+      const newState = servers([existing], {
+        type: WEBVIEW_PAGE_TITLE_CHANGED,
+        payload: { url, pageTitle: 'Page' },
+      } as any);
+
+      expect(newState[0].pageTitle).toBe('Page');
+    });
+  });
+
+  describe('WEBVIEW_SERVER_SUPPORTED_VERSIONS_UPDATED', () => {
+    it('should set supportedVersions, source and success fetch state', () => {
+      const supportedVersions = { foo: 'bar' };
+      const newState = servers([existing], {
+        type: WEBVIEW_SERVER_SUPPORTED_VERSIONS_UPDATED,
+        payload: { url, supportedVersions, source: 'cloud' },
+      } as any);
+
+      expect(newState[0].supportedVersions).toBe(supportedVersions);
+      expect(newState[0].supportedVersionsSource).toBe('cloud');
+      expect(newState[0].supportedVersionsFetchState).toBe('success');
+    });
+  });
+
+  describe('WEBVIEW_SERVER_SUPPORTED_VERSIONS_LOADING', () => {
+    it('should set fetch state to loading', () => {
+      const newState = servers([existing], {
+        type: WEBVIEW_SERVER_SUPPORTED_VERSIONS_LOADING,
+        payload: { url },
+      } as any);
+
+      expect(newState[0].supportedVersionsFetchState).toBe('loading');
+    });
+  });
+
+  describe('WEBVIEW_SERVER_SUPPORTED_VERSIONS_ERROR', () => {
+    it('should set fetch state to error', () => {
+      const newState = servers([existing], {
+        type: WEBVIEW_SERVER_SUPPORTED_VERSIONS_ERROR,
+        payload: { url },
+      } as any);
+
+      expect(newState[0].supportedVersionsFetchState).toBe('error');
+    });
+  });
+
+  describe('SUPPORTED_VERSION_DIALOG_DISMISS', () => {
+    it('should set expirationMessageLastTimeShown to a Date', () => {
+      const newState = servers([existing], {
+        type: SUPPORTED_VERSION_DIALOG_DISMISS,
+        payload: { url },
+      } as any);
+
+      expect(newState[0].expirationMessageLastTimeShown).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('WEBVIEW_SERVER_UNIQUE_ID_UPDATED', () => {
+    it('should set uniqueID', () => {
+      const newState = servers([existing], {
+        type: WEBVIEW_SERVER_UNIQUE_ID_UPDATED,
+        payload: { url, uniqueID: 'abc' },
+      } as any);
+
+      expect(newState[0].uniqueID).toBe('abc');
+    });
+  });
+
+  describe('WEBVIEW_SERVER_IS_SUPPORTED_VERSION', () => {
+    it('should set isSupportedVersion and validatedAt', () => {
+      const newState = servers([existing], {
+        type: WEBVIEW_SERVER_IS_SUPPORTED_VERSION,
+        payload: { url, isSupportedVersion: true },
+      } as any);
+
+      expect(newState[0].isSupportedVersion).toBe(true);
+      expect(newState[0].supportedVersionsValidatedAt).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('WEBVIEW_SERVER_VERSION_UPDATED', () => {
+    it('should set version and gitCommitHash when hash provided', () => {
+      const newState = servers([existing], {
+        type: WEBVIEW_SERVER_VERSION_UPDATED,
+        payload: { url, version: '7.0.0', gitCommitHash: 'deadbeef' },
+      } as any);
+
+      expect(newState[0].version).toBe('7.0.0');
+      expect(newState[0].gitCommitHash).toBe('deadbeef');
+    });
+
+    it('should not overwrite gitCommitHash when hash is undefined', () => {
+      const withHash: Server = { url, gitCommitHash: 'keepme' };
+      const newState = servers([withHash], {
+        type: WEBVIEW_SERVER_VERSION_UPDATED,
+        payload: { url, version: '7.0.0' },
+      } as any);
+
+      expect(newState[0].version).toBe('7.0.0');
+      expect(newState[0].gitCommitHash).toBe('keepme');
+    });
+  });
+
+  describe('WEBVIEW_UNREAD_CHANGED', () => {
+    it('should set badge', () => {
+      const newState = servers([existing], {
+        type: WEBVIEW_UNREAD_CHANGED,
+        payload: { url, badge: 5 },
+      } as any);
+
+      expect(newState[0].badge).toBe(5);
+    });
+  });
+
+  describe('WEBVIEW_USER_LOGGED_IN', () => {
+    it('should set userLoggedIn', () => {
+      const newState = servers([existing], {
+        type: WEBVIEW_USER_LOGGED_IN,
+        payload: { url, userLoggedIn: true },
+      } as any);
+
+      expect(newState[0].userLoggedIn).toBe(true);
+    });
+  });
+
+  describe('WEBVIEW_ALLOWED_REDIRECTS_CHANGED', () => {
+    it('should set allowedRedirects', () => {
+      const newState = servers([existing], {
+        type: WEBVIEW_ALLOWED_REDIRECTS_CHANGED,
+        payload: { url, allowedRedirects: ['https://x/'] },
+      } as any);
+
+      expect(newState[0].allowedRedirects).toEqual(['https://x/']);
+    });
+  });
+
+  describe('WEBVIEW_SIDEBAR_STYLE_CHANGED', () => {
+    it('should set style', () => {
+      const style = { background: '#000', color: '#fff', border: null };
+      const newState = servers([existing], {
+        type: WEBVIEW_SIDEBAR_STYLE_CHANGED,
+        payload: { url, style },
+      } as any);
+
+      expect(newState[0].style).toBe(style);
+    });
+  });
+
+  describe('WEBVIEW_SIDEBAR_CUSTOM_THEME_CHANGED', () => {
+    it('should set customTheme', () => {
+      const newState = servers([existing], {
+        type: WEBVIEW_SIDEBAR_CUSTOM_THEME_CHANGED,
+        payload: { url, customTheme: 'dark' },
+      } as any);
+
+      expect(newState[0].customTheme).toBe('dark');
+    });
+  });
+
+  describe('WEBVIEW_GIT_COMMIT_HASH_CHANGED', () => {
+    it('should set gitCommitHash', () => {
+      const newState = servers([existing], {
+        type: WEBVIEW_GIT_COMMIT_HASH_CHANGED,
+        payload: { url, gitCommitHash: 'abc123' },
+      } as any);
+
+      expect(newState[0].gitCommitHash).toBe('abc123');
+    });
+  });
+
+  describe('WEBVIEW_FAVICON_CHANGED', () => {
+    it('should set favicon', () => {
+      const newState = servers([existing], {
+        type: WEBVIEW_FAVICON_CHANGED,
+        payload: { url, favicon: 'data:image/png;base64,xxx' },
+      } as any);
+
+      expect(newState[0].favicon).toBe('data:image/png;base64,xxx');
+    });
+  });
+
+  describe('WEBVIEW_DID_NAVIGATE', () => {
+    it('should set lastPath when pageUrl includes the server url', () => {
+      const newState = servers([existing], {
+        type: WEBVIEW_DID_NAVIGATE,
+        payload: { url, pageUrl: `${url}channel/general` },
+      } as any);
+
+      expect(newState[0].lastPath).toBe(`${url}channel/general`);
+    });
+
+    it('should return unchanged state when pageUrl does not include url', () => {
+      const state = [existing];
+      const newState = servers(state, {
+        type: WEBVIEW_DID_NAVIGATE,
+        payload: { url, pageUrl: 'https://elsewhere/' },
+      } as any);
+
+      expect(newState).toBe(state);
+    });
+
+    it('should return unchanged state when pageUrl is undefined', () => {
+      const state = [existing];
+      const newState = servers(state, {
+        type: WEBVIEW_DID_NAVIGATE,
+        payload: { url, pageUrl: undefined },
+      } as any);
+
+      expect(newState).toBe(state);
+    });
+  });
+
+  describe('WEBVIEW_DID_START_LOADING', () => {
+    it('should clear the failed flag', () => {
+      const failed: Server = { url, failed: true };
+      const newState = servers([failed], {
+        type: WEBVIEW_DID_START_LOADING,
+        payload: { url },
+      } as any);
+
+      expect(newState[0].failed).toBe(false);
+    });
+  });
+
+  describe('WEBVIEW_DID_FAIL_LOAD', () => {
+    it('should set failed when main frame', () => {
+      const newState = servers([existing], {
+        type: WEBVIEW_DID_FAIL_LOAD,
+        payload: { url, isMainFrame: true },
+      } as any);
+
+      expect(newState[0].failed).toBe(true);
+    });
+
+    it('should return unchanged state when not main frame', () => {
+      const state = [existing];
+      const newState = servers(state, {
+        type: WEBVIEW_DID_FAIL_LOAD,
+        payload: { url, isMainFrame: false },
+      } as any);
+
+      expect(newState).toBe(state);
+    });
+  });
+
+  describe('SERVERS_LOADED', () => {
+    it('should normalize server urls from payload', () => {
+      const newState = servers([], {
+        type: SERVERS_LOADED,
+        payload: { servers: [{ url: 'https://open.rocket.chat' }] },
+      } as any);
+
+      expect(newState[0].url).toBe('https://open.rocket.chat/');
+    });
+
+    it('should fall back to current state when servers missing in payload', () => {
+      const state = [{ url: 'https://open.rocket.chat' } as Server];
+      const newState = servers(state, {
+        type: SERVERS_LOADED,
+        payload: {},
+      } as any);
+
+      expect(newState[0].url).toBe('https://open.rocket.chat/');
+    });
+  });
+
+  describe('APP_SETTINGS_LOADED', () => {
+    it('should normalize urls and reset document viewer fields', () => {
+      const newState = servers([], {
+        type: APP_SETTINGS_LOADED,
+        payload: { servers: [{ url: 'https://open.rocket.chat' }] },
+      } as any);
+
+      expect(newState[0].url).toBe('https://open.rocket.chat/');
+      expect(newState[0].documentViewerOpenUrl).toBe('');
+      expect(newState[0].documentViewerFormat).toBe('');
+    });
+
+    it('should fall back to current state when servers missing', () => {
+      const state = [{ url: 'https://open.rocket.chat' } as Server];
+      const newState = servers(state, {
+        type: APP_SETTINGS_LOADED,
+        payload: {},
+      } as any);
+
+      expect(newState[0].url).toBe('https://open.rocket.chat/');
+    });
+  });
+
+  describe('WEBVIEW_READY / WEBVIEW_ATTACHED (update path)', () => {
+    it('should set webContentsId on an existing server', () => {
+      const newState = servers([existing], {
+        type: WEBVIEW_READY,
+        payload: { url, webContentsId: 42 },
+      } as any);
+
+      expect(newState[0].webContentsId).toBe(42);
+    });
+
+    it('should return unchanged state for unknown url (update no-op)', () => {
+      const state = [existing];
+      const newState = servers(state, {
+        type: WEBVIEW_ATTACHED,
+        payload: { url: 'https://unknown/', webContentsId: 7 },
+      } as any);
+
+      expect(newState).toBe(state);
+    });
+  });
+
+  describe('OUTLOOK_CALENDAR_SAVE_CREDENTIALS', () => {
+    it('should set outlookCredentials', () => {
+      const outlookCredentials = {
+        userId: 'u',
+        login: 'l',
+        password: 'p',
+        serverUrl: url,
+      };
+      const newState = servers([existing], {
+        type: OUTLOOK_CALENDAR_SAVE_CREDENTIALS,
+        payload: { url, outlookCredentials },
+      } as any);
+
+      expect(newState[0].outlookCredentials).toBe(outlookCredentials);
+    });
+  });
+
+  describe('SERVER_DOCUMENT_VIEWER_OPEN_URL', () => {
+    it('should set document viewer url and format', () => {
+      const newState = servers([existing], {
+        type: SERVER_DOCUMENT_VIEWER_OPEN_URL,
+        payload: {
+          server: url,
+          documentUrl: 'https://doc/',
+          documentFormat: 'pdf',
+        },
+      } as any);
+
+      expect(newState[0].documentViewerOpenUrl).toBe('https://doc/');
+      expect(newState[0].documentViewerFormat).toBe('pdf');
+    });
+
+    it('should default documentViewerFormat to empty string when not provided', () => {
+      const newState = servers([existing], {
+        type: SERVER_DOCUMENT_VIEWER_OPEN_URL,
+        payload: { server: url, documentUrl: 'https://doc/' },
+      } as any);
+
+      expect(newState[0].documentViewerFormat).toBe('');
+    });
+  });
+
+  describe('immutability', () => {
+    it('should not mutate the original state array on upsert', () => {
+      const state = [existing];
+      const newState = servers(state, {
+        type: WEBVIEW_TITLE_CHANGED,
+        payload: { url, title: 'Changed' },
+      } as any);
+
+      expect(newState).not.toBe(state);
+      expect(state[0].title).toBe('Open');
+    });
+  });
+});

--- a/src/store/__tests__/index.spec.ts
+++ b/src/store/__tests__/index.spec.ts
@@ -1,0 +1,437 @@
+/**
+ * Unit tests for the store helpers in src/store/index.ts.
+ *
+ * The store module keeps a module-level `reduxStore` singleton, so each test
+ * group uses `jest.resetModules()` + dynamic `import()` to obtain a fresh
+ * module instance with an uninitialized store when needed.
+ *
+ * The `./ipc` module is mocked so store creation does not touch Electron IPC.
+ */
+import type { Middleware } from 'redux';
+
+import type * as StoreModuleType from '../index';
+
+type StoreModule = typeof StoreModuleType;
+
+const FORWARD_TO_RENDERERS_MOCK: Middleware = () => (next) => (action) =>
+  next(action);
+const FORWARD_TO_MAIN_MOCK: Middleware = () => (next) => (action) =>
+  next(action);
+
+let getInitialStateMock: jest.Mock;
+
+const loadStoreModule = async (): Promise<StoreModule> => {
+  jest.resetModules();
+  getInitialStateMock = jest.fn(async () => ({}));
+
+  jest.doMock('../ipc', () => ({
+    forwardToRenderers: FORWARD_TO_RENDERERS_MOCK,
+    forwardToMain: FORWARD_TO_MAIN_MOCK,
+    getInitialState: getInitialStateMock,
+  }));
+
+  return import('../index');
+};
+
+afterEach(() => {
+  jest.resetModules();
+  jest.restoreAllMocks();
+});
+
+describe('store/index', () => {
+  describe('before the store is initialized', () => {
+    let store: StoreModule;
+
+    beforeEach(async () => {
+      store = await loadStoreModule();
+    });
+
+    it('dispatch is a no-op', () => {
+      expect(() => store.dispatch({ type: 'ANY_ACTION' } as any)).not.toThrow();
+    });
+
+    it('dispatchSingle is a no-op', () => {
+      expect(() =>
+        store.dispatchSingle({ type: 'ANY_ACTION' } as any)
+      ).not.toThrow();
+    });
+
+    it('dispatchLocal is a no-op', () => {
+      expect(() =>
+        store.dispatchLocal({ type: 'ANY_ACTION' } as any)
+      ).not.toThrow();
+    });
+
+    it('safeSelect returns undefined', () => {
+      expect(store.safeSelect(() => 42)).toBeUndefined();
+    });
+
+    it('watch warns, runs nothing, and returns a no-op unsubscribe', () => {
+      const warnSpy = jest
+        .spyOn(console, 'warn')
+        .mockImplementation(() => undefined);
+      const watcher = jest.fn();
+
+      const unsubscribe = store.watch(() => 1, watcher);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[store] watch() called before store initialized'
+      );
+      expect(watcher).not.toHaveBeenCalled();
+      expect(() => unsubscribe()).not.toThrow();
+    });
+
+    it('listen returns a no-op unsubscribe', () => {
+      const listener = jest.fn();
+      const unsubscribe = store.listen('SOME_TYPE' as any, listener);
+      expect(listener).not.toHaveBeenCalled();
+      expect(() => unsubscribe()).not.toThrow();
+    });
+
+    it('request rejects when the store is not initialized', async () => {
+      await expect(
+        store.request({ type: 'SOME_REQUEST' } as any, 'SOME_RESPONSE' as any)
+      ).rejects.toThrow('Store not initialized');
+    });
+  });
+
+  describe('createMainReduxStore', () => {
+    let store: StoreModule;
+
+    beforeEach(async () => {
+      store = await loadStoreModule();
+      store.createMainReduxStore();
+    });
+
+    it('creates a store with the initial reducer state', () => {
+      expect(store.select((state) => state)).toBeDefined();
+      expect(typeof store.select((state) => state)).toBe('object');
+    });
+
+    it('dispatch forwards actions to the store', () => {
+      expect(() => store.dispatch({ type: 'ANY_ACTION' } as any)).not.toThrow();
+    });
+
+    it('safeSelect returns the selected value once initialized', () => {
+      const result = store.safeSelect((state) => state);
+      expect(result).toBeDefined();
+    });
+  });
+
+  describe('createRendererReduxStore', () => {
+    let store: StoreModule;
+
+    beforeEach(async () => {
+      store = await loadStoreModule();
+      delete (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__;
+    });
+
+    it('hydrates the store from getInitialState and returns it', async () => {
+      const created = await store.createRendererReduxStore();
+
+      expect(getInitialStateMock).toHaveBeenCalledTimes(1);
+      expect(created).toBeDefined();
+      expect(typeof created.getState).toBe('function');
+      expect(created.getState()).toBeDefined();
+    });
+
+    it('uses the Redux devtools compose enhancer when present', async () => {
+      const composeSpy = jest.fn((enhancer: unknown) => enhancer);
+      (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ = composeSpy;
+
+      await store.createRendererReduxStore();
+
+      expect(composeSpy).toHaveBeenCalledTimes(1);
+
+      delete (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__;
+    });
+  });
+
+  describe('select / safeSelect after initialization', () => {
+    let store: StoreModule;
+
+    beforeEach(async () => {
+      store = await loadStoreModule();
+      store.createMainReduxStore();
+    });
+
+    it('select runs the selector against the current state', () => {
+      const selector = jest.fn((state) => state);
+      const result = store.select(selector);
+      expect(selector).toHaveBeenCalledTimes(1);
+      expect(result).toBeDefined();
+    });
+
+    it('safeSelect runs the selector against the current state', () => {
+      const selector = jest.fn((state) => state);
+      const result = store.safeSelect(selector);
+      expect(selector).toHaveBeenCalledTimes(1);
+      expect(result).toBeDefined();
+    });
+  });
+
+  describe('dispatch variants set the expected scope metadata', () => {
+    let store: StoreModule;
+    let dispatched: any[];
+
+    beforeEach(async () => {
+      store = await loadStoreModule();
+      store.createMainReduxStore();
+      dispatched = [];
+      // Capture every dispatched action via a listener-style subscription.
+      store.listen(
+        ((_action: any): _action is any => true) as any,
+        (action) => {
+          dispatched.push(action);
+        }
+      );
+    });
+
+    it('dispatchSingle tags ipcMeta.scope as "single"', () => {
+      store.dispatchSingle({ type: 'SINGLE_ACTION' } as any);
+      const action = dispatched.find((a) => a.type === 'SINGLE_ACTION');
+      expect(action).toBeDefined();
+      expect(action.ipcMeta.scope).toBe('single');
+    });
+
+    it('dispatchLocal tags ipcMeta.scope and meta.scope as "local"', () => {
+      store.dispatchLocal({ type: 'LOCAL_ACTION' } as any);
+      const action = dispatched.find((a) => a.type === 'LOCAL_ACTION');
+      expect(action).toBeDefined();
+      expect(action.ipcMeta.scope).toBe('local');
+      expect(action.meta.scope).toBe('local');
+    });
+  });
+
+  describe('watch', () => {
+    let store: StoreModule;
+
+    beforeEach(async () => {
+      store = await loadStoreModule();
+      store.createMainReduxStore();
+    });
+
+    it('invokes the watcher immediately with the initial value', () => {
+      const watcher = jest.fn();
+      store.watch((state) => state, watcher);
+      expect(watcher).toHaveBeenCalledTimes(1);
+      expect(watcher.mock.calls[0][1]).toBeUndefined();
+    });
+
+    it('invokes the watcher when the selected value changes', () => {
+      const watcher = jest.fn();
+      // Select a value derived from a counter that we mutate via dispatch.
+      let toggle = false;
+      store.watch(() => toggle, watcher);
+      expect(watcher).toHaveBeenCalledTimes(1);
+
+      toggle = true;
+      store.dispatch({ type: 'TRIGGER_SUBSCRIPTION' } as any);
+
+      expect(watcher).toHaveBeenCalledTimes(2);
+      expect(watcher).toHaveBeenLastCalledWith(true, false);
+    });
+
+    it('does not invoke the watcher when the selected value is unchanged', () => {
+      const watcher = jest.fn();
+      store.watch(() => 'constant', watcher);
+      expect(watcher).toHaveBeenCalledTimes(1);
+
+      store.dispatch({ type: 'TRIGGER_SUBSCRIPTION' } as any);
+
+      expect(watcher).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns an unsubscribe that stops further watcher calls', () => {
+      const watcher = jest.fn();
+      let value = 0;
+      const unsubscribe = store.watch(() => value, watcher);
+      expect(watcher).toHaveBeenCalledTimes(1);
+
+      unsubscribe();
+      value = 1;
+      store.dispatch({ type: 'TRIGGER_SUBSCRIPTION' } as any);
+
+      expect(watcher).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('listen', () => {
+    let store: StoreModule;
+
+    beforeEach(async () => {
+      store = await loadStoreModule();
+      store.createMainReduxStore();
+    });
+
+    it('invokes the listener when the action type matches', () => {
+      const listener = jest.fn();
+      store.listen('MATCHING_TYPE' as any, listener);
+
+      store.dispatch({ type: 'MATCHING_TYPE' } as any);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener.mock.calls[0][0].type).toBe('MATCHING_TYPE');
+    });
+
+    it('does not invoke the listener when the action type does not match', () => {
+      const listener = jest.fn();
+      store.listen('MATCHING_TYPE' as any, listener);
+
+      store.dispatch({ type: 'OTHER_TYPE' } as any);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('supports a predicate function instead of a type string', () => {
+      const listener = jest.fn();
+      store.listen(
+        ((action: any): action is any =>
+          action.type === 'PREDICATE_HIT') as any,
+        listener
+      );
+
+      store.dispatch({ type: 'PREDICATE_MISS' } as any);
+      expect(listener).not.toHaveBeenCalled();
+
+      store.dispatch({ type: 'PREDICATE_HIT' } as any);
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns an unsubscribe that stops further listener calls', () => {
+      const listener = jest.fn();
+      const unsubscribe = store.listen('MATCHING_TYPE' as any, listener);
+
+      unsubscribe();
+      store.dispatch({ type: 'MATCHING_TYPE' } as any);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('request', () => {
+    let store: StoreModule;
+
+    beforeEach(async () => {
+      store = await loadStoreModule();
+      store.createMainReduxStore();
+    });
+
+    it('resolves with the payload of a matching response action', async () => {
+      // Capture the auto-generated request id by listening for the request
+      // action that the helper dispatches.
+      let requestId: unknown;
+      store.listen(
+        ((action: any): action is any => action?.meta?.request === true) as any,
+        (action: any) => {
+          requestId = action.meta.id;
+        }
+      );
+
+      const promise = store.request(
+        { type: 'DO_REQUEST' } as any,
+        'DO_RESPONSE' as any
+      );
+
+      expect(requestId).toBeDefined();
+
+      store.dispatch({
+        type: 'DO_RESPONSE',
+        payload: { ok: true },
+        meta: { response: true, id: requestId },
+      } as any);
+
+      await expect(promise).resolves.toEqual({ ok: true });
+    });
+
+    it('rejects with the error payload of an errored response action', async () => {
+      let requestId: unknown;
+      store.listen(
+        ((action: any): action is any => action?.meta?.request === true) as any,
+        (action: any) => {
+          requestId = action.meta.id;
+        }
+      );
+
+      const promise = store.request(
+        { type: 'ERR_REQUEST' } as any,
+        'ERR_RESPONSE' as any
+      );
+
+      const failure = new Error('boom');
+      store.dispatch({
+        type: 'ERR_RESPONSE',
+        payload: failure,
+        error: true,
+        meta: { response: true, id: requestId },
+      } as any);
+
+      await expect(promise).rejects.toBe(failure);
+    });
+  });
+
+  describe('Service', () => {
+    let store: StoreModule;
+
+    beforeEach(async () => {
+      store = await loadStoreModule();
+      store.createMainReduxStore();
+    });
+
+    it('setUp calls initialize and tearDown calls destroy', () => {
+      const initialize = jest.fn();
+      const destroy = jest.fn();
+
+      class TestService extends store.Service {
+        protected initialize(): void {
+          initialize();
+        }
+
+        protected destroy(): void {
+          destroy();
+        }
+      }
+
+      const service = new TestService();
+      service.setUp();
+      expect(initialize).toHaveBeenCalledTimes(1);
+
+      service.tearDown();
+      expect(destroy).toHaveBeenCalledTimes(1);
+    });
+
+    it('registers watchers/listeners on setUp and unsubscribes on tearDown', () => {
+      const watcher = jest.fn();
+      const listener = jest.fn();
+
+      class TestService extends store.Service {
+        protected initialize(): void {
+          this.watch((state) => state, watcher);
+          this.listen('SERVICE_TYPE' as any, listener);
+          this.listen(
+            ((action: any): action is any =>
+              action.type === 'SERVICE_PREDICATE') as any,
+            listener
+          );
+        }
+      }
+
+      const service = new TestService();
+      service.setUp();
+
+      // watch fires immediately with the initial value.
+      expect(watcher).toHaveBeenCalledTimes(1);
+
+      store.dispatch({ type: 'SERVICE_TYPE' } as any);
+      store.dispatch({ type: 'SERVICE_PREDICATE' } as any);
+      expect(listener).toHaveBeenCalledTimes(2);
+
+      service.tearDown();
+
+      // After tearDown, no further listener invocations.
+      store.dispatch({ type: 'SERVICE_TYPE' } as any);
+      store.dispatch({ type: 'SERVICE_PREDICATE' } as any);
+      expect(listener).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/updates/reducers/__tests__/updates.spec.ts
+++ b/src/updates/reducers/__tests__/updates.spec.ts
@@ -1,0 +1,362 @@
+import { APP_SETTINGS_LOADED } from '../../../app/actions';
+import {
+  ABOUT_DIALOG_TOGGLE_UPDATE_ON_START,
+  ABOUT_DIALOG_UPDATE_CHANNEL_CHANGED,
+} from '../../../ui/actions';
+import {
+  UPDATES_CHECKING_FOR_UPDATE,
+  UPDATES_ERROR_THROWN,
+  UPDATES_NEW_VERSION_AVAILABLE,
+  UPDATES_NEW_VERSION_NOT_AVAILABLE,
+  UPDATES_READY,
+  UPDATE_SKIPPED,
+  UPDATES_CHANNEL_CHANGED,
+} from '../../actions';
+import {
+  doCheckForUpdatesOnStartup,
+  isCheckingForUpdates,
+  isEachUpdatesSettingConfigurable,
+  isUpdatingAllowed,
+  isUpdatingEnabled,
+  newUpdateVersion,
+  skippedUpdateVersion,
+  updateError,
+  updateChannel,
+} from '../../reducers';
+
+const unknown = { type: 'UNKNOWN_ACTION' } as any;
+
+describe('doCheckForUpdatesOnStartup reducer', () => {
+  it('should default to true', () => {
+    expect(doCheckForUpdatesOnStartup(undefined, unknown)).toBe(true);
+  });
+
+  it('should read value from UPDATES_READY', () => {
+    expect(
+      doCheckForUpdatesOnStartup(true, {
+        type: UPDATES_READY,
+        payload: { doCheckForUpdatesOnStartup: false },
+      } as any)
+    ).toBe(false);
+  });
+
+  it('should set value from ABOUT_DIALOG_TOGGLE_UPDATE_ON_START', () => {
+    expect(
+      doCheckForUpdatesOnStartup(true, {
+        type: ABOUT_DIALOG_TOGGLE_UPDATE_ON_START,
+        payload: false,
+      } as any)
+    ).toBe(false);
+  });
+
+  it('should read value from APP_SETTINGS_LOADED', () => {
+    expect(
+      doCheckForUpdatesOnStartup(true, {
+        type: APP_SETTINGS_LOADED,
+        payload: { doCheckForUpdatesOnStartup: false },
+      } as any)
+    ).toBe(false);
+  });
+
+  it('should fall back to current state when missing in APP_SETTINGS_LOADED', () => {
+    expect(
+      doCheckForUpdatesOnStartup(false, {
+        type: APP_SETTINGS_LOADED,
+        payload: {},
+      } as any)
+    ).toBe(false);
+  });
+});
+
+describe('isCheckingForUpdates reducer', () => {
+  it('should default to false', () => {
+    expect(isCheckingForUpdates(undefined, unknown)).toBe(false);
+  });
+
+  it('should be true on UPDATES_CHECKING_FOR_UPDATE', () => {
+    expect(
+      isCheckingForUpdates(false, { type: UPDATES_CHECKING_FOR_UPDATE } as any)
+    ).toBe(true);
+  });
+
+  it('should be false on UPDATES_ERROR_THROWN', () => {
+    expect(
+      isCheckingForUpdates(true, { type: UPDATES_ERROR_THROWN } as any)
+    ).toBe(false);
+  });
+
+  it('should be false on UPDATES_NEW_VERSION_NOT_AVAILABLE', () => {
+    expect(
+      isCheckingForUpdates(true, {
+        type: UPDATES_NEW_VERSION_NOT_AVAILABLE,
+      } as any)
+    ).toBe(false);
+  });
+
+  it('should be false on UPDATES_NEW_VERSION_AVAILABLE', () => {
+    expect(
+      isCheckingForUpdates(true, {
+        type: UPDATES_NEW_VERSION_AVAILABLE,
+        payload: '7.0.0',
+      } as any)
+    ).toBe(false);
+  });
+
+  it('should preserve state on unknown action', () => {
+    expect(isCheckingForUpdates(true, unknown)).toBe(true);
+  });
+});
+
+describe('isEachUpdatesSettingConfigurable reducer', () => {
+  it('should default to true', () => {
+    expect(isEachUpdatesSettingConfigurable(undefined, unknown)).toBe(true);
+  });
+
+  it('should read value from UPDATES_READY', () => {
+    expect(
+      isEachUpdatesSettingConfigurable(true, {
+        type: UPDATES_READY,
+        payload: { isEachUpdatesSettingConfigurable: false },
+      } as any)
+    ).toBe(false);
+  });
+
+  it('should read value from APP_SETTINGS_LOADED', () => {
+    expect(
+      isEachUpdatesSettingConfigurable(true, {
+        type: APP_SETTINGS_LOADED,
+        payload: { isEachUpdatesSettingConfigurable: false },
+      } as any)
+    ).toBe(false);
+  });
+
+  it('should fall back to current state when missing in APP_SETTINGS_LOADED', () => {
+    expect(
+      isEachUpdatesSettingConfigurable(false, {
+        type: APP_SETTINGS_LOADED,
+        payload: {},
+      } as any)
+    ).toBe(false);
+  });
+});
+
+describe('isUpdatingAllowed reducer', () => {
+  it('should default to true', () => {
+    expect(isUpdatingAllowed(undefined, unknown)).toBe(true);
+  });
+
+  it('should read value from UPDATES_READY', () => {
+    expect(
+      isUpdatingAllowed(true, {
+        type: UPDATES_READY,
+        payload: { isUpdatingAllowed: false },
+      } as any)
+    ).toBe(false);
+  });
+
+  it('should preserve state on unknown action', () => {
+    expect(isUpdatingAllowed(false, unknown)).toBe(false);
+  });
+});
+
+describe('isUpdatingEnabled reducer', () => {
+  it('should default to true', () => {
+    expect(isUpdatingEnabled(undefined, unknown)).toBe(true);
+  });
+
+  it('should read value from UPDATES_READY', () => {
+    expect(
+      isUpdatingEnabled(true, {
+        type: UPDATES_READY,
+        payload: { isUpdatingEnabled: false },
+      } as any)
+    ).toBe(false);
+  });
+
+  it('should read value from APP_SETTINGS_LOADED', () => {
+    expect(
+      isUpdatingEnabled(true, {
+        type: APP_SETTINGS_LOADED,
+        payload: { isUpdatingEnabled: false },
+      } as any)
+    ).toBe(false);
+  });
+
+  it('should fall back to current state when missing in APP_SETTINGS_LOADED', () => {
+    expect(
+      isUpdatingEnabled(false, {
+        type: APP_SETTINGS_LOADED,
+        payload: {},
+      } as any)
+    ).toBe(false);
+  });
+});
+
+describe('newUpdateVersion reducer', () => {
+  it('should default to null', () => {
+    expect(newUpdateVersion(undefined, unknown)).toBeNull();
+  });
+
+  it('should set version on UPDATES_NEW_VERSION_AVAILABLE', () => {
+    expect(
+      newUpdateVersion(null, {
+        type: UPDATES_NEW_VERSION_AVAILABLE,
+        payload: '7.0.0',
+      } as any)
+    ).toBe('7.0.0');
+  });
+
+  it('should reset to null on UPDATES_NEW_VERSION_NOT_AVAILABLE', () => {
+    expect(
+      newUpdateVersion('7.0.0', {
+        type: UPDATES_NEW_VERSION_NOT_AVAILABLE,
+      } as any)
+    ).toBeNull();
+  });
+
+  it('should reset to null on UPDATE_SKIPPED', () => {
+    expect(
+      newUpdateVersion('7.0.0', {
+        type: UPDATE_SKIPPED,
+        payload: '7.0.0',
+      } as any)
+    ).toBeNull();
+  });
+
+  it('should preserve state on unknown action', () => {
+    expect(newUpdateVersion('7.0.0', unknown)).toBe('7.0.0');
+  });
+});
+
+describe('skippedUpdateVersion reducer', () => {
+  it('should default to null', () => {
+    expect(skippedUpdateVersion(undefined, unknown)).toBeNull();
+  });
+
+  it('should read value from UPDATES_READY', () => {
+    expect(
+      skippedUpdateVersion(null, {
+        type: UPDATES_READY,
+        payload: { skippedUpdateVersion: '7.0.0' },
+      } as any)
+    ).toBe('7.0.0');
+  });
+
+  it('should set value from UPDATE_SKIPPED', () => {
+    expect(
+      skippedUpdateVersion(null, {
+        type: UPDATE_SKIPPED,
+        payload: '7.0.0',
+      } as any)
+    ).toBe('7.0.0');
+  });
+
+  it('should read value from APP_SETTINGS_LOADED', () => {
+    expect(
+      skippedUpdateVersion(null, {
+        type: APP_SETTINGS_LOADED,
+        payload: { skippedUpdateVersion: '7.0.0' },
+      } as any)
+    ).toBe('7.0.0');
+  });
+
+  it('should fall back to current state when missing in APP_SETTINGS_LOADED', () => {
+    expect(
+      skippedUpdateVersion('6.0.0', {
+        type: APP_SETTINGS_LOADED,
+        payload: {},
+      } as any)
+    ).toBe('6.0.0');
+  });
+});
+
+describe('updateError reducer', () => {
+  it('should default to null', () => {
+    expect(updateError(undefined, unknown)).toBeNull();
+  });
+
+  it('should reset to null on UPDATES_CHECKING_FOR_UPDATE', () => {
+    expect(
+      updateError(new Error('x'), {
+        type: UPDATES_CHECKING_FOR_UPDATE,
+      } as any)
+    ).toBeNull();
+  });
+
+  it('should set the error on UPDATES_ERROR_THROWN', () => {
+    const error = new Error('boom');
+    expect(
+      updateError(null, { type: UPDATES_ERROR_THROWN, payload: error } as any)
+    ).toBe(error);
+  });
+
+  it('should reset to null on UPDATES_NEW_VERSION_NOT_AVAILABLE', () => {
+    expect(
+      updateError(new Error('x'), {
+        type: UPDATES_NEW_VERSION_NOT_AVAILABLE,
+      } as any)
+    ).toBeNull();
+  });
+
+  it('should reset to null on UPDATES_NEW_VERSION_AVAILABLE', () => {
+    expect(
+      updateError(new Error('x'), {
+        type: UPDATES_NEW_VERSION_AVAILABLE,
+        payload: '7.0.0',
+      } as any)
+    ).toBeNull();
+  });
+
+  it('should preserve state on unknown action', () => {
+    const error = new Error('keep');
+    expect(updateError(error, unknown)).toBe(error);
+  });
+});
+
+describe('updateChannel reducer', () => {
+  it("should default to 'latest'", () => {
+    expect(updateChannel(undefined, unknown)).toBe('latest');
+  });
+
+  it('should set value from ABOUT_DIALOG_UPDATE_CHANNEL_CHANGED', () => {
+    expect(
+      updateChannel('latest', {
+        type: ABOUT_DIALOG_UPDATE_CHANNEL_CHANGED,
+        payload: 'beta',
+      } as any)
+    ).toBe('beta');
+  });
+
+  it('should set value from UPDATES_CHANNEL_CHANGED', () => {
+    expect(
+      updateChannel('latest', {
+        type: UPDATES_CHANNEL_CHANGED,
+        payload: 'alpha',
+      } as any)
+    ).toBe('alpha');
+  });
+
+  it('should read value from UPDATES_READY', () => {
+    expect(
+      updateChannel('latest', {
+        type: UPDATES_READY,
+        payload: { updateChannel: 'beta' },
+      } as any)
+    ).toBe('beta');
+  });
+
+  it('should read value from APP_SETTINGS_LOADED', () => {
+    expect(
+      updateChannel('latest', {
+        type: APP_SETTINGS_LOADED,
+        payload: { updateChannel: 'alpha' },
+      } as any)
+    ).toBe('alpha');
+  });
+
+  it('should fall back to current state when missing in APP_SETTINGS_LOADED', () => {
+    expect(
+      updateChannel('beta', { type: APP_SETTINGS_LOADED, payload: {} } as any)
+    ).toBe('beta');
+  });
+});


### PR DESCRIPTION
## What

Phase 1 of the coverage-improvement plan: unit tests for high-ROI **pure-logic** modules that had little or no coverage, plus a `coverageThreshold` ratchet gate so the number can't regress.

> **Stacked on #3362** — base branch is `chore/coverage-measurement` (the measurement-tooling PR), not `master`, so this diff stays scoped to Phase 1. Merge #3362 first, then this.

## Coverage delta

| Metric | Before | After |
|--------|--------|-------|
| Lines | 17.15% | **22.34%** |
| Statements | 17.67% | **22.91%** |
| Branches | 13.18% | **20.39%** |
| Functions | 11.87% | **16.11%** |

640 tests pass, 2 skipped, 0 failures. Lint clean.

## New specs (11 files, ~94–100% on each target)

| Module | Spec | Coverage |
|--------|------|----------|
| `servers/reducers.ts` | `servers/reducers/__tests__/servers.spec.ts` | 100% |
| `updates/reducers.ts` | `updates/reducers/__tests__/updates.spec.ts` | ~99% |
| `navigation/reducers.ts` | `navigation/reducers/__tests__/navigation.spec.ts` | 100% |
| `logging/privacy.ts` | `logging/__tests__/privacy.spec.ts` | 97% lines |
| `logging/dedup.ts` | `logging/__tests__/dedup.spec.ts` | 100% |
| `logging/context.ts` | `logging/main/context.main.spec.ts` | 100% lines |
| `outlookCalendar/errorClassification.ts` | `outlookCalendar/__tests__/errorClassification.spec.ts` | 100% lines |
| `i18n/common.ts` | `i18n/__tests__/common.spec.ts` | 100% |
| `store/index.ts` | `store/__tests__/index.spec.ts` | 100% lines |
| `errors.ts` | `errors/main/criticalError.spec.ts` | 94% |
| `screenSharing/desktopCapturerCache.ts` | `screenSharing/main/desktopCapturerCache.main.spec.ts` | 95% |

## Conventions followed

Reuses the three existing repo test patterns — reducer-direct (`isMenuBarEnabled.spec.ts`), `it.each` input/output matrices (`getOutlookEvents.spec.ts`), and extract-logic-from-IPC (`videoCallWindow/main/ipc.spec.ts`). No new test harness.

Specs are placed in subdirs (`__tests__/`, `main/`) to satisfy the jest `testMatch` globs — flat `src/<dir>/*.spec.ts` is silently dropped by the renderer glob. Each spec was confirmed discoverable via `jest --listTests` before landing.

## Ratchet gate

Adds `coverageThreshold` to `jest.config.js` (lines/statements 21, branches 19, functions 15 — set just under the new baseline for cross-platform headroom). `validate-pr.yml` already runs `test:coverage`, so the gate is active in CI and fails any PR that drops coverage below the floor.

## Notes

- A few defensive/unreachable branches were intentionally left uncovered (e.g. the null-URL `throw` guard in `servers/reducers.ts`, process-undefined guards) rather than contriving synthetic inputs. No source files were modified.

## Next (deferred)

Phase 2 — extract-and-test the moderate files (`navigation/main.ts` cert utils, `ScreenSharingRequestTracker`, `browserLauncher`, `ipc/renderer`, `logging/index.ts`), then ratchet the threshold up again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit test suites covering critical error handling, i18n interpolation/formatting, logging deduplication/privacy redaction, navigation/server/update reducers, error classification messaging, desktop capturer caching, and store helper behavior.
  * Total of ~3,300 lines of test coverage added across multiple modules.

* **Chores**
  * Updated Jest to enforce global coverage thresholds for lines, statements, branches, and functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->