### PR TITLE
chore: update Electron from 41.9.0 to 42.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "chokidar": "~3.5.3",
     "conventional-changelog-cli": "~4.1.0",
     "convert-svg-to-png": "~0.6.4",
-    "electron": "41.9.0",
+    "electron": "42.5.0",
     "electron-builder": "26.0.3",
     "electron-devtools-installer": "^3.2.0",
     "electron-notarize": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "chokidar": "~3.5.3",
     "conventional-changelog-cli": "~4.1.0",
     "convert-svg-to-png": "~0.6.4",
-    "electron": "40.8.5",
+    "electron": "41.9.0",
     "electron-builder": "26.0.3",
     "electron-devtools-installer": "^3.2.0",
     "electron-notarize": "^1.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1620,6 +1620,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@electron-internal/extract-zip@npm:^1.0.1":
+  version: 1.0.4
+  resolution: "@electron-internal/extract-zip@npm:1.0.4"
+  checksum: 10/de4f721b3810a8ef6a615e3f1a1eae901f3ad0c528cd4a20fe78efc67250c70c4c8bf91dc76a730bbea970dfc81e9aed18fd5ef465ac46856edd1f34f595b4ad
+  languageName: node
+  linkType: hard
+
 "@electron/asar@npm:3.2.18":
   version: 3.2.18
   resolution: "@electron/asar@npm:3.2.18"
@@ -1675,6 +1682,24 @@ __metadata:
     global-agent:
       optional: true
   checksum: 10/ac736cdeac52513b23038c761ebcb9fd315d443675f12c975805d7bcddcdabe5be492310ce5f6f1915d27013bcdcf19d0dac73c72353120948bbdf01fb3e11bf
+  languageName: node
+  linkType: hard
+
+"@electron/get@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@electron/get@npm:5.0.0"
+  dependencies:
+    debug: "npm:^4.1.1"
+    env-paths: "npm:^3.0.0"
+    graceful-fs: "npm:^4.2.11"
+    progress: "npm:^2.0.3"
+    semver: "npm:^7.6.3"
+    sumchecker: "npm:^3.0.1"
+    undici: "npm:^7.24.4"
+  dependenciesMeta:
+    undici:
+      optional: true
+  checksum: 10/b69a1874c80f2164e99f8fbab1916bd4f4bfd038310b7bcdadaebc5290f4b9cd61347286a71ed01a74863b14fd31d8def1bd3a6f2eac1d2324a6b0268b1bf309
   languageName: node
   linkType: hard
 
@@ -8192,16 +8217,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:40.8.5":
-  version: 40.8.5
-  resolution: "electron@npm:40.8.5"
+"electron@npm:41.9.0":
+  version: 41.9.0
+  resolution: "electron@npm:41.9.0"
   dependencies:
-    "@electron/get": "npm:^2.0.0"
+    "@electron-internal/extract-zip": "npm:^1.0.1"
+    "@electron/get": "npm:^5.0.0"
     "@types/node": "npm:^24.9.0"
-    extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10/13782668afa2ba8404e129eb3c67269d52f009734d0e100193fc382d98efc51b79d2afce3dc1c7a091e74f6028b10f9fe0cf1a32330af873d4df5ee9a83e93c2
+  checksum: 10/9a9099a20bd9560ade00ecc299723b39717c7cdd5a896b5fa4add8d10ec4f3e373c9fe52b7023a602b5d297eae726f78ff6cc82633dd62d78441d9147e365ac1
   languageName: node
   linkType: hard
 
@@ -8309,6 +8334,13 @@ __metadata:
   version: 2.2.1
   resolution: "env-paths@npm:2.2.1"
   checksum: 10/65b5df55a8bab92229ab2b40dad3b387fad24613263d103a97f91c9fe43ceb21965cd3392b1ccb5d77088021e525c4e0481adb309625d0cb94ade1d1fb8dc17e
+  languageName: node
+  linkType: hard
+
+"env-paths@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "env-paths@npm:3.0.0"
+  checksum: 10/b2b0a0d0d9931a13d279c22ed94d78648a1cc5f408f05d47ff3e0c1616f0aa0c38fb33deec5e5be50497225d500607d57f9c8652c4d39c2f2b7608cd45768128
   languageName: node
   linkType: hard
 
