### PR TITLE
fix: restore unread badge on Rocket.Chat 7.8.0+ servers

### DIFF
--- a/src/injected.ts
+++ b/src/injected.ts
@@ -510,7 +510,7 @@ const start = async () => {
       });
 
       window.addEventListener('unread-changed', (event) => {
-        const detail = (event as CustomEvent<number | undefined>).detail;
+        const { detail } = event as CustomEvent<number | undefined>;
         const aggregateCount =
           typeof detail === 'number' && Number.isFinite(detail)
             ? detail

--- a/src/injected.ts
+++ b/src/injected.ts
@@ -383,6 +383,7 @@ const start = async () => {
   const setupFlags = {
     urlResolver: false,
     badgeUpdates: false,
+    unreadChangedEvent: false,
     faviconUpdates: false,
     jitsiIntegration: false,
     backgroundSettings: false,
@@ -393,6 +394,15 @@ const start = async () => {
     themeAppearance: false,
     userPresence: false,
   };
+
+  // Per-subscription unread state, accumulated from the
+  // `unread-changed-by-subscription` global event so the badge can reproduce
+  // the server's alert-only "•" indicator. Lives outside setupReactiveFeatures
+  // so it survives the periodic re-invocation below.
+  const unreadSubscriptions = new Map<
+    string,
+    { unread: number; alert?: boolean; unreadAlert?: string }
+  >();
 
   // Setup reactive features that depend on modules (with polling)
   // eslint-disable-next-line complexity
@@ -408,6 +418,83 @@ const start = async () => {
         window.RocketChatDesktop.setBadge(unread);
       });
       setupFlags.badgeUpdates = true;
+    }
+
+    // Servers >= 7.x removed `unread` from the Meteor Session reactive dict
+    // (RocketChat/Rocket.Chat#36001), so the Tracker.autorun above reads
+    // `undefined` there. Those servers no longer expose the badge through
+    // Meteor at all, but they still broadcast it through two global
+    // CustomEvents on window, mirroring the server's own `useUnread` hook:
+    //   - `unread-changed-by-subscription`: fires per subscription whenever its
+    //     unread-relevant fields change, carrying { rid, unread, alert,
+    //     unreadAlert }. We accumulate these into `unreadSubscriptions` to
+    //     rebuild the alert-only "•" indicator that the numeric count alone
+    //     cannot represent.
+    //   - `unread-changed`: fires on every recompute with the aggregate count.
+    //     We use it as the recompute trigger and the source of truth for the
+    //     numeric total.
+    // The badge value is resolved exactly as the server's `useUnread` does:
+    // a positive count wins, otherwise an alert-only "•", otherwise no badge.
+    // Registered independently of the Meteor modules so it works even when they
+    // never load.
+    if (!setupFlags.unreadChangedEvent) {
+      const resolveBadge = (): void => {
+        let unreadCount = 0;
+        let alertIndicator: '•' | undefined;
+
+        // The user's `unreadAlert` preference only influences rooms left on the
+        // default. No global event carries it, so we read it from the Meteor
+        // user document when available and fall back to the server's shipped
+        // default of `true`.
+        const unreadAlertEnabled =
+          Meteor?.user?.()?.settings?.preferences?.unreadAlert ?? true;
+
+        for (const subscription of unreadSubscriptions.values()) {
+          const { unread, alert, unreadAlert } = subscription;
+          if (alert || unread > 0) {
+            if (
+              alert === true &&
+              unreadAlert !== 'nothing' &&
+              (unreadAlert === 'all' || unreadAlertEnabled !== false)
+            ) {
+              alertIndicator = '•';
+            }
+            unreadCount += unread;
+          }
+        }
+
+        if (unreadCount > 0) {
+          window.RocketChatDesktop.setBadge(unreadCount);
+          return;
+        }
+        window.RocketChatDesktop.setBadge(alertIndicator ?? 0);
+      };
+
+      window.addEventListener('unread-changed-by-subscription', (event) => {
+        const subscription = (
+          event as CustomEvent<{
+            rid?: string;
+            unread?: number;
+            alert?: boolean;
+            unreadAlert?: string;
+          }>
+        ).detail;
+        if (!subscription?.rid) {
+          return;
+        }
+        unreadSubscriptions.set(subscription.rid, {
+          unread: subscription.unread ?? 0,
+          alert: subscription.alert,
+          unreadAlert: subscription.unreadAlert,
+        });
+        resolveBadge();
+      });
+
+      window.addEventListener('unread-changed', () => {
+        resolveBadge();
+      });
+
+      setupFlags.unreadChangedEvent = true;
     }
 
     if (Tracker && settings && !setupFlags.faviconUpdates) {

--- a/src/injected.ts
+++ b/src/injected.ts
@@ -412,7 +412,16 @@ const start = async () => {
       setupFlags.urlResolver = true;
     }
 
-    if (Tracker && Session && !setupFlags.badgeUpdates) {
+    // Pre-7.8.0 only: those servers still publish the badge through the Meteor
+    // Session reactive dict. On 7.8.0+ this key is gone (Session.get('unread')
+    // resolves to undefined) and the global-event path below owns the badge, so
+    // running this autorun there would clear the badge with setBadge(undefined).
+    if (
+      !versionIsGreaterOrEqualsTo(serverInfo.version, '7.8.0') &&
+      Tracker &&
+      Session &&
+      !setupFlags.badgeUpdates
+    ) {
       Tracker.autorun(() => {
         const unread = Session.get('unread');
         window.RocketChatDesktop.setBadge(unread);
@@ -421,8 +430,8 @@ const start = async () => {
     }
 
     // Servers >= 7.x removed `unread` from the Meteor Session reactive dict
-    // (RocketChat/Rocket.Chat#36001), so the Tracker.autorun above reads
-    // `undefined` there. Those servers no longer expose the badge through
+    // (RocketChat/Rocket.Chat#36001), which is why the Session autorun above is
+    // gated to pre-7.8.0. Those servers no longer expose the badge through
     // Meteor at all, but they still broadcast it through two global
     // CustomEvents on window, mirroring the server's own `useUnread` hook:
     //   - `unread-changed-by-subscription`: fires per subscription whenever its
@@ -438,7 +447,12 @@ const start = async () => {
     // Registered independently of the Meteor modules so it works even when they
     // never load.
     if (!setupFlags.unreadChangedEvent) {
-      const resolveBadge = (): void => {
+      // `aggregateCount`, when provided, is the authoritative total carried by
+      // the `unread-changed` event. The per-subscription map is incremental and
+      // only sees rooms that changed after the listener attached, so it can
+      // undercount; we prefer the aggregate for the numeric total and use the
+      // map solely to rebuild the alert-only "•" indicator.
+      const resolveBadge = (aggregateCount?: number): void => {
         let unreadCount = 0;
         let alertIndicator: '•' | undefined;
 
@@ -463,8 +477,13 @@ const start = async () => {
           }
         }
 
-        if (unreadCount > 0) {
-          window.RocketChatDesktop.setBadge(unreadCount);
+        const total =
+          aggregateCount !== undefined && aggregateCount > unreadCount
+            ? aggregateCount
+            : unreadCount;
+
+        if (total > 0) {
+          window.RocketChatDesktop.setBadge(total);
           return;
         }
         window.RocketChatDesktop.setBadge(alertIndicator ?? 0);
@@ -490,8 +509,13 @@ const start = async () => {
         resolveBadge();
       });
 
-      window.addEventListener('unread-changed', () => {
-        resolveBadge();
+      window.addEventListener('unread-changed', (event) => {
+        const detail = (event as CustomEvent<number | undefined>).detail;
+        const aggregateCount =
+          typeof detail === 'number' && Number.isFinite(detail)
+            ? detail
+            : undefined;
+        resolveBadge(aggregateCount);
       });
 
       setupFlags.unreadChangedEvent = true;


### PR DESCRIPTION
## Proposed changes

Restores the unread badge (dock, tray, and sidebar server avatar) on servers running **Rocket.Chat 7.8.0 or newer**, where it had stopped appearing.

### Root cause

The desktop app reads the unread badge exclusively from Meteor's reactive `Session` dict, via `injected.ts`:

```ts
Tracker.autorun(() => {
  const unread = Session.get('unread');
  window.RocketChatDesktop.setBadge(unread);
});
```

Server PR [RocketChat/Rocket.Chat#36001](https://github.com/RocketChat/Rocket.Chat/pull/36001) — *"refactor: remove `unread` from Meteor"* (ARCH-1606), first shipped in **7.8.0** — deleted `apps/meteor/client/startup/unread.ts`, the only code that wrote `Session.set('unread', …)`. Unread state moved to a React-only store (`useUnread` hook). On those servers, `Session.get('unread')` resolves to `undefined`, so `setBadge(undefined)` clears the badge across every sink. The desktop code itself was unchanged, so nothing in the desktop changelog pointed at the cause; the break surfaces only as each server independently upgrades past 7.8.0.

### Fix

Those servers still broadcast unread state through two global `CustomEvent`s on `window` (dispatched unconditionally by `fireGlobalEventBase`), mirroring the server's own `useUnread` hook:

| Event | Payload | Use here |
|-------|---------|----------|
| `unread-changed` | aggregate numeric count | recompute trigger / numeric total |
| `unread-changed-by-subscription` | per-sub `{ rid, unread, alert, unreadAlert }` | accumulated to rebuild the alert-only `•` indicator |

`injected.ts` now listens to both and resolves the badge with the same logic `useUnread` uses: a positive count wins, otherwise an alert-only `•`, otherwise no badge. The `unreadAlert` user preference is read from `Meteor.user()` when available and defaults to `true` (the server's shipped default).

The legacy `Session.get('unread')` autorun is **kept as a fallback** for servers older than 7.8.0, so the badge works across both old and new servers.

### Known limitation

`unread-changed-by-subscription` is incremental (fires only when a subscription changes). An alert-only room (zero unread count) that settled before the listener attached may not show its `•` dot until it next changes. Any real unread **count** always shows immediately. A future server-side change adding the alert state to a global event would remove this edge.

## Steps to test or reproduce

1. Connect the desktop app to a Rocket.Chat **7.8.0+** server and log in.
2. Receive an unread message → dock/tray/sidebar badge shows the count; clears when read.
3. (Optional, in the server view DevTools console) verify wiring directly:
   ```js
   window.dispatchEvent(new CustomEvent('unread-changed', { detail: 3 }));            // shows 3
   window.dispatchEvent(new CustomEvent('unread-changed-by-subscription',
     { detail: { rid: 'x', unread: 0, alert: true, unreadAlert: 'all' } }));
   window.dispatchEvent(new CustomEvent('unread-changed', { detail: 0 }));            // shows •
   ```
4. Connect to a pre-7.8.0 server and confirm the badge still works via the legacy Meteor path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unread badge behavior by tracking unread counts per subscription and rebuilding the badge state from server updates, ensuring accurate totals across sessions.
  * Refined badge logic to display an alert-style indicator only when appropriate (respecting the user’s unread alert preference) and to automatically clear the badge when there are no unread items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->