### PR TITLE
chore: update Electron from 40.8.5 to 41.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "chokidar": "~3.5.3",
     "conventional-changelog-cli": "~4.1.0",
     "convert-svg-to-png": "~0.6.4",
-    "electron": "40.8.5",
+    "electron": "41.9.0",
     "electron-builder": "26.0.3",
     "electron-devtools-installer": "^3.2.0",
     "electron-notarize": "^1.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1620,6 +1620,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@electron-internal/extract-zip@npm:^1.0.1":
+  version: 1.0.4
+  resolution: "@electron-internal/extract-zip@npm:1.0.4"
+  checksum: 10/de4f721b3810a8ef6a615e3f1a1eae901f3ad0c528cd4a20fe78efc67250c70c4c8bf91dc76a730bbea970dfc81e9aed18fd5ef465ac46856edd1f34f595b4ad
+  languageName: node
+  linkType: hard
+
 "@electron/asar@npm:3.2.18":
   version: 3.2.18
   resolution: "@electron/asar@npm:3.2.18"
@@ -1675,6 +1682,24 @@ __metadata:
     global-agent:
       optional: true
   checksum: 10/ac736cdeac52513b23038c761ebcb9fd315d443675f12c975805d7bcddcdabe5be492310ce5f6f1915d27013bcdcf19d0dac73c72353120948bbdf01fb3e11bf
+  languageName: node
+  linkType: hard
+
+"@electron/get@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@electron/get@npm:5.0.0"
+  dependencies:
+    debug: "npm:^4.1.1"
+    env-paths: "npm:^3.0.0"
+    graceful-fs: "npm:^4.2.11"
+    progress: "npm:^2.0.3"
+    semver: "npm:^7.6.3"
+    sumchecker: "npm:^3.0.1"
+    undici: "npm:^7.24.4"
+  dependenciesMeta:
+    undici:
+      optional: true
+  checksum: 10/b69a1874c80f2164e99f8fbab1916bd4f4bfd038310b7bcdadaebc5290f4b9cd61347286a71ed01a74863b14fd31d8def1bd3a6f2eac1d2324a6b0268b1bf309
   languageName: node
   linkType: hard
 
@@ -8192,16 +8217,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:40.8.5":
-  version: 40.8.5
-  resolution: "electron@npm:40.8.5"
+"electron@npm:41.9.0":
+  version: 41.9.0
+  resolution: "electron@npm:41.9.0"
   dependencies:
-    "@electron/get": "npm:^2.0.0"
+    "@electron-internal/extract-zip": "npm:^1.0.1"
+    "@electron/get": "npm:^5.0.0"
     "@types/node": "npm:^24.9.0"
-    extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10/13782668afa2ba8404e129eb3c67269d52f009734d0e100193fc382d98efc51b79d2afce3dc1c7a091e74f6028b10f9fe0cf1a32330af873d4df5ee9a83e93c2
+  checksum: 10/9a9099a20bd9560ade00ecc299723b39717c7cdd5a896b5fa4add8d10ec4f3e373c9fe52b7023a602b5d297eae726f78ff6cc82633dd62d78441d9147e365ac1
   languageName: node
   linkType: hard
 
@@ -8309,6 +8334,13 @@ __metadata:
   version: 2.2.1
   resolution: "env-paths@npm:2.2.1"
   checksum: 10/65b5df55a8bab92229ab2b40dad3b387fad24613263d103a97f91c9fe43ceb21965cd3392b1ccb5d77088021e525c4e0481adb309625d0cb94ade1d1fb8dc17e
+  languageName: node
+  linkType: hard
+
+"env-paths@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "env-paths@npm:3.0.0"
+  checksum: 10/b2b0a0d0d9931a13d279c22ed94d78648a1cc5f408f05d47ff3e0c1616f0aa0c38fb33deec5e5be50497225d500607d57f9c8652c4d39c2f2b7608cd45768128
   languageName: node
   linkType: hard
 
@@ -9903,7 +9935,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
+"graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10/bf152d0ed1dc159239db1ba1f74fdbc40cb02f626770dcd5815c427ce0688c2635a06ed69af364396da4636d0408fcf7d4afdf7881724c3307e46aff30ca49e2
@@ -14722,7 +14754,7 @@ __metadata:
     convert-svg-to-png: "npm:~0.6.4"
     detect-browsers: "npm:~6.1.0"
     dompurify: "npm:~3.3.3"
-    electron: "npm:40.8.5"
+    electron: "npm:41.9.0"
     electron-builder: "npm:26.0.3"
     electron-devtools-installer: "npm:^3.2.0"
     electron-dl: "npm:4.0.0"


### PR DESCRIPTION
## What changed

Bumps Electron **40.8.5 → 41.9.0** (devDependency) + regenerated `yarn.lock`.

| | 40.8.5 | 41.9.0 |
|---|---|---|
| Chromium | 144 | 146 |
| V8 | 14.4 | 14.6 |
| Node.js | 24.x | 24.x (major unchanged) |

This is step 1 of 2 toward Electron 42 (stepping through majors one at a time).

## Breaking changes review (Electron 41)

Reviewed every E41 breaking/removed/deprecated API against this codebase — none require adaptation:

- `webFrame.routingId` / `webFrame.findFrameByRoutingId()` **removed** — not used.
- `systemPreferences.isAeroGlassEnabled()` **removed** — not used.
- Renderer `clipboard` **deprecated** (removal targeted for E42) — `clipboard` here is only used in the main process and preload scripts, never raw renderer. Will revisit at the E42 bump.
- PDF rendering now uses OOPIFs instead of a separate WebContents (behavior change) — `PdfContent.tsx` owns its own `<webview>` and reads `getWebContentsId()` on `did-attach`; it does not enumerate PDF guest WebContents, so it is unaffected. Worth a manual PDF-attachment smoke-test (see below).
- Cookie `changed`-event cause values & Linux `showHiddenFiles` (behavior changes) — no usage in this repo.

No Electron-coupled patches, no native deps (no ABI rebuild). `electron-builder` kept at `26.0.3` (compatible, no peer-dependency conflict). CI `node-version` and `@types/node` left unchanged since Node stays on major 24.

## Verification

- `yarn lint` (ESLint + tsc) — pass
- `yarn build` (rollup, 8 bundles) — pass
- `yarn test` (full Jest suite) — **912 passed / 0 failed**, 52 suites
- Manual PDF-attachment rendering — **not yet verified**; needs a running app + a server with PDF attachments. Flagging for QA given the E41 PDF→OOPIF behavior change.

CI will run the cross-platform installer builds (build-artifacts label applied).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app’s Electron development dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->