### PR TITLE
chore: bump version to 4.15.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "Rocket.Chat",
   "name": "rocketchat",
   "description": "Official OSX, Windows, and Linux Desktop Clients for Rocket.Chat",
-  "version": "4.15.1",
+  "version": "4.15.2",
   "author": "Rocket.Chat Support <support@rocket.chat>",
   "copyright": "© 2016-2026, Rocket.Chat",
   "homepage": "https://rocket.chat",


### PR DESCRIPTION
Release 4.15.2.

## Ships
- feat: Click-to-Call telephony + internal video chat session sharing (#3370)

## Release notes
### ✨ Improvements
- **Click-to-Call telephony** — click `tel:`/`callto:` links in any app to open Rocket.Chat with the number ready to dial. Master toggle in Settings › Voice & Video, global dial shortcut, multi-workspace routing, default-handler diagnostics. Opt-in (off by default).
- **Internal video chat session sharing** — internal conference windows share the main webview session so same-origin calls load authenticated. Hardened screen-share routing, per-window call state, lifecycle bridges, external-link routing to system browser.

### 🔧 Internal
- Settings panel grouped into sections with a dedicated Voice & Video tab (CORE-2201 UX rewrite).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app version to 4.15.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->