### PR TITLE
fix(CORE-2400): remove startup screen capture enumeration that opens Wayland picker (#3308)

### DIFF
--- a/src/screenSharing/screenSharePicker.tsx
+++ b/src/screenSharing/screenSharePicker.tsx
@@ -100,10 +100,6 @@ export function ScreenSharePicker({
   }, [visible, permissionChannel]);
 
   useEffect(() => {
-    fetchSources();
-  }, [fetchSources]);
-
-  useEffect(() => {
     if (onMounted) {
       onMounted(setVisible);
     }


### PR DESCRIPTION
## What

Removes a mount-time `desktopCapturer.getSources()` call from `ScreenSharePicker`. The component is pre-mounted (hidden) in the root window at every startup and in the video-call window; its mount effect enumerated capture sources before any user action. A visible-gated effect already fetches sources when the picker actually opens (and refreshes every 3s while open), so the mount-time fetch was redundant.

## Why

On Linux Wayland with `WebRTCPipeWireCapturer` (forced for all Linux sessions), source enumeration routes through the XDG desktop portal, which presents the system screen-share dialog. This made the picker dialog appear at app launch with no user interaction — reported in #3308 (Fedora Flatpak, Ubuntu deb, Wayland, since 4.14.0).

This startup path never consults `detectPickerType()`, which is why the sandbox-safe detection fix (#3386) did not cover it.

## Verification

- `tsc --noEmit`, `eslint`, and 24 targeted tests pass (`Shell/index.spec.tsx`, `desktopCapturerCache.main.spec.ts`)
- **Electron 42 (current, 4.15.x) — GPU-passthrough Wayland VM (fedora42 + GTX 970/nouveau, GNOME Wayland), dbus-level A/B, same boot, fresh profiles:**
  - Stock 4.15.2 AppImage: `org.freedesktop.portal.ScreenCast` `CreateSession` + `SelectSources` issued at **every launch** (2/2 runs) — `SelectSources` is the stage that shows the system dialog. Matches reporters' "picker every launch".
  - Same AppImage rebuilt with only this fix: **zero** ScreenCast portal calls (2/2 runs).
  - Note: this trigger only manifests with hardware GL — software-rendered VMs (llvmpipe) never initialize the PipeWire capture path, which is why earlier VM sweeps couldn't reproduce the 4.15.x reports.
- **Electron 40-era build (4.14.1) — fresh-boot visual A/B (mOSdat, fedora42):** picker dialog confirmed at launch on the old build (VLM-verified screenshot); no picker across 3/3 fresh-boot launches with the fix (`verify-fix` verdict NOT_REPRODUCED)
- On-demand screen sharing is unaffected: the request-driven portal/internal picker path (`setDisplayMediaRequestHandler` → provider) does not use the removed effect

## Role of the Electron version (40 → 42)

The Electron upgrade neither caused nor fixes this bug — it only changed where it manifests, which is what made diagnosis non-obvious:

- **Electron 40 (4.14.x):** Chromium's capture stack routed `getSources()` through the XDG portal even under software rendering — the dialog reproduced everywhere, including software-GL VMs.
- **Electron 42 (4.15.x):** Chromium initializes the PipeWire capture path only when hardware GL is available. Software-rendered VMs return silently from the same call (masking the bug in test environments), while every real machine — all reporters — kept hitting the portal on each launch.

The trigger in both eras is the same application code path removed by this PR. Upgrading Electron further would not help: enumerating capture sources on Wayland goes through the portal by design; the defect was enumerating at startup without user intent.

## Scope notes

- Covers both reported eras of #3308: the Electron 40 trigger (visual repro) and the Electron 42 trigger (dbus-level repro on real-GPU Wayland) trace to the same mount-time enumeration removed here.
- Side benefit: removes an unnecessary IPC + enumeration on all platforms at startup, and stops mount-effect refetches on selection changes (`fetchSources` identity churn).

Closes #3308
Jira: [CORE-2400](https://rocketchat.atlassian.net/browse/CORE-2400)


[CORE-2400]: https://rocketchat.atlassian.net/browse/CORE-2400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