### PR TITLE
fix: detect screen picker type reliably inside sandboxes (#3308)

### DIFF
--- a/src/screenSharing/screenPicker/createScreenPicker.spec.ts
+++ b/src/screenSharing/screenPicker/createScreenPicker.spec.ts
@@ -1,0 +1,107 @@
+import fs from 'fs';
+
+import { detectPickerType } from './createScreenPicker';
+
+jest.mock('./providers/PortalPickerProvider', () => ({
+  PortalPickerProvider: class {},
+}));
+
+jest.mock('./providers/InternalPickerProvider', () => ({
+  InternalPickerProvider: class {},
+}));
+
+jest.mock('fs', () => ({
+  statSync: jest.fn(),
+}));
+
+const statSyncMock = fs.statSync as jest.Mock;
+
+const ENV_KEYS = [
+  'XDG_SESSION_TYPE',
+  'XDG_CURRENT_DESKTOP',
+  'WAYLAND_DISPLAY',
+  'XDG_RUNTIME_DIR',
+  'ROCKETCHAT_INTERNAL_SCREEN_PICKER',
+];
+
+const setPlatform = (platform: NodeJS.Platform): void => {
+  Object.defineProperty(process, 'platform', {
+    value: platform,
+    configurable: true,
+  });
+};
+
+describe('detectPickerType', () => {
+  const originalPlatform = process.platform;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    ENV_KEYS.forEach((key) => {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    });
+    statSyncMock.mockReset();
+    // Default: no wayland socket on disk.
+    statSyncMock.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+  });
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+    ENV_KEYS.forEach((key) => {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    });
+  });
+
+  it("returns 'portal' on linux with no XDG env at all (sandbox)", () => {
+    setPlatform('linux');
+    expect(detectPickerType()).toBe('portal');
+  });
+
+  it("returns 'portal' on linux when XDG_SESSION_TYPE=wayland", () => {
+    setPlatform('linux');
+    process.env.XDG_SESSION_TYPE = 'wayland';
+    expect(detectPickerType()).toBe('portal');
+  });
+
+  it("returns 'portal' on linux when WAYLAND_DISPLAY is set and the socket exists (Flatpak-Wayland, session type stripped)", () => {
+    setPlatform('linux');
+    process.env.WAYLAND_DISPLAY = 'wayland-0';
+    process.env.XDG_RUNTIME_DIR = '/run/user/1000';
+    statSyncMock.mockImplementation((path: string) => {
+      if (path === '/run/user/1000/wayland-0') {
+        return { isSocket: () => true };
+      }
+      throw new Error('ENOENT');
+    });
+    expect(detectPickerType()).toBe('portal');
+  });
+
+  it("returns 'internal' on linux when XDG_SESSION_TYPE=x11", () => {
+    setPlatform('linux');
+    process.env.XDG_SESSION_TYPE = 'x11';
+    expect(detectPickerType()).toBe('internal');
+  });
+
+  it("returns 'internal' when ROCKETCHAT_INTERNAL_SCREEN_PICKER=1 overrides everything", () => {
+    setPlatform('linux');
+    process.env.ROCKETCHAT_INTERNAL_SCREEN_PICKER = '1';
+    process.env.XDG_SESSION_TYPE = 'wayland';
+    expect(detectPickerType()).toBe('internal');
+  });
+
+  it("returns 'internal' on darwin", () => {
+    setPlatform('darwin');
+    expect(detectPickerType()).toBe('internal');
+  });
+
+  it("returns 'internal' on win32", () => {
+    setPlatform('win32');
+    expect(detectPickerType()).toBe('internal');
+  });
+});

--- a/src/screenSharing/screenPicker/createScreenPicker.ts
+++ b/src/screenSharing/screenPicker/createScreenPicker.ts
@@ -1,21 +1,69 @@
+import fs from 'fs';
+
 import { InternalPickerProvider } from './providers/InternalPickerProvider';
 import { PortalPickerProvider } from './providers/PortalPickerProvider';
 import type { ScreenPickerProvider, ScreenPickerType } from './types';
 
