### PR TITLE
fix: make logging spec path assertions cross-platform (Windows CI)

### DIFF
--- a/src/logging/main/index.main.spec.ts
+++ b/src/logging/main/index.main.spec.ts
@@ -7,7 +7,17 @@
  * `jest.isolateModules`.
  */
 
+import path from 'path';
+
 import type * as LoggingModule from '../index';
+
+// The source builds log paths with path.join(app.getPath('logs'), ...), so on
+// Windows the separator is '\\'. Mirror that here so assertions are
+// platform-correct: on POSIX these resolve to '/logs/...', on Windows to
+// '\\logs\\...'.
+const LOGS_DIR = '/logs';
+const MAIN_LOG_PATH = path.join(LOGS_DIR, 'main.log');
+const ERRORS_JSONL_PATH = path.join(LOGS_DIR, 'errors.jsonl');
 
 type Hook = (message: any, transport?: any, transportName?: string) => any;
 
@@ -51,7 +61,7 @@ const makeFakeLog = (withTransports: boolean): FakeLog => ({
 let fakeLog: FakeLog;
 const appOn = jest.fn<void, [string, (...args: any[]) => void]>();
 const ipcMainOn = jest.fn<void, [string, (...args: any[]) => void]>();
-const getPath = jest.fn<string, [string]>(() => '/logs');
+const getPath = jest.fn<string, [string]>(() => LOGS_DIR);
 const getVersion = jest.fn<string, []>(() => '9.9.9');
 let selectImpl: jest.Mock;
 let watchImpl: jest.Mock;
@@ -134,7 +144,7 @@ describe('logging/index', () => {
     fakeLog = makeFakeLog(true);
     selectImpl = jest.fn(() => false);
     watchImpl = jest.fn();
-    getPath.mockReturnValue('/logs');
+    getPath.mockReturnValue(LOGS_DIR);
     getVersion.mockReturnValue('9.9.9');
     fsMock.existsSync.mockReturnValue(false);
     fsMock.statSync.mockReturnValue({ size: 0 } as any);
@@ -203,11 +213,8 @@ describe('logging/index', () => {
       setProcessType('browser');
       fsMock.existsSync.mockReturnValue(true);
       loadModule();
-      expect(fsMock.chmodSync).toHaveBeenCalledWith('/logs/main.log', 0o600);
-      expect(fsMock.chmodSync).toHaveBeenCalledWith(
-        '/logs/errors.jsonl',
-        0o600
-      );
+      expect(fsMock.chmodSync).toHaveBeenCalledWith(MAIN_LOG_PATH, 0o600);
+      expect(fsMock.chmodSync).toHaveBeenCalledWith(ERRORS_JSONL_PATH, 0o600);
     });
 
     it('does not register before-quit when not in browser process', () => {
@@ -334,7 +341,7 @@ describe('logging/index', () => {
     it('truncates the error log file when it exceeds the size limit', () => {
       setProcessType('browser');
       fsMock.existsSync.mockImplementation(
-        (p: string) => p === '/logs/errors.jsonl'
+        (p: string) => p === ERRORS_JSONL_PATH
       );
       fsMock.statSync.mockReturnValue({ size: 6 * 1024 * 1024 } as any);
       fsMock.readFileSync.mockReturnValue('a\nb\nc\nd\n' as any);
@@ -345,7 +352,7 @@ describe('logging/index', () => {
       }
       // The writeFileSync (truncation) must have been invoked for errors.jsonl.
       expect(fsMock.writeFileSync).toHaveBeenCalledWith(
-        '/logs/errors.jsonl',
+        ERRORS_JSONL_PATH,
         expect.any(String)
       );
     });


### PR DESCRIPTION
## Problem

`src/logging/main/index.main.spec.ts` (added in #3365) fails on **Windows CI** while passing on Linux/macOS:

```
● logging/index › error jsonl hook › truncates the error log file when it exceeds the size limit
  Expected: "/logs/errors.jsonl"  Received: "\logs\errors.jsonl"
Tests: 2 failed (Windows only)
```

The spec hardcoded POSIX path literals (`/logs/errors.jsonl`) in assertions. The source builds paths with `path.join(app.getPath('logs'), …)`, which emits `\` separators on Windows — so the exact-string match failed. Violates the repo's cross-platform test requirement (CLAUDE.md).

## Fix

Test-only. Derive expected paths with `path.join` from a shared `LOGS_DIR` constant so the test and source use the same primitive:
- `MAIN_LOG_PATH = path.join('/logs', 'main.log')`, `ERRORS_JSONL_PATH = path.join('/logs', 'errors.jsonl')`.
- Fixed 4 hardcoded literals: two `chmodSync` asserts, the `writeFileSync` truncation assert, and an `existsSync` mock comparison (the last would have silently skipped the truncation branch on Windows, masking the assertion).
- Source `src/logging/index.ts` unchanged — it was already correct.

Platform-correct by construction: both sides now produce `\logs\errors.jsonl` on Windows and `/logs/errors.jsonl` on POSIX.

## Verify
`npx jest src/logging/main/index.main.spec.ts` → 35 pass. Lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure by standardizing logging path constants across test assertions and mocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->