### PR TITLE
fix(dev): stop dev watch restart from freezing the old window

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -19,6 +19,39 @@ const canRun =
 // Single shared controller across all bundle configs. Because `rollup -c -w`
 // rebuilds multiple bundles on one file save, the restart is debounced so the
 // whole save-batch finishes writing, then the app restarts exactly once.
+const DEV_INSPECT_PORT = 9339;
+
+// OS signals don't reach Electron's app.quit() on macOS (SIGTERM is a no-op
+// there), so a graceful shutdown has to go through the Node inspector
+// protocol instead. Returns true once app.quit() was successfully requested.
+const requestGracefulQuit = async () => {
+  try {
+    const res = await fetch(`http://127.0.0.1:${DEV_INSPECT_PORT}/json/list`);
+    const [{ webSocketDebuggerUrl }] = await res.json();
+    const ws = new WebSocket(webSocketDebuggerUrl);
+    await new Promise((resolve, reject) => {
+      ws.onopen = resolve;
+      ws.onerror = reject;
+    });
+    ws.send(
+      JSON.stringify({
+        id: 1,
+        method: 'Runtime.evaluate',
+        params: {
+          expression: "process.mainModule.require('electron').app.quit()",
+        },
+      })
+    );
+    await new Promise((resolve) => {
+      ws.onmessage = resolve;
+    });
+    ws.close();
+    return true;
+  } catch {
+    return false; // inspector unreachable — process likely never finished booting
+  }
+};
+
 const electronRunner = (() => {
   let proc = null;
   let restartTimer = null;
@@ -32,7 +65,23 @@ const electronRunner = (() => {
     const current = proc;
     proc = null;
     const closed = new Promise((resolve) => current.once('close', resolve));
-    current.kill('SIGKILL'); // SIGKILL bypasses the app's tray/before-quit guards
+
+    // Try a graceful app.quit() first so Electron closes windows through its
+    // normal lifecycle. Skipping straight to SIGKILL leaves a stale
+    // composited frame on screen — the OS window compositor never gets the
+    // close/orderOut call, so the old window appears frozen/white while the
+    // new one is either hidden behind it or never gets focus.
+    if (await requestGracefulQuit()) {
+      const result = await Promise.race([
+        closed.then(() => 'closed'),
+        new Promise((resolve) => setTimeout(() => resolve('timeout'), 2500)),
+      ]);
+      if (result === 'closed') {
+        return;
+      }
+    }
+
+    current.kill('SIGKILL'); // fallback: never hang the watcher
     await Promise.race([
       closed,
       new Promise((resolve) => setTimeout(resolve, 3000)), // never hang the watcher
@@ -51,7 +100,7 @@ const electronRunner = (() => {
       );
       hasStarted = true;
 
-      const electronArgs = ['.'];
+      const electronArgs = [`--inspect=${DEV_INSPECT_PORT}`, '.'];
 
       // Linux-specific flags for development
       if (process.platform === 'linux') {

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -21,36 +21,55 @@ const canRun =
 // whole save-batch finishes writing, then the app restarts exactly once.
 const DEV_INSPECT_PORT = 9339;
 
+const GRACEFUL_QUIT_REQUEST_TIMEOUT_MS = 2000;
+
 // OS signals don't reach Electron's app.quit() on macOS (SIGTERM is a no-op
 // there), so a graceful shutdown has to go through the Node inspector
-// protocol instead. Returns true once app.quit() was successfully requested.
-const requestGracefulQuit = async () => {
-  try {
-    const res = await fetch(`http://127.0.0.1:${DEV_INSPECT_PORT}/json/list`);
-    const [{ webSocketDebuggerUrl }] = await res.json();
-    const ws = new WebSocket(webSocketDebuggerUrl);
-    await new Promise((resolve, reject) => {
-      ws.onopen = resolve;
-      ws.onerror = reject;
-    });
-    ws.send(
-      JSON.stringify({
-        id: 1,
-        method: 'Runtime.evaluate',
-        params: {
-          expression: "process.mainModule.require('electron').app.quit()",
-        },
-      })
-    );
-    await new Promise((resolve) => {
-      ws.onmessage = resolve;
-    });
-    ws.close();
-    return true;
-  } catch {
-    return false; // inspector unreachable — process likely never finished booting
-  }
-};
+// protocol instead. Bounded by its own timeout so a hung fetch/WebSocket
+// handshake can't block killProc() from ever reaching its SIGKILL fallback.
+// Resolves true once app.quit() was acknowledged by the process.
+const requestGracefulQuit = () =>
+  new Promise((resolve) => {
+    let settled = false;
+    let ws;
+    let timer;
+    const finish = (result) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      ws?.close();
+      resolve(result);
+    };
+
+    timer = setTimeout(() => finish(false), GRACEFUL_QUIT_REQUEST_TIMEOUT_MS);
+
+    (async () => {
+      try {
+        const res = await fetch(
+          `http://127.0.0.1:${DEV_INSPECT_PORT}/json/list`
+        );
+        const [{ webSocketDebuggerUrl }] = await res.json();
+        ws = new WebSocket(webSocketDebuggerUrl);
+        ws.onerror = () => finish(false);
+        ws.onopen = () => {
+          ws.send(
+            JSON.stringify({
+              id: 1,
+              method: 'Runtime.evaluate',
+              params: {
+                expression: "process.mainModule.require('electron').app.quit()",
+              },
+            })
+          );
+        };
+        ws.onmessage = () => finish(true);
+      } catch {
+        finish(false); // inspector unreachable — process likely never finished booting
+      }
+    })();
+  });
 
 const electronRunner = (() => {
   let proc = null;

--- a/src/ui/main/rootWindow.ts
+++ b/src/ui/main/rootWindow.ts
@@ -56,7 +56,6 @@ const selectRootWindowState = ({ rootWindowState }: RootState): WindowState =>
 
 let _rootWindow: BrowserWindow;
 let tempWindow: BrowserWindow;
-let isAppQuitting = false;
 
 export const getRootWindow = (): Promise<BrowserWindow> =>
   new Promise((resolve, reject) => {
@@ -351,16 +350,21 @@ export const setupRootWindow = (): void => {
       rootWindow.flashFrame(false);
     });
 
-    rootWindow.addListener('close', (event) => {
-      // Let Electron destroy the window when the app is quitting; never
-      // preventDefault or hide here or the quit wedges into an ANR.
-      if (isAppQuitting) {
-        return;
-      }
-
+    rootWindow.addListener('close', async (event) => {
       try {
         if (rootWindow.isDestroyed()) {
           return;
+        }
+
+        if (rootWindow.isFullScreen()) {
+          await new Promise<void>((resolve) =>
+            rootWindow.once('leave-full-screen', () => resolve())
+          );
+          rootWindow.setFullScreen(false);
+        }
+
+        if (process.platform !== 'linux' && !rootWindow.isDestroyed()) {
+          rootWindow.blur();
         }
 
         let isTrayIconEnabled: boolean;
@@ -383,20 +387,16 @@ export const setupRootWindow = (): void => {
         }
 
         if (process.platform === 'darwin' || isTrayIconEnabled) {
-          event.preventDefault();
-          if (rootWindow.isFullScreen()) {
-            rootWindow.setFullScreen(false);
+          if (!rootWindow.isDestroyed()) {
+            rootWindow.hide();
           }
-          if (process.platform !== 'linux') {
-            rootWindow.blur();
-          }
-          rootWindow.hide();
           return;
         }
 
         if (process.platform === 'win32' && isMinimizeOnCloseEnabled) {
-          event.preventDefault();
-          rootWindow.minimize();
+          if (!rootWindow.isDestroyed()) {
+            rootWindow.minimize();
+          }
           return;
         }
 
@@ -523,7 +523,6 @@ export const setupRootWindow = (): void => {
   }
 
   app.addListener('before-quit', () => {
-    isAppQuitting = true;
     unsubscribers.forEach((unsubscriber) => {
       try {
         unsubscriber();

--- a/src/ui/main/rootWindow.ts
+++ b/src/ui/main/rootWindow.ts
@@ -56,6 +56,7 @@ const selectRootWindowState = ({ rootWindowState }: RootState): WindowState =>
 
 let _rootWindow: BrowserWindow;
 let tempWindow: BrowserWindow;
+let isAppQuitting = false;
 
 export const getRootWindow = (): Promise<BrowserWindow> =>
   new Promise((resolve, reject) => {
@@ -350,21 +351,16 @@ export const setupRootWindow = (): void => {
       rootWindow.flashFrame(false);
     });
 
-    rootWindow.addListener('close', async (event) => {
+    rootWindow.addListener('close', (event) => {
+      // Let Electron destroy the window when the app is quitting; never
+      // preventDefault or hide here or the quit wedges into an ANR.
+      if (isAppQuitting) {
+        return;
+      }
+
       try {
         if (rootWindow.isDestroyed()) {
           return;
-        }
-
-        if (rootWindow.isFullScreen()) {
-          await new Promise<void>((resolve) =>
-            rootWindow.once('leave-full-screen', () => resolve())
-          );
-          rootWindow.setFullScreen(false);
-        }
-
-        if (process.platform !== 'linux' && !rootWindow.isDestroyed()) {
-          rootWindow.blur();
         }
 
         let isTrayIconEnabled: boolean;
@@ -387,16 +383,20 @@ export const setupRootWindow = (): void => {
         }
 
         if (process.platform === 'darwin' || isTrayIconEnabled) {
-          if (!rootWindow.isDestroyed()) {
-            rootWindow.hide();
+          event.preventDefault();
+          if (rootWindow.isFullScreen()) {
+            rootWindow.setFullScreen(false);
           }
+          if (process.platform !== 'linux') {
+            rootWindow.blur();
+          }
+          rootWindow.hide();
           return;
         }
 
         if (process.platform === 'win32' && isMinimizeOnCloseEnabled) {
-          if (!rootWindow.isDestroyed()) {
-            rootWindow.minimize();
-          }
+          event.preventDefault();
+          rootWindow.minimize();
           return;
         }
 
@@ -523,6 +523,7 @@ export const setupRootWindow = (): void => {
   }
 
   app.addListener('before-quit', () => {
+    isAppQuitting = true;
     unsubscribers.forEach((unsubscriber) => {
       try {
         unsubscriber();


### PR DESCRIPTION
## Summary
Fixes the dev-mode issue where saving a code change under `yarn start` leaves the old Electron window frozen/white and no new window appears, requiring a manual force-quit.

**Root cause**: the watch-mode restart controller (`rollup.config.mjs`) SIGKILLed the previous Electron process on every rebuild — the only reliable option, since macOS ignores `SIGTERM` for this unsigned dev binary and Apple Events routed to it are unreliable across repeated relaunches. SIGKILL never lets the app close its windows through Electron's normal lifecycle, so macOS WindowServer keeps the last composited frame on screen as a stale/frozen image while the new instance is hidden behind it or never gets focus.

**Fix**: the dev process now launches with `--inspect`, and on restart the old process is asked to `app.quit()` in-process via the Node inspector protocol first (bounded to 2.5s), falling back to `SIGKILL` only if that doesn't complete — preserving the original anti-hang guarantee while letting windows close cleanly.

Note: an earlier commit on this branch also touched `src/ui/main/rootWindow.ts` (an `isAppQuitting` guard inherited from an in-progress, unvalidated change). It broke 4 existing tests in `rootWindow.spec.ts` and was reverted in a follow-up commit — the validated fix is `rollup.config.mjs` alone.

## Test plan
- [x] `npx eslint` — no issues
- [x] `npx tsc --noEmit` — no errors
- [x] `npx jest src/ui/main/rootWindow.spec.ts` — 16/16 pass
- [x] Verified via CDP that raw `kill -TERM` and macOS Apple Event quit both fail to reach `before-quit` on this dev binary (0% CPU, idle) — confirms `SIGKILL` was previously the only working option
- [x] Verified the graceful-quit-then-SIGKILL-fallback path over 4 separate restart cycles (single edit, rapid 150ms-apart saves, 3 sequential edits) — each produced exactly one clean PID transition, no orphaned or duplicate processes
- [ ] Manual smoke test in a real dev session with a logged-in server (this fix was validated against a blank/no-login dev instance)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Electron app shutdown during development, making it more likely to close cleanly before forcing termination.
  * Reduced the chance of the dev process hanging by adding timeout safeguards if shutdown takes too long.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->