### PR TITLE
chore: bump version to 4.15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "Rocket.Chat",
   "name": "rocketchat",
   "description": "Official OSX, Windows, and Linux Desktop Clients for Rocket.Chat",
-  "version": "4.15.0",
+  "version": "4.15.1",
   "author": "Rocket.Chat Support <support@rocket.chat>",
   "copyright": "© 2016-2026, Rocket.Chat",
   "homepage": "https://rocket.chat",


### PR DESCRIPTION
## Summary
Version bump for 4.15.1 patch release, bundling four fixes already merged to master:

- #3296 — fix: handle unhandled promise rejections in auto-updater (CORE-2368)
- #3379 — fix: stop server sidebar tile rendering a literal "0" badge (CORE-2369)
- #3386 — fix: detect screen picker type reliably inside sandboxes (#3308) (CORE-2365)
- #3388 — fix: stale supported-versions cache outranking fresh builtin fallback, fixes #3385 (CORE-2367)

## Test plan
- [x] All four fixes merged to master with green CI
- [x] `package.json` version bumped 4.15.0 → 4.15.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the app version from 4.15.0 to 4.15.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->