@@ -9903,7 +9935,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
+"graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10/bf152d0ed1dc159239db1ba1f74fdbc40cb02f626770dcd5815c427ce0688c2635a06ed69af364396da4636d0408fcf7d4afdf7881724c3307e46aff30ca49e2
@@ -14722,7 +14754,7 @@ __metadata:
     convert-svg-to-png: "npm:~0.6.4"
     detect-browsers: "npm:~6.1.0"
     dompurify: "npm:~3.3.3"
-    electron: "npm:40.8.5"
+    electron: "npm:41.9.0"
     electron-builder: "npm:26.0.3"
     electron-devtools-installer: "npm:^3.2.0"
     electron-dl: "npm:4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8217,16 +8217,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:41.9.0":
-  version: 41.9.0
-  resolution: "electron@npm:41.9.0"
+"electron@npm:42.5.0":
+  version: 42.5.0
+  resolution: "electron@npm:42.5.0"
   dependencies:
     "@electron-internal/extract-zip": "npm:^1.0.1"
     "@electron/get": "npm:^5.0.0"
     "@types/node": "npm:^24.9.0"
   bin:
     electron: cli.js
-  checksum: 10/9a9099a20bd9560ade00ecc299723b39717c7cdd5a896b5fa4add8d10ec4f3e373c9fe52b7023a602b5d297eae726f78ff6cc82633dd62d78441d9147e365ac1
+    install-electron: install.js
+  checksum: 10/d2d90d9f81fcf825a1fc8fd0ee923ba9820ef73ac70417295675a406fc256c93c0d45afd7a5aa81612a1c76fd3387398da2b73fe8400c7ba0a6891836b64cb4c
   languageName: node
   linkType: hard
 
@@ -14754,7 +14755,7 @@ __metadata:
     convert-svg-to-png: "npm:~0.6.4"
     detect-browsers: "npm:~6.1.0"
     dompurify: "npm:~3.3.3"
-    electron: "npm:41.9.0"
+    electron: "npm:42.5.0"
     electron-builder: "npm:26.0.3"
     electron-devtools-installer: "npm:^3.2.0"
     electron-dl: "npm:4.0.0"


### PR DESCRIPTION
## What changed

Bumps Electron **41.9.0 → 42.5.0** (devDependency) + regenerated `yarn.lock`.

> **Stacked PR** — based on `chore/electron-41.9.0` (#3372). The diff shows only the 41→42 delta. This will retarget to `master` automatically once #3372 merges. Step 2 of 2 in the 40→41→42 step-through.

| | 41.9.0 | 42.5.0 |
|---|---|---|
| Chromium | 146 | 148 |
| Node.js | 24.17.0 | 24.17.0 (unchanged) |

## Breaking changes review (Electron 42)

Reviewed every E42 breaking/removed/deprecated API against this codebase — none require adaptation:

- **`Session.clearStorageData()` `quotas` parameter removed** — all 4 callsites (`serverView/index.ts`, `servers/main.ts`, `servers/cache.ts`) pass `storages:` only; none used `quotas`. Unaffected.
- **`ELECTRON_SKIP_BINARY_DOWNLOAD` removed** — not used anywhere.
- **macOS notifications now use `UNNotification`** (unsigned apps fail silently) — the app is already code-signed via Google Cloud KMS, so this is a no-op for release builds.
- **npm lazy binary download** (postinstall no longer eagerly downloads the Electron binary) — verified `yarn install` fetches the 42.5.0 binary correctly; `require('electron')` resolves to the binary path.
- **Offscreen rendering default device scale → 1.0** — no offscreen rendering in use (`videoCallWindow` sets `offscreen: false`).
- **Renderer `clipboard` deprecated** (still functional in E42, not removed) — `clipboard` here is only used in the main process and preload scripts. Will revisit if/when it's removed in a later major.
- **`nativeImage.createFromNamedImage` array `hslShift` deprecated** — not used (only `createFromPath` / `createEmpty`).

No Electron-coupled patches, no native deps (no ABI rebuild). `electron-builder` kept at `26.0.3` (compatible, no peer-dependency conflict). CI `node-version` and `@types/node` unchanged since Node stays on major 24.

## Verification

- `yarn install` — Electron 42.5.0 binary fetched and resolved (lazy-download confirmed working)
- `yarn lint` (ESLint + tsc) — pass (no `clearStorageData` type errors)
- `yarn build` (rollup) — pass
- `yarn test` (full Jest suite) — **912 passed / 0 failed**, 52 suites
- Manual macOS notification (UNNotification switch) — **not yet verified**; needs a signed build. Flagging for QA.

CI will run the cross-platform installer builds (build-artifacts label applied).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app’s underlying desktop framework to a newer version, which may improve stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->