### PR TITLE
security(CORE-1121): bind geolocation/notifications/fullscreen permissions to known server origin

### DIFF
--- a/src/ui/main/serverView/index.ts
+++ b/src/ui/main/serverView/index.ts
@@ -105,6 +105,36 @@ const resolvePreloadPath = (isVideoCall: boolean): string | null => {
   return null;
 };
 
+/**
+ * Determines if a permission request's origin matches a configured server.
+ * Used to gate permissions (geolocation, notifications, fullscreen) that
+ * Electron would otherwise grant unconditionally, regardless of which
+ * origin — including a compromised or unexpected one — asked for them.
+ */
+export const isRequestFromKnownServer = (
+  requestingUrl: string | undefined,
+  servers: ReadonlyArray<Pick<Server, 'url'>>
+): boolean => {
+  if (!requestingUrl) {
+    return false;
+  }
+  try {
+    const requestingOrigin = new URL(requestingUrl).origin;
+    return servers.some((server) => {
+      if (!server.url) {
+        return false;
+      }
+      try {
+        return new URL(server.url).origin === requestingOrigin;
+      } catch {
+        return false;
+      }
+    });
+  } catch {
+    return false;
+  }
+};
+
 export const getWebContentsByServerUrl = (
   url: string
 ): WebContents | undefined => webContentsByServerUrl.get(url);
@@ -150,13 +180,19 @@ export const setupServerViewPermissionHandler = (
           return;
         }
 
-        case 'geolocation':
-        case 'notifications':
         case 'midiSysex':
         case 'pointerLock':
-        case 'fullscreen':
           callback(true);
           return;
+
+        case 'geolocation':
+        case 'notifications':
+        case 'fullscreen': {
+          const { requestingUrl } = details;
+          const servers = select(({ servers }) => servers);
+          callback(isRequestFromKnownServer(requestingUrl, servers));
+          return;
+        }
 
         case 'openExternal': {
           const { externalURL } = details as OpenExternalPermissionRequest;

--- a/src/ui/main/serverView/isRequestFromKnownServer.main.spec.ts
+++ b/src/ui/main/serverView/isRequestFromKnownServer.main.spec.ts
@@ -1,0 +1,58 @@
+import { isRequestFromKnownServer } from './index';
+
+describe('isRequestFromKnownServer', () => {
+  const servers = [
+    { url: 'https://chat.example.com' },
+    { url: 'https://other.example.com/' },
+  ];
+
+  it('allows a requesting URL whose origin matches a configured server', () => {
+    expect(
+      isRequestFromKnownServer('https://chat.example.com/some/path', servers)
+    ).toBe(true);
+  });
+
+  it('allows a match even when the configured server URL has a trailing slash', () => {
+    expect(
+      isRequestFromKnownServer('https://other.example.com/x', servers)
+    ).toBe(true);
+  });
+
+  it('denies a requesting URL whose origin is not configured', () => {
+    expect(isRequestFromKnownServer('https://evil.example.com', servers)).toBe(
+      false
+    );
+  });
+
+  it('denies when requestingUrl is undefined', () => {
+    expect(isRequestFromKnownServer(undefined, servers)).toBe(false);
+  });
+
+  it('denies when requestingUrl is not a valid URL', () => {
+    expect(isRequestFromKnownServer('not-a-url', servers)).toBe(false);
+  });
+
+  it('denies when there are no configured servers', () => {
+    expect(isRequestFromKnownServer('https://chat.example.com', [])).toBe(
+      false
+    );
+  });
+
+  it('skips a configured server with an empty url without throwing', () => {
+    expect(
+      isRequestFromKnownServer('https://chat.example.com', [
+        { url: '' },
+        ...servers,
+      ])
+    ).toBe(true);
+  });
+
+  it('skips a configured server with an invalid url without throwing', () => {
+    expect(
+      isRequestFromKnownServer('https://chat.example.com', [
+        { url: 'not-a-url' },
+        ...servers,
+      ])
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- `geolocation`, `notifications`, and `fullscreen` permission requests in the server webview were granted unconditionally (`callback(true)`) regardless of the requesting origin.
- Added `isRequestFromKnownServer(requestingUrl, servers)` in `src/ui/main/serverView/index.ts`, validating the request's origin against the app's configured server list — same origin-binding pattern already used by `isServerWebview` in `src/ipc/validateSender.ts`.
- `media` and `openExternal` permissions already had proper validation and are unchanged. `midiSysex`/`pointerLock` remain unconditionally allowed (low-risk, out of scope for CORE-1121).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `yarn eslint` clean on changed files
- [x] New unit tests in `isRequestFromKnownServer.main.spec.ts` (8 cases: known origin match, trailing-slash server URL, unknown origin, undefined/invalid requestingUrl, empty server list, malformed server URLs in the list) — all passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Permission prompts in the server view now only approve sensitive browser permissions for trusted server origins.
  * Requests with missing, invalid, or unrecognized URLs are now denied more safely.
  * Server URLs with formatting differences like trailing slashes are handled correctly.
* **Tests**
  * Added coverage for allowed and denied permission requests, including invalid and empty server URL cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->