### PR TITLE
chore(dev): fix watch-mode auto-restart + remove dead webview console injection

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -58,10 +58,15 @@ const electronRunner = (() => {
         electronArgs.push('--no-sandbox');
       }
 
-      proc = spawn(electron, electronArgs, { stdio: 'inherit' });
+      const child = spawn(electron, electronArgs, { stdio: 'inherit' });
+      proc = child;
 
-      proc.once('close', () => {
-        proc = null;
+      // Guard against a stale `close` from a process that hit the kill timeout
+      // firing after a newer child has already been assigned to `proc`.
+      child.once('close', () => {
+        if (proc === child) {
+          proc = null;
+        }
       });
     } finally {
       starting = false;
@@ -75,9 +80,7 @@ const electronRunner = (() => {
       }
       restartTimer = setTimeout(() => {
         restartTimer = null;
-        start().catch((err) =>
-          console.error('Electron restart failed:', err)
-        );
+        start().catch((err) => console.error('Electron restart failed:', err));
       }, 300); // debounce: coalesce a multi-bundle rebuild batch into one restart
     },
   };

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -16,23 +16,40 @@ const NODE_ENV = process.env.NODE_ENV || 'development';
 const canRun =
   process.env.ROLLUP_WATCH === 'true' && process.env.NO_RUN !== 'true';
 
-const run = () => {
-  if (!canRun) {
-    return;
-  }
-
+// Single shared controller across all bundle configs. Because `rollup -c -w`
+// rebuilds multiple bundles on one file save, the restart is debounced so the
+// whole save-batch finishes writing, then the app restarts exactly once.
+const electronRunner = (() => {
   let proc = null;
+  let restartTimer = null;
+  let starting = false;
+  let hasStarted = false;
 
-  return {
-    writeBundle: async () => {
-      if (proc) {
-        proc.kill();
-        await new Promise((resolve) => proc.on('close', resolve));
-      }
+  const killProc = async () => {
+    if (!proc) {
+      return;
+    }
+    const current = proc;
+    proc = null;
+    const closed = new Promise((resolve) => current.once('close', resolve));
+    current.kill('SIGKILL'); // SIGKILL bypasses the app's tray/before-quit guards
+    await Promise.race([
+      closed,
+      new Promise((resolve) => setTimeout(resolve, 3000)), // never hang the watcher
+    ]);
+  };
 
+  const start = async () => {
+    if (starting) {
+      return;
+    }
+    starting = true;
+    try {
+      await killProc();
       console.log(
-        proc ? 'Restarting main process...' : 'Starting main process...'
+        hasStarted ? 'Restarting main process...' : 'Starting main process...'
       );
+      hasStarted = true;
 
       const electronArgs = ['.'];
 
@@ -43,9 +60,38 @@ const run = () => {
 
       proc = spawn(electron, electronArgs, { stdio: 'inherit' });
 
-      proc.on('close', () => {
+      proc.once('close', () => {
         proc = null;
       });
+    } finally {
+      starting = false;
+    }
+  };
+
+  return {
+    schedule: () => {
+      if (restartTimer) {
+        clearTimeout(restartTimer);
+      }
+      restartTimer = setTimeout(() => {
+        restartTimer = null;
+        start().catch((err) =>
+          console.error('Electron restart failed:', err)
+        );
+      }, 300); // debounce: coalesce a multi-bundle rebuild batch into one restart
+    },
+  };
+})();
+
+const run = () => {
+  if (!canRun) {
+    return { name: 'run-electron-noop' };
+  }
+
+  return {
+    name: 'run-electron',
+    writeBundle() {
+      electronRunner.schedule();
     },
   };
 };
@@ -105,6 +151,7 @@ export default [
         extensions,
       }),
       commonjs(),
+      run(),
     ],
     output: [
       {
@@ -138,6 +185,7 @@ export default [
         extensions,
       }),
       commonjs(),
+      run(),
     ],
     output: [
       {
@@ -171,6 +219,7 @@ export default [
         extensions,
       }),
       commonjs(),
+      run(),
     ],
     output: [
       {
@@ -217,6 +266,7 @@ export default [
         extensions,
       }),
       commonjs(),
+      run(),
     ],
     output: {
       dir: 'app',
@@ -250,6 +300,7 @@ export default [
         extensions,
       }),
       commonjs(),
+      run(),
     ],
     output: [
       {
@@ -277,6 +328,7 @@ export default [
         extensions,
       }),
       commonjs(),
+      run(),
     ],
     output: [
       {

--- a/src/logging/index.ts
+++ b/src/logging/index.ts
@@ -284,19 +284,13 @@ export const setupWebContentsLogging = () => {
       event.returnValue = '';
     });
 
-    // Rate limiting for console-log IPC to prevent flooding from compromised webviews
-    const ipcRateLimit = new Map<
-      number,
-      { count: number; resetTime: number }
-    >();
-    const MAX_IPC_MESSAGES_PER_SECOND = 100;
-
     // Listen for new webContents creation
     app.on('web-contents-created', (_event, webContents) => {
       // Skip if this is the main renderer process (it already has logging)
       if (webContents.getType() === 'window') return;
 
-      // For webviews and other renderer processes, inject console override
+      // Tag this webContents with its server context so logs forwarded by the
+      // webview preload (src/logging/preload.ts) are attributed to the server.
       webContents.on('dom-ready', () => {
         try {
           // Get server URL for this webContents
@@ -328,69 +322,6 @@ export const setupWebContentsLogging = () => {
           if (serverUrl !== 'unknown') {
             registerWebContentsServer(webContents.id, serverUrl);
           }
-
-          // TODO: Replace executeJavaScript injection with a preload script for
-          // better maintainability and debuggability (see src/logging/preload.ts)
-          // Inject enhanced console override directly into the webContents
-          const consoleOverrideScript = `
-            (function() {
-              try {
-                const { ipcRenderer } = require('electron');
-                
-                // Store original console methods
-                const originalConsole = {
-                  log: console.log,
-                  info: console.info,
-                  warn: console.warn,
-                  error: console.error,
-                  debug: console.debug,
-                };
-
-                 // Get webContents ID and server URL for context
-                 const webContentsId = ${webContents.id};
-                 const serverUrl = ${JSON.stringify(serverUrl)};
-
-
-                // Override console methods to send to main process with context
-                console.log = (...args) => {
-                  originalConsole.log(...args);
-                  ipcRenderer.send('console-log', 'debug', webContentsId, serverUrl, ...args);
-                };
-                
-                console.info = (...args) => {
-                  originalConsole.info(...args);
-                  ipcRenderer.send('console-log', 'info', webContentsId, serverUrl, ...args);
-                };
-                
-                console.warn = (...args) => {
-                  originalConsole.warn(...args);
-                  ipcRenderer.send('console-log', 'warn', webContentsId, serverUrl, ...args);
-                };
-                
-                console.error = (...args) => {
-                  originalConsole.error(...args);
-                  ipcRenderer.send('console-log', 'error', webContentsId, serverUrl, ...args);
-                };
-                
-                console.debug = (...args) => {
-                  originalConsole.debug(...args);
-                  ipcRenderer.send('console-log', 'debug', webContentsId, serverUrl, ...args);
-                };
-
-                // Add marker to know console override is active
-                console.original = originalConsole;
-               } catch (error) {
-                 console.error('[logging] Failed to override console in webContents:', error);
-               }
-            })();
-          `;
-
-          webContents.executeJavaScript(consoleOverrideScript).catch((err) => {
-            log.warn(
-              `[logging] Failed to inject console override into webContents ${webContents.id}:`,
-              err
-            );
-          });
         } catch (error) {
           logLoggingFailure(
             error,
@@ -399,99 +330,11 @@ export const setupWebContentsLogging = () => {
         }
       });
 
-      // Clean up context and rate limit state when webContents is destroyed
+      // Clean up server context when webContents is destroyed
       webContents.on('destroyed', () => {
         cleanupServerContext(webContents.id);
-        ipcRateLimit.delete(webContents.id);
       });
     });
-
-    // Handle console messages from renderer processes with enhanced context
-    ipcMain.on(
-      'console-log',
-      (event, level, _webContentsId, _serverUrl, ...args) => {
-        try {
-          // Use authenticated sender identity — never trust renderer-supplied IDs
-          const senderWebContents = event.sender;
-          const senderId = senderWebContents.id;
-
-          const now = Date.now();
-          let rateState = ipcRateLimit.get(senderId);
-          if (!rateState || now > rateState.resetTime) {
-            rateState = { count: 0, resetTime: now + 1000 };
-            ipcRateLimit.set(senderId, rateState);
-          }
-          rateState.count++;
-          if (rateState.count > MAX_IPC_MESSAGES_PER_SECOND) {
-            return;
-          }
-
-          // Register webContents → server URL mapping using the authenticated
-          // sender's URL — never trust renderer-supplied values.
-          if (selectFunction && senderWebContents.getType() === 'webview') {
-            try {
-              const currentUrl = senderWebContents.getURL();
-              if (currentUrl) {
-                const currentOrigin = new URL(currentUrl).origin;
-                const servers = selectFunction(
-                  (state: RootState) => state.servers
-                );
-                const matchedServer = servers.find((s: any) => {
-                  try {
-                    return s.url && new URL(s.url).origin === currentOrigin;
-                  } catch {
-                    return false;
-                  }
-                });
-                if (matchedServer?.url) {
-                  registerWebContentsServer(
-                    senderWebContents.id,
-                    matchedServer.url
-                  );
-                }
-              }
-            } catch {
-              // Non-critical: server URL registration failed
-            }
-          }
-
-          // Create enhanced context string with server info
-          const context = getLogContext(senderWebContents);
-          const contextStr = formatLogContext(context);
-
-          // Dedup non-error IPC messages before they reach electron-log
-          if (
-            logDeduplicator &&
-            !logDeduplicator.shouldLog(level, contextStr, args)
-          ) {
-            return;
-          }
-
-          // Log with enhanced context
-          switch (level) {
-            case 'debug':
-            case 'verbose':
-            case 'silly':
-              log.debug(contextStr, ...args);
-              break;
-            case 'info':
-              log.info(contextStr, ...args);
-              break;
-            case 'warn':
-              log.warn(contextStr, ...args);
-              break;
-            case 'error':
-              log.error(contextStr, ...args);
-              break;
-            default:
-              log.info(contextStr, ...args);
-              break;
-          }
-        } catch (error) {
-          logLoggingFailure(error, 'console-log IPC handler');
-        }
-      }
-    );
   } catch (error) {
     console.warn('[main] [app] Failed to setup webContents logging:', error);
   }

--- a/src/logging/main/index.main.spec.ts
+++ b/src/logging/main/index.main.spec.ts
@@ -492,10 +492,6 @@ describe('logging/index', () => {
         'log-viewer-window/get-server-tag',
         expect.any(Function)
       );
-      expect(ipcMainOn).toHaveBeenCalledWith(
-        'console-log',
-        expect.any(Function)
-      );
       expect(appOn).toHaveBeenCalledWith(
         'web-contents-created',
         expect.any(Function)
@@ -544,92 +540,6 @@ describe('logging/index', () => {
       });
     });
 
-    describe('console-log IPC handler', () => {
-      const getHandler = (mod: typeof LoggingModule) => {
-        mod.setupWebContentsLogging();
-        const call = ipcMainOn.mock.calls.find(
-          ([channel]) => channel === 'console-log'
-        );
-        return call![1] as (
-          event: any,
-          level: string,
-          id: number,
-          url: string,
-          ...args: any[]
-        ) => void;
-      };
-
-      const makeSender = (type = 'window', url = '') => ({
-        id: 42,
-        getType: () => type,
-        getURL: () => url,
-      });
-
-      it('routes each level to the matching electron-log method', () => {
-        setProcessType('browser');
-        const mod = loadModule();
-        const handler = getHandler(mod);
-        const event = { sender: makeSender() };
-
-        handler(event, 'debug', 1, 'u', 'd');
-        handler(event, 'info', 1, 'u', 'i');
-        handler(event, 'warn', 1, 'u', 'w');
-        handler(event, 'error', 1, 'u', 'e');
-        handler(event, 'verbose', 1, 'u', 'v');
-        handler(event, 'unknownLevel', 1, 'u', 'x');
-
-        expect(fakeLog.debug).toHaveBeenCalledWith('[main]', 'd');
-        expect(fakeLog.info).toHaveBeenCalledWith('[main]', 'i');
-        expect(fakeLog.warn).toHaveBeenCalledWith('[main]', 'w');
-        expect(fakeLog.error).toHaveBeenCalledWith('[main]', 'e');
-        // verbose maps to debug
-        expect(fakeLog.debug).toHaveBeenCalledWith('[main]', 'v');
-        // unknown maps to info
-        expect(fakeLog.info).toHaveBeenCalledWith('[main]', 'x');
-      });
-
-      it('enforces the per-sender rate limit', () => {
-        setProcessType('browser');
-        const mod = loadModule();
-        const handler = getHandler(mod);
-        const event = { sender: makeSender() };
-
-        for (let i = 0; i < 105; i++) {
-          handler(event, 'info', 1, 'u', `msg ${i}`);
-        }
-        // Only the first 100 messages within the window reach electron-log.
-        expect(fakeLog.info).toHaveBeenCalledTimes(100);
-      });
-
-      it('registers the sender server mapping for webview senders', () => {
-        setProcessType('browser');
-        selectImpl = jest.fn(() => [{ url: 'https://chat.example.com' }]);
-        const mod = loadModule();
-        const handler = getHandler(mod);
-        const event = {
-          sender: makeSender('webview', 'https://chat.example.com/channel'),
-        };
-        handler(event, 'info', 1, 'u', 'hello');
-        // The matched server is registered; logging proceeds with context.
-        expect(fakeLog.info).toHaveBeenCalled();
-      });
-
-      it('swallows errors raised inside the handler', () => {
-        setProcessType('browser');
-        const mod = loadModule();
-        const handler = getHandler(mod);
-        const event = {
-          sender: {
-            get id() {
-              throw new Error('boom');
-            },
-            getType: () => 'window',
-          },
-        };
-        expect(() => handler(event, 'info', 1, 'u', 'x')).not.toThrow();
-      });
-    });
-
     describe('web-contents-created listener', () => {
       const getListener = (mod: typeof LoggingModule) => {
         mod.setupWebContentsLogging();
@@ -665,17 +575,15 @@ describe('logging/index', () => {
         expect(wc._handlers['dom-ready']).toBeUndefined();
       });
 
-      it('injects the console override into webview dom-ready', () => {
+      it('registers server context on dom-ready without calling executeJavaScript', () => {
         setProcessType('browser');
         selectImpl = jest.fn(() => [{ url: 'https://chat.example.com' }]);
         const mod = loadModule();
         const listener = getListener(mod);
         const wc = makeWebContents('webview');
         listener({}, wc);
-        wc._handlers['dom-ready']();
-        expect(wc.executeJavaScript).toHaveBeenCalledTimes(1);
-        const script = wc.executeJavaScript.mock.calls[0][0];
-        expect(script).toContain("ipcRenderer.send('console-log'");
+        expect(() => wc._handlers['dom-ready']()).not.toThrow();
+        expect(wc.executeJavaScript).not.toHaveBeenCalled();
       });
 
       it('cleans up on destroyed', () => {


### PR DESCRIPTION
Two developer-experience fixes that came out of debugging a stuck dev loop and noisy server-view console.

---

## 1. Reliable Electron auto-restart in watch mode (`rollup.config.mjs`)

### Problem
`yarn start` rebuilt bundles but the app would not restart on change, and hard-killed runs left orphaned Electron processes (stale dock icons). Two causes in the watch-mode `run()` plugin:

1. **Restart wired only to the `src/main.ts` bundle.** Edits whose output landed in any other bundle (`rootWindow`, `preload`, `injected`, `videoCallWindow`, `logViewerWindow`) rebuilt but never restarted the running app.
2. **Killed with the default `SIGTERM`.** The app's hide-to-tray guard `preventDefault()`s the window `close` event, so `SIGTERM` never terminated the process and the runner's `await proc.on('close')` hung forever — wedging the watcher and leaking Electron processes.

### Fix
Replace the per-config runner with a single module-level restart controller shared across every bundle config:
- `SIGKILL` the previous process (bypasses the tray / `before-quit` guards), with a 3s `Promise.race` timeout so the watcher can never hang.
- Debounce restarts (300ms) so a multi-bundle rebuild from one file save coalesces into exactly one respawn instead of N racing launches.
- Attach `run()` to every bundle config so any source change restarts the app. `run()` returns a no-op named plugin when not in watch mode, so `yarn build` is unaffected.

### Verified
`yarn start` launches once; edits to both main and renderer bundles each trigger a single `Restarting main process...`; the live Electron main process count stays at exactly 1 throughout; shutdown leaves zero orphaned processes. `NO_RUN=true yarn build` and `node --check rollup.config.mjs` both pass.

---

## 2. Remove dead webview console injection (`src/logging/index.ts`)

### Problem
The `web-contents-created` → `dom-ready` handler injected a console-override script via `webContents.executeJavaScript(...)` that began with `const { ipcRenderer } = require('electron');`. With `contextIsolation` enabled, `require` does not exist in the page main world, so the script threw `ReferenceError: require is not defined` on every server view and never wired anything up — producing recurring noise in the loaded server view's devtools console:

```
[logging] Failed to override console in webContents: ReferenceError: require is not defined
```

The working console override already lives in the webview preload (`src/logging/preload.ts`), which forwards through `electron-log`. A `TODO` in the removed block already pointed at the preload as the intended replacement. Because the injected script was the only sender of the `console-log` IPC channel, its main-side handler and per-sender rate limiter were dead too.

### Fix
- Remove the `executeJavaScript` console-override injection.
- Remove the orphaned `ipcMain.on('console-log', ...)` handler.
- Remove the now-unused `ipcRateLimit` map / `MAX_IPC_MESSAGES_PER_SECOND` constant and the `ipcRateLimit.delete` cleanup call.
- The `dom-ready` handler now only registers the webContents → server context mapping (log tagging unchanged).
- Update `src/logging/main/index.main.spec.ts` accordingly.

### Verified
`npx tsc --noEmit` clean (no orphaned imports), `yarn lint` clean, `src/logging/main/index.main.spec.ts` 31/31 pass.

---

_Supersedes #3374._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development restart behavior by coordinating Electron restarts to avoid repeated restarts from a single save batch.
  * Streamlined renderer logging so logs are associated with the correct server without injecting console override scripts.
  * Refined webContents cleanup to only remove server-context data when a renderer is destroyed.
* **Tests**
  * Updated webContents logging tests to reflect the new restart and logging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->