### PR TITLE
chore: bump version to 4.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "Rocket.Chat",
   "name": "rocketchat",
   "description": "Official OSX, Windows, and Linux Desktop Clients for Rocket.Chat",
-  "version": "4.15.0-alpha.0",
+  "version": "4.15.0",
   "author": "Rocket.Chat Support <support@rocket.chat>",
   "copyright": "© 2016-2026, Rocket.Chat",
   "homepage": "https://rocket.chat",


### PR DESCRIPTION
Promotes `4.15.0-alpha.0` to stable `4.15.0`. No code changes — version bump only (`package.json`).

alpha.0 soaked in daily use since cut (2026-06-25) with no regressions. Master sits exactly on the `4.15.0-alpha.0` tag, so stable ships identical code.

## What 4.15.0 contains (since 4.14.1)
- Electron 40.8.5 → 42.5.0
- Unread badge fix for Rocket.Chat 7.8.0+ servers (#3369)
- supportedVersions role-targeted expiration messages + unsupported-version false-block fix
- PDF viewer: encrypted-PDF preview size limit, `supportedDocumentViewerFormats` desktop API
- Telephony groundwork: tel:/callto: deep linking, preferred-server settings UI
- Fuselage 0.58 → 0.78 migration
- Test/coverage infrastructure (RTL + coverage ratchet)
- Window-position-at-screen-edge fix, markdown download cancellation

After merge: run `yarn release:tag` on master to create and push the `4.15.0` tag, triggering the build-release workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app version from `4.15.0-alpha.0` to `4.15.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->