### PR TITLE
Fix stale supported-versions cache outranking fresh builtin fallback

### DIFF
--- a/src/servers/supportedVersions/main.main.spec.ts
+++ b/src/servers/supportedVersions/main.main.spec.ts
@@ -1339,6 +1339,98 @@ describe('supportedVersions/main.ts', () => {
       expect(errorDispatch).toBeDefined();
     });
 
+    it('prefers builtin over cache when cache is older than builtin (stale-cache-after-update guard)', async () => {
+      // Regression test for #3385: a cache entry written by an older app
+      // version (before the server's version was added to the supported
+      // list) must not permanently outrank a freshly-bundled builtin list
+      // that already supports it. Uses jest.isolateModules for a fresh
+      // builtinSupportedVersions singleton, same as the no-data-anywhere test.
+      await jest.isolateModulesAsync(async () => {
+        jest.mock('../../store');
+        jest.mock('axios');
+        jest.mock('jsonwebtoken');
+        jest.mock('electron-store');
+        jest.mock('node:fs/promises');
+        jest.mock('electron', () => ({
+          ipcMain: { handle: jest.fn() },
+        }));
+
+        const { dispatch: isolatedDispatch, select: isolatedSelect } =
+          await import('../../store');
+        const isolatedAxios = (await import('axios')).default;
+        const isolatedJwt = await import('jsonwebtoken');
+        const { updateSupportedVersionsData: isolatedUpdate } = await import(
+          './main'
+        );
+        const isolatedFs = await import('node:fs/promises');
+
+        const isolatedDispatchMock = isolatedDispatch as jest.MockedFunction<
+          typeof isolatedDispatch
+        >;
+        const isolatedSelectMock = isolatedSelect as jest.MockedFunction<
+          typeof isolatedSelect
+        >;
+        const isolatedAxiosMock = isolatedAxios as jest.Mocked<
+          typeof isolatedAxios
+        >;
+
+        const IsolatedElectronStoreMock = jest.requireMock('electron-store');
+        const isolatedStoreGetMock = jest.spyOn(
+          IsolatedElectronStoreMock.prototype,
+          'get'
+        ) as jest.Mock;
+
+        const mockServer = createMockServer({ version: '8.5.1' });
+        isolatedSelectMock.mockReturnValue(mockServer);
+        isolatedAxiosMock.get = jest
+          .fn()
+          .mockRejectedValue(new Error('Network error'));
+
+        const futureExpiry = new Date(Date.now() + 86400000 * 365);
+
+        // Stale cache: written long ago, does not know about 8.5 -> unsupported.
+        const staleCachedVersions = createMockSupportedVersions({
+          versions: [{ version: '7.0.0', expiration: futureExpiry }],
+          enforcementStartDate: '2023-01-01T00:00:00Z',
+          timestamp: '2020-01-01T00:00:00Z',
+        });
+        isolatedStoreGetMock.mockReturnValue(staleCachedVersions);
+
+        // Fresh builtin: bundled with the current app version, knows 8.5 is supported.
+        const freshBuiltinVersions = createMockSupportedVersions({
+          versions: [{ version: '8.5.0', expiration: futureExpiry }],
+          enforcementStartDate: '2023-01-01T00:00:00Z',
+          timestamp: new Date().toISOString(),
+        });
+        (isolatedFs.readFile as jest.Mock).mockResolvedValue(
+          'builtin-jwt-token'
+        );
+        (isolatedJwt.verify as jest.Mock).mockReturnValue(freshBuiltinVersions);
+
+        jest.useFakeTimers();
+        const promise = isolatedUpdate(mockServer.url);
+        await jest.advanceTimersByTimeAsync(4000);
+        await promise;
+        jest.useRealTimers();
+
+        const isSupportedDispatch = isolatedDispatchMock.mock.calls.find(
+          ([action]) =>
+            (action as any).type === WEBVIEW_SERVER_IS_SUPPORTED_VERSION
+        );
+        expect(isSupportedDispatch).toBeDefined();
+        // Must be true — proves the fresher builtin data won over the stale cache.
+        expect(
+          (isSupportedDispatch?.[0] as any)?.payload?.isSupportedVersion
+        ).toBe(true);
+
+        const updatedDispatch = isolatedDispatchMock.mock.calls.find(
+          ([action]) =>
+            (action as any).type === WEBVIEW_SERVER_SUPPORTED_VERSIONS_UPDATED
+        );
+        expect((updatedDispatch?.[0] as any)?.payload?.source).toBe('builtin');
+      });
+    });
+
     it('cache fallback uses freshly-fetched server version, not stale persisted version', async () => {
       // Persisted server.version is stale ("7.5.0"); /api/info returns FRESH 8.5.
       // server-side signed payload missing -> falls through to cloud -> cloud fails -> cache.

--- a/src/servers/supportedVersions/main.ts
+++ b/src/servers/supportedVersions/main.ts
@@ -90,6 +90,13 @@ const logRequestError =
 const getCacheKey = (serverUrl: string): string =>
   `supportedVersions:${serverUrl}`;
 
+// Missing/malformed timestamps sort as the oldest possible value, so a source
+// with no usable timestamp never wins a freshness comparison it shouldn't.
+const parseTimestamp = (value?: string): number => {
+  const time = value ? Date.parse(value) : NaN;
+  return Number.isNaN(time) ? 0 : time;
+};
+
 const loadFromCache = (serverUrl: string): SupportedVersions | undefined => {
   try {
     const cached = supportedVersionsStore.get(getCacheKey(serverUrl));
@@ -644,40 +651,31 @@ export const updateSupportedVersionsData = async (
     }
   }
 
-  // Try to load from cache
+  // Neither the server nor the cloud could be reached. Pick the freshest of
+  // the two remaining sources by `timestamp` instead of always trusting the
+  // cache: a persisted cache entry can predate the app's own bundled builtin
+  // data (e.g. right after an app update ships a refreshed builtin list), in
+  // which case trusting the stale cache indefinitely blocks servers the new
+  // builtin already recognizes as supported.
   const cachedVersions = loadFromCache(serverUrl);
-  if (cachedVersions) {
-    if (isStale()) return;
-    const cachedSupported = await isServerVersionSupported(
-      serverWithFreshIdentity,
-      cachedVersions,
-      freshCommitHash
-    );
-    if (isStale()) return;
-    dispatch({
-      type: WEBVIEW_SERVER_IS_SUPPORTED_VERSION,
-      payload: {
-        url: server.url,
-        isSupportedVersion: cachedSupported.supported,
-      },
-    });
-    dispatchSupportedVersionsUpdated(server.url, cachedVersions, {
-      source: 'cloud',
-    });
-    dispatch({
-      type: WEBVIEW_SERVER_SUPPORTED_VERSIONS_ERROR,
-      payload: { url: serverUrl },
-    });
-    return;
-  }
+  const useBuiltinOverCache =
+    !!builtinSupportedVersions &&
+    (!cachedVersions ||
+      parseTimestamp(builtinSupportedVersions.timestamp) >
+        parseTimestamp(cachedVersions.timestamp));
+  const fallbackVersions = useBuiltinOverCache
+    ? builtinSupportedVersions
+    : cachedVersions;
+  const fallbackSource: 'cloud' | 'builtin' = useBuiltinOverCache
+    ? 'builtin'
+    : 'cloud';
 
-  // Fall back to builtin (always available)
-  if (builtinSupportedVersions) {
+  if (fallbackVersions) {
     if (isStale()) return;
-    saveToCache(serverUrl, builtinSupportedVersions);
-    const builtinSupported = await isServerVersionSupported(
+    saveToCache(serverUrl, fallbackVersions);
+    const fallbackSupported = await isServerVersionSupported(
       serverWithFreshIdentity,
-      builtinSupportedVersions,
+      fallbackVersions,
       freshCommitHash
     );
     if (isStale()) return;
@@ -685,11 +683,11 @@ export const updateSupportedVersionsData = async (
       type: WEBVIEW_SERVER_IS_SUPPORTED_VERSION,
       payload: {
         url: server.url,
-        isSupportedVersion: builtinSupported.supported,
+        isSupportedVersion: fallbackSupported.supported,
       },
     });
-    dispatchSupportedVersionsUpdated(server.url, builtinSupportedVersions, {
-      source: 'builtin',
+    dispatchSupportedVersionsUpdated(server.url, fallbackVersions, {
+      source: fallbackSource,
     });
     dispatch({
       type: WEBVIEW_SERVER_SUPPORTED_VERSIONS_ERROR,


### PR DESCRIPTION
## Summary

Fixes #3385. Server on a fully supported version (8.5.1 LTS) got permanently blocked with "unsupported version" on 4.15.0. Workaround reported by user: deleting `AppData\Roaming\Rocket.Chat` (the app's userData/cache dir) fixed it.

Root cause: in `updateSupportedVersionsData` (`src/servers/supportedVersions/main.ts`), when both the server-embedded and cloud supported-versions fetches fail, the fallback chain picked the persisted disk cache unconditionally over the app's own bundled builtin list. A cache entry written by an older app version — before the server's version was added to the supported list — permanently outranks a freshly-shipped builtin list that already supports it, with no TTL or freshness check. The `SupportedVersions.timestamp` field exists specifically for this purpose but was never read.

## What changed

- Compare `timestamp` on the cached payload vs the builtin payload and use whichever is more recent, instead of a fixed cache-first priority.
- Added `parseTimestamp` helper: missing/invalid timestamps sort as oldest, so a corrupt timestamp can't spuriously win the comparison.
- Collapsed the previously-duplicated cache/builtin dispatch blocks into one, since they now share the same fallback path.

Not touched: the exception/version-matching logic from #3323 (still correct), and #3371 (role-targeted messages, unrelated to the block verdict).

## Test plan

- [x] Added regression test: stale cache (old timestamp, would incorrectly mark 8.5.1 unsupported) + fresh builtin (correct timestamp, marks it supported) + failed server/cloud fetch → verdict follows builtin, not cache.
- [x] Full `main.main.spec.ts` suite passes (77/77).
- [x] `eslint` clean on both changed files.
- [x] `tsc --noEmit` shows no new errors introduced by this change (14 pre-existing errors in the worktree are unrelated React 18/19 type mismatches, confirmed present with `git stash`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback behavior for supported-version checks when live data can’t be reached.
  * The app now prefers the freshest available source between cached and built-in version data, avoiding stale results after updates.
  * Missing or invalid timestamps are handled safely so older data won’t override newer information.
  * Updated status notifications now reflect whether the chosen data came from built-in or cloud sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->