### PR TITLE
fix: stop server sidebar tile rendering a literal "0" badge

### DIFF
--- a/src/ui/components/SideBar/ServerButton.spec.tsx
+++ b/src/ui/components/SideBar/ServerButton.spec.tsx
@@ -99,6 +99,12 @@ describe('ServerButton', () => {
     expect(screen.getByText('3')).toBeInTheDocument();
   });
 
+  it('does not render a literal "0" badge when the mention count is zero', () => {
+    renderButton({ mentionCount: 0, hasUnreadMessages: true });
+
+    expect(screen.queryByText('0')).not.toBeInTheDocument();
+  });
+
   it('shows a warning badge when the user is not logged in', () => {
     renderButton({ userLoggedIn: false });
 

--- a/src/ui/components/SideBar/ServerButton.tsx
+++ b/src/ui/components/SideBar/ServerButton.tsx
@@ -204,7 +204,9 @@ const ServerButton = ({
               transform: translate(30%, -30%);
             `}
           >
-            {mentionCount && <Badge variant='secondary'>{mentionCount}</Badge>}
+            {!!mentionCount && (
+              <Badge variant='secondary'>{mentionCount}</Badge>
+            )}
             {!userLoggedIn && <Badge variant='warning'>!</Badge>}
           </Box>
         </IconButton>


### PR DESCRIPTION
## What changed

The per-server sidebar tile rendered a literal **"0"** overlay whenever a server's unread `badge` was the number `0`.

`ServerButton.tsx` guarded its mention `<Badge>` with:

```tsx
{mentionCount && <Badge variant='secondary'>{mentionCount}</Badge>}
```

Because `0 && <Badge>` evaluates to `0`, React renders the number as a text node — the stray "0" on the tile. Coerced the guard to a boolean (`!!mentionCount`) so a zero count renders nothing.

## Why it surfaced now

PR #3369 (restore unread badge on Rocket.Chat 7.8.0+ servers) made `injected.ts` emit `setBadge(0)` explicitly via `setBadge(alertIndicator ?? 0)`. Servers now carry `badge: 0` where they previously carried `undefined`. `SideBar/index.tsx` maps that to `mentionCount={0}`, which hit the falsy-number render path.

## Scope

The aggregate badge sinks (`selectGlobalBadge`, tray title, dock) already collapse an all-zero state to `undefined`, so only the per-server tile was affected — those are left unchanged.

## Test

Added a regression test asserting `mentionCount={0}` renders no "0" text.

```
Tests: 10 passed, 10 total
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mention badges so a `0` count no longer appears as a visible badge.
  * Server list items now only show a badge when there is at least one mention, improving clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->