-export function detectPickerType(): ScreenPickerType {
-  if (process.platform === 'linux') {
-    const sessionType = process.env.XDG_SESSION_TYPE;
-    const desktop = process.env.XDG_CURRENT_DESKTOP || '';
-
-    const isWayland = sessionType === 'wayland';
-    const hasPortal =
-      /GNOME|KDE|XFCE|Cinnamon|MATE|Pantheon|Budgie|Unity/i.test(desktop);
-
-    if (isWayland || hasPortal) {
-      return 'portal';
-    }
+// Detect a Wayland session without trusting XDG_SESSION_TYPE alone.
+// Sandboxes (Flatpak/Snap) strip XDG_SESSION_TYPE / XDG_CURRENT_DESKTOP, so we
+// fall back to confirming the Wayland socket exists on disk (same pattern used
+// by src/app/main/app.ts for the ozone platform decision).
+function isWaylandSession(): boolean {
+  if (process.env.XDG_SESSION_TYPE?.trim() === 'wayland') {
+    return true;
   }
 
+  const waylandDisplay = process.env.WAYLAND_DISPLAY?.trim();
+  if (!waylandDisplay) {
+    return false;
+  }
+
+  try {
+    const runtimeDir =
+      process.env.XDG_RUNTIME_DIR || `/run/user/${process.getuid?.() ?? 1000}`;
+    const socketPath = `${runtimeDir}/${waylandDisplay}`;
+    return fs.statSync(socketPath).isSocket();
+  } catch {
+    return false;
+  }
+}
+
+// The Linux default is 'portal', NOT 'internal'. Rationale:
+// - The app forces --enable-features=WebRTCPipeWireCapturer on ALL Linux, so on
+//   Wayland every desktopCapturer.getSources() call routes through the XDG portal
+//   and pops the system picker dialog. The internal picker warms a source cache at
+//   launch, which triggers that dialog on every startup (issue #3308).
+// - Sandboxes (Flatpak/Snap) strip XDG_SESSION_TYPE / XDG_CURRENT_DESKTOP, so
+//   env-based session sniffing cannot reliably tell Wayland from X11. Defaulting to
+//   'internal' on ambiguous env is exactly what pops the dialog on real Wayland.
+// - Worst case of defaulting to 'portal': the picker appears on user demand (correct
+//   behaviour) instead of unexpectedly at launch. So 'internal' is only chosen when
+//   we can positively confirm a silent-capable environment (pure X11 + no portal), or
+//   via the ROCKETCHAT_INTERNAL_SCREEN_PICKER escape hatch.
+export function detectPickerType(): ScreenPickerType {
+  if (process.platform === 'linux') {
+    // 1. Escape hatch — force the internal picker regardless of environment.
+    if (process.env.ROCKETCHAT_INTERNAL_SCREEN_PICKER === '1') {
+      return 'internal';
+    }
+
+    // 2. Wayland → portal (getSources cannot enumerate silently there).
+    if (isWaylandSession()) {
+      return 'portal';
+    }
+
+    // 3. Pure X11 → silent capture works, internal picker is fine.
+    //    Only chosen when the session type is positively X11; ambiguous env
+    //    (sandbox with XDG_SESSION_TYPE stripped) falls through to portal.
+    if (process.env.XDG_SESSION_TYPE?.trim() === 'x11') {
+      return 'internal';
+    }
+
+    // 4. Unknown / ambiguous / sandbox with stripped env → portal (the #3308 fix).
+    return 'portal';
+  }
+
+  // Non-Linux (darwin/win32): keep the internal picker.
   // Future: Add macOS native picker detection here
   // if (process.platform === 'darwin' && hasMacOSNativePicker()) {
   //   return 'native-macos';


### PR DESCRIPTION
## Problem

Fixes #3308 — the screen-share picker dialog ("Rocket.Chat wants to share your screen. Choose what you'd like to share.") opens automatically on **every app launch** on Linux, before any user action. Reported on Flatpak/Flathub, reproducible on 4.14.0, 4.14.1 and 4.15.0.

## Root cause

`detectPickerType()` chooses between the XDG-portal picker and the internal cached-thumbnail picker by reading `XDG_SESSION_TYPE` / `XDG_CURRENT_DESKTOP`. **Flatpak and Snap strip those variables from the sandbox environment**, so on a Wayland host the function fell through to `'internal'`.

The `InternalPickerProvider` sets `requiresCacheWarming = true`, which warms the desktopCapturer cache at `WEBVIEW_READY` via `desktopCapturer.getSources()`. Because we force `--enable-features=WebRTCPipeWireCapturer` on all Linux, `getSources()` on Wayland routes through the XDG portal and **pops the picker dialog** — at every launch, with no user involvement.

This is a picker **detection** gap, not a webapp probe: the Rocket.Chat web client does not call `getDisplayMedia()` at load (verified against the webapp call graph — the only `getDisplayMedia` is the user-gesture-gated VoIP path).

## Fix

Flip the Linux default to `'portal'` and only recover `'internal'` when a silent-capable environment can be **positively confirmed**:

1. `ROCKETCHAT_INTERNAL_SCREEN_PICKER=1` → `internal` (escape hatch for legacy X11-without-portal setups).
2. Wayland detected → `portal`. Detection no longer trusts `XDG_SESSION_TYPE` alone: it also accepts a real `WAYLAND_DISPLAY` socket on disk (`fs.statSync().isSocket()`), mirroring the ozone-platform decision in `src/app/main/app.ts`. Sandbox-safe.
3. `XDG_SESSION_TYPE=x11` → `internal` (pure X11 enumerates silently; the internal picker with cached thumbnails is preferable there).
4. Ambiguous / stripped env (sandbox) → **`portal`** — the core fix. Worst case the picker appears on user demand (correct) instead of at launch.

Non-Linux (macOS / Windows) is unchanged → `internal`.

Complements the existing `requiresCacheWarming` guard in `serverViewScreenSharing.ts`: with `portal` correctly detected, the launch-time `getSources()` prewarm never runs.

## Testing

- New `createScreenPicker.spec.ts` — 7 cases: sandbox (no env) → portal, Wayland env → portal, Flatpak-Wayland socket → portal, X11 → internal, escape hatch → internal, macOS → internal, Windows → internal.
- `npx tsc --noEmit` clean · `eslint` clean · `jest` (createScreenPicker + serverViewScreenSharing) 10/10 pass.

## Impact

GitNexus impact analysis: **LOW** risk. Only direct caller is `createScreenPicker`; return type unchanged, both consumers (`videoCallWindow/ipc.ts` main, `video-call-window.ts` renderer) already switch on `'portal' | 'internal'`.

## Note

The Flathub package (`chat.rocket.RocketChat`) is community-maintained and separate from this repo's official builds; this fix flows to the AppImage/deb/rpm/snap/flatpak artifacts produced here and downstream once released.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved screen picker selection on Linux, making the app choose the most appropriate picker more reliably across desktop and sandboxed environments.

* **Bug Fixes**
  * Reduced unexpected launch dialogs by defaulting to the portal-based picker in ambiguous Linux sessions.
  * Kept screen picker behavior unchanged on macOS and Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->