### PR TITLE
security(CORE-1123): block non-http(s) main-frame navigation in server webview

### DIFF
--- a/src/ui/main/serverView/index.spec.ts
+++ b/src/ui/main/serverView/index.spec.ts
@@ -1,0 +1,156 @@
+import type { Event, WebContents } from 'electron';
+
+import { isProtocolAllowed } from '../../../navigation/main';
+import { listen } from '../../../store';
+import { openExternal } from '../../../utils/browserLauncher';
+import { WEBVIEW_READY } from '../../actions';
+import { attachGuestWebContentsEvents } from './index';
+
+jest.mock('electron', () => ({
+  app: {
+    userAgentFallback: 'test-agent',
+    name: 'Rocket.Chat',
+    getVersion: jest.fn(() => '1.0.0'),
+  },
+  clipboard: { writeText: jest.fn() },
+  Menu: { buildFromTemplate: jest.fn(() => ({ popup: jest.fn() })) },
+  webContents: { fromId: jest.fn() },
+}));
+
+jest.mock('../../../app/main/dev', () => ({
+  setupPreloadReload: jest.fn(),
+}));
+
+jest.mock('../../../ipc/main', () => ({
+  handle: jest.fn(),
+}));
+
+jest.mock('../../../navigation/main', () => ({
+  isProtocolAllowed: jest.fn(),
+}));
+
+jest.mock('../../../screenSharing/serverViewScreenSharing', () => ({
+  setupServerViewDisplayMedia: jest.fn(),
+}));
+
+jest.mock('../../../store', () => ({
+  dispatch: jest.fn(),
+  listen: jest.fn(),
+  select: jest.fn(),
+}));
+
+jest.mock('../../../utils/browserLauncher', () => ({
+  openExternal: jest.fn(),
+}));
+
+jest.mock('../mediaPermissions', () => ({
+  handleMediaPermissionRequest: jest.fn(),
+}));
+
+jest.mock('../rootWindow', () => ({
+  getRootWindow: jest.fn(() =>
+    Promise.resolve({
+      webContents: { addListener: jest.fn() },
+    })
+  ),
+}));
+
+jest.mock('./popupMenu', () => ({
+  createPopupMenuForServerView: jest.fn(),
+}));
+
+describe('serverView attachGuestWebContentsEvents will-navigate guard', () => {
+  const mockIsProtocolAllowed = isProtocolAllowed as jest.MockedFunction<
+    typeof isProtocolAllowed
+  >;
+  const mockOpenExternal = openExternal as jest.MockedFunction<
+    typeof openExternal
+  >;
+  const mockListen = listen as unknown as jest.Mock;
+
+  let willNavigateHandler: (event: Event, url: string) => void;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockIsProtocolAllowed.mockResolvedValue(true);
+
+    await attachGuestWebContentsEvents();
+
+    const webviewReadyCall = mockListen.mock.calls.find(
+      ([actionType]) => actionType === WEBVIEW_READY
+    );
+    const webviewReadyCallback = webviewReadyCall?.[1] as (
+      action: unknown
+    ) => void;
+
+    const guestWebContents = {
+      addListener: jest.fn(),
+      on: jest.fn((event: string, handler: any) => {
+        if (event === 'will-navigate') {
+          willNavigateHandler = handler;
+        }
+      }),
+      setWindowOpenHandler: jest.fn(),
+      session: { setPermissionRequestHandler: jest.fn() },
+    } as unknown as WebContents;
+
+    (
+      jest.requireMock('electron').webContents.fromId as jest.Mock
+    ).mockReturnValue(guestWebContents);
+
+    webviewReadyCallback({
+      payload: { webContentsId: 1, url: 'https://open.rocket.chat' },
+    });
+  });
+
+  const createEvent = (): Event =>
+    ({ preventDefault: jest.fn() }) as unknown as Event;
+
+  it('allows http navigation', () => {
+    const event = createEvent();
+    willNavigateHandler(event, 'http://open.rocket.chat/page');
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('allows https navigation', () => {
+    const event = createEvent();
+    willNavigateHandler(event, 'https://open.rocket.chat/page');
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('denies file:// navigation', () => {
+    const event = createEvent();
+    willNavigateHandler(event, 'file:///etc/passwd');
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it('denies navigation to an unknown/custom scheme', () => {
+    const event = createEvent();
+    willNavigateHandler(event, 'custom-scheme://payload');
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it('still prevents and opens t.co links externally when allowed', async () => {
+    const event = createEvent();
+    willNavigateHandler(event, 'https://t.co/abc123');
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockIsProtocolAllowed).toHaveBeenCalledWith('https://t.co/abc123');
+    expect(mockOpenExternal).toHaveBeenCalledWith('https://t.co/abc123');
+  });
+
+  it('does not open externally when protocol is not allowed for t.co links', async () => {
+    mockIsProtocolAllowed.mockResolvedValueOnce(false);
+    const event = createEvent();
+    willNavigateHandler(event, 'https://twitter.com/some/status');
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockOpenExternal).not.toHaveBeenCalled();
+  });
+});

--- a/src/ui/main/serverView/index.ts
+++ b/src/ui/main/serverView/index.ts
@@ -484,9 +484,16 @@ export const attachGuestWebContentsEvents = async (): Promise<void> => {
 
     // prevents the webview from navigating because of twitter preview links
     guestWebContents.on('will-navigate', (e, redirectUrl) => {
+      const { protocol, hostname } = new URL(redirectUrl);
+
+      if (protocol !== 'http:' && protocol !== 'https:') {
+        e.preventDefault();
+        return;
+      }
+
       const preventNavigateHosts = ['t.co', 'twitter.com'];
 
-      if (preventNavigateHosts.includes(new URL(redirectUrl).hostname)) {
+      if (preventNavigateHosts.includes(hostname)) {
         e.preventDefault();
         isProtocolAllowed(redirectUrl).then((allowed) => {
           if (!allowed) {


### PR DESCRIPTION
## Summary
- CORE-1123 (2022 pentest finding: Missing File Handler Protections). The server webview's `will-navigate` handler only special-cased `t.co`/`twitter.com` redirects — a main-frame navigation to a non-web scheme (e.g. `file://`) inside the webview had no explicit guard.
- Deep links, downloads, and popup/new-window navigation already had proper validation (`parseDeepLink`, electron-dl Save-As flow, `setWindowOpenHandler`/`isProtocolAllowed`) — untouched, out of scope.
- Drag-and-drop file validation and download file-type filtering were evaluated and intentionally NOT added: the guest webview runs with `nodeIntegration=false`/`contextIsolation=true`/`webSecurity=true`, so these vectors don't apply to this app's threat model — adding them would be defending against attacks that can't reach the filesystem or Node from here.
- Fix: `will-navigate` now `preventDefault()`s any main-frame navigation whose protocol isn't `http:`/`https:`, before the existing t.co/twitter external-open logic runs. Reuses the existing `new URL()` parse (no duplicate parsing).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `yarn eslint` clean
- [x] New spec (`src/ui/main/serverView/index.spec.ts`, 6 cases): http allowed, https allowed, file:// denied, unknown scheme denied, t.co external-open preserved (allowed + denied-by-isProtocolAllowed paths) — all passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webview link handling so only safe `http` and `https` navigations proceed.
  * Blocked unsupported protocols and custom schemes from opening inside the embedded view.
  * Twitter preview links now open externally when allowed, instead of navigating within the app.
  * Added test coverage for allowed and blocked navigation paths to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->