### PR TITLE
security(CORE-1130): clear session data on logout transition

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -38,7 +38,10 @@ import { setupOutlookLogger } from './outlookCalendar/logger';
 import { handleDesktopCapturerGetSources } from './screenSharing/desktopCapturerCache';
 import { setupScreenSharing } from './screenSharing/main';
 import { startServerViewScreenSharingHandler } from './screenSharing/serverViewScreenSharing';
-import { handleClearCacheDialog } from './servers/cache';
+import {
+  handleClearCacheDialog,
+  handleUserLoggedOutDataClearing,
+} from './servers/cache';
 import { setupServers } from './servers/main';
 import { checkSupportedVersionServers } from './servers/supportedVersions/main';
 import { setupSpellChecking } from './spellChecking/main';
@@ -155,6 +158,7 @@ const start = async (): Promise<void> => {
   handleJitsiDesktopCapturerGetSources();
   handleDesktopCapturerGetSources();
   handleClearCacheDialog();
+  handleUserLoggedOutDataClearing();
   startDocumentViewerHandler();
   startBrowserHandler();
   checkSupportedVersionServers();

--- a/src/servers/cache.ts
+++ b/src/servers/cache.ts
@@ -4,7 +4,10 @@ import { listen } from '../store';
 import {
   CLEAR_CACHE_DIALOG_DELETE_LOGIN_DATA_CLICKED,
   CLEAR_CACHE_DIALOG_KEEP_LOGIN_DATA_CLICKED,
+  WEBVIEW_USER_LOGGED_IN,
 } from '../ui/actions';
+import { getWebContentsByServerUrl } from '../ui/main/serverView';
+import type { Server } from './common';
 
 export const clearWebviewStorageKeepingLoginData = async (
   guestWebContents: WebContents
@@ -45,6 +48,29 @@ export const handleClearCacheDialog = () => {
 
   listen(CLEAR_CACHE_DIALOG_DELETE_LOGIN_DATA_CLICKED, async (action) => {
     const guestWebContents = webContents.fromId(action.payload);
+    if (!guestWebContents) {
+      return;
+    }
+    await clearWebviewStorageDeletingLoginData(guestWebContents);
+  });
+};
+
+const previousUserLoggedInByUrl = new Map<
+  Server['url'],
+  Server['userLoggedIn']
+>();
+
+export const handleUserLoggedOutDataClearing = (): void => {
+  listen(WEBVIEW_USER_LOGGED_IN, async (action) => {
+    const { url, userLoggedIn } = action.payload;
+    const wasLoggedIn = previousUserLoggedInByUrl.get(url);
+    previousUserLoggedInByUrl.set(url, userLoggedIn);
+
+    if (wasLoggedIn !== true || userLoggedIn !== false) {
+      return;
+    }
+
+    const guestWebContents = getWebContentsByServerUrl(url);
     if (!guestWebContents) {
       return;
     }

--- a/src/servers/main/cache.spec.ts
+++ b/src/servers/main/cache.spec.ts
@@ -1,0 +1,101 @@
+import type { WebContents } from 'electron';
+
+import { listen } from '../../store';
+import type { RootAction } from '../../store/actions';
+import { WEBVIEW_USER_LOGGED_IN } from '../../ui/actions';
+import { getWebContentsByServerUrl } from '../../ui/main/serverView';
+import { handleUserLoggedOutDataClearing } from '../cache';
+
+jest.mock('electron', () => ({
+  webContents: {
+    fromId: jest.fn(),
+  },
+}));
+
+jest.mock('../../store', () => ({
+  listen: jest.fn(),
+}));
+
+jest.mock('../../ui/main/serverView', () => ({
+  getWebContentsByServerUrl: jest.fn(),
+}));
+
+describe('servers/cache handleUserLoggedOutDataClearing', () => {
+  const mockListen = listen as unknown as jest.Mock<
+    () => void,
+    [string, (action: RootAction) => void]
+  >;
+  const mockGetWebContentsByServerUrl =
+    getWebContentsByServerUrl as jest.MockedFunction<
+      typeof getWebContentsByServerUrl
+    >;
+
+  const url = 'https://open.rocket.chat/';
+
+  const createMockWebContents = (): WebContents =>
+    ({
+      session: {
+        clearCache: jest.fn().mockResolvedValue(undefined),
+        clearStorageData: jest.fn().mockResolvedValue(undefined),
+      },
+      reloadIgnoringCache: jest.fn(),
+    }) as unknown as WebContents;
+
+  const dispatchUserLoggedIn = async (userLoggedIn: boolean) => {
+    const [, listener] = mockListen.mock.calls.find(
+      ([type]) => type === WEBVIEW_USER_LOGGED_IN
+    )!;
+    await listener({
+      type: WEBVIEW_USER_LOGGED_IN,
+      payload: { url, userLoggedIn },
+    } as any);
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    handleUserLoggedOutDataClearing();
+  });
+
+  it('clears webview storage on a logged-in -> logged-out transition', async () => {
+    const mockWebContents = createMockWebContents();
+    mockGetWebContentsByServerUrl.mockReturnValue(mockWebContents);
+
+    await dispatchUserLoggedIn(true);
+    await dispatchUserLoggedIn(false);
+
+    expect(mockGetWebContentsByServerUrl).toHaveBeenCalledWith(url);
+    expect(mockWebContents.session.clearCache).toHaveBeenCalled();
+    expect(mockWebContents.session.clearStorageData).toHaveBeenCalledWith();
+    expect(mockWebContents.reloadIgnoringCache).toHaveBeenCalled();
+  });
+
+  it('does not clear on the initial logged-out state at startup/attach', async () => {
+    const mockWebContents = createMockWebContents();
+    mockGetWebContentsByServerUrl.mockReturnValue(mockWebContents);
+
+    await dispatchUserLoggedIn(false);
+
+    expect(mockGetWebContentsByServerUrl).not.toHaveBeenCalled();
+    expect(mockWebContents.session.clearStorageData).not.toHaveBeenCalled();
+  });
+
+  it('does not clear on a logged-out -> logged-in transition', async () => {
+    const mockWebContents = createMockWebContents();
+    mockGetWebContentsByServerUrl.mockReturnValue(mockWebContents);
+
+    await dispatchUserLoggedIn(false);
+    await dispatchUserLoggedIn(true);
+
+    expect(mockGetWebContentsByServerUrl).not.toHaveBeenCalled();
+    expect(mockWebContents.session.clearStorageData).not.toHaveBeenCalled();
+  });
+
+  it('is a safe no-op when no webContents is found for the url', async () => {
+    mockGetWebContentsByServerUrl.mockReturnValue(undefined);
+
+    await dispatchUserLoggedIn(true);
+    await expect(dispatchUserLoggedIn(false)).resolves.not.toThrow();
+
+    expect(mockGetWebContentsByServerUrl).toHaveBeenCalledWith(url);
+  });
+});


### PR DESCRIPTION
## Summary
- CORE-1130 (2022 pentest finding: Insufficient Deletion of Application Data On Logout). Session data (cookies, localStorage, indexedDB, service workers) was only cleared via a manual "Clear Cache" dialog action — logging out of a server through the normal webapp UI left that data behind.
- The logout signal already existed end-to-end (`src/injected.ts` → `WEBVIEW_USER_LOGGED_IN` action) but had no main-process listener reacting to it — this PR wires it up. No webapp-side (Rocket.Chat repo) change needed.
- Added `handleUserLoggedOutDataClearing()` in `src/servers/cache.ts`: tracks each server's prior `userLoggedIn` state and only clears on a genuine `true → false` transition — not on the initial `false` emitted at webview attach/startup, which would otherwise wipe storage and reload before the user ever logs in.
- Scope: clears the webview's session storage/cookies/cache for the server the user logged out of. Does not wipe other servers' data or app-level Redux-persisted preferences — correct for a multi-server client where a user may stay logged into other servers.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `yarn eslint` clean
- [x] New spec `src/servers/main/cache.spec.ts` (4 cases, independently re-run and verified): logged-in→logged-out triggers clear; initial `false` at startup does NOT trigger (critical regression guard); logged-out→logged-in does NOT trigger; missing webContents is a safe no-op

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Guest browsing data is now automatically cleared when a user logs out of a server, helping prevent stale session data from carrying over.
  * The affected web view is refreshed after logout so the next session starts cleanly.

* **Bug Fixes**
  * Fixed an issue where logging out could leave behind cached or stored login-related data for the same server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->