### PR TITLE
docs: post-mortems for #3308 screen-picker triggers + capture-testing rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ This prevents MSI build failures from KMS CNG provider conflicts.
 - Renderer specs must live in a Jest-matched nested path, e.g. `src/<module>/<subdir>/*.spec.ts(x)` or `src/<module>/renderer.spec.ts(x)`. Flat `src/<module>/*.spec.ts` files are not discovered by current `testMatch`; verify new specs with `yarn test --listTests --runTestsByPath <file>`.
 - Uses `@kayahr/jest-electron-runner` for Electron environment simulation
 - Tests run on Windows, macOS, AND Linux CI — always verify cross-platform
+- **Screen-capture / WebRTC / portal behavior CANNOT be validated in software-rendered VMs** — Chromium gates the PipeWire capture path on hardware GL (gate moves between Electron versions). Validate on hardware GL (GPU passthrough or physical machine) and prefer dbus-level assertions (`org.freedesktop.portal.ScreenCast` requests) over dialog visibility, which is portal/boot-state flaky. Full story: `docs/postmortem-screen-picker-startup-enumeration.md`
 
 ## QA Flow Authoring
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,24 +145,24 @@ git worktree add ../Rocket.Chat.Electron-worktrees/feature-name -b new-branch ma
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **Rocket.Chat.Electron** (4593 symbols, 7029 relationships, 103 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **Rocket.Chat.Electron** (4212 symbols, 8257 relationships, 267 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "master"})`.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+- When exploring unfamiliar code, use `query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
 
 ## Never Do
 
-- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER edit a function, class, or method without first running `impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
-- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
+- NEVER commit changes without running `detect_changes()` to check affected scope.
 
 ## Resources
 

--- a/docs/postmortem-screen-picker-sandbox-detection.md
+++ b/docs/postmortem-screen-picker-sandbox-detection.md
@@ -1,0 +1,63 @@
+# Post-Mortem: Screen-share picker opens on every launch (issue #3308)
+
+## Objective
+
+Diagnose why the XDG screen-share picker dialog opened at every launch on Linux (reported on Flatpak/Flathub, present in 4.14.0 / 4.14.1 / 4.15.0) and why the earlier cache-warming guard did not cover the reporter's environment. Ship a fix that works across all Linux packaging formats.
+
+## Background
+
+Screen sharing for the server view was added in PR #3266 (4.14.0). It registers a `setDisplayMediaRequestHandler` per server-view webview and, for the internal picker path, warms a `desktopCapturer` source cache at `WEBVIEW_READY`. A follow-up guard (`requiresCacheWarming`) was added so the prewarm only runs for the `InternalPickerProvider`, not the `PortalPickerProvider`. The guard shipped in 4.15.0 but reports of the dialog persisted — that is where this investigation started.
+
+## Timeline
+
+### Attempt 1: "Surviving trigger is the request handler firing on a webapp load-time getDisplayMedia probe" (wrong hypothesis)
+**What was done:** Read the handler code, saw `setDisplayMediaRequestHandler` registered on every webview with no user-gesture gate, and adopted the reporter's own hypothesis: the Rocket.Chat webapp probes `navigator.mediaDevices.getDisplayMedia()` at page load, the handler catches it, and the portal picker opens.
+**What went wrong:** The whole theory rested on an unverified assumption — that the webapp issues a load-time `getDisplayMedia()`.
+**Root cause of the misstep:** Adopting a plausible-sounding hypothesis before verifying its foundational assumption. The assumption was checkable and turned out false.
+**Correction:** Queried the indexed Rocket.Chat webapp knowledge graph. The only `getDisplayMedia` in the webapp is the VoIP `MediaSessionStore.getDisplayMedia`, called solely by a user-gesture-gated `displayMediaFactory`. Zero load-time callers, zero process participation. The webapp does not probe at load. Hypothesis eliminated.
+
+### Attempt 2: "Our fix was never shipped" (wrong, tooling misread)
+**What was done:** Ran `git merge-base --is-ancestor <fix-commit-sha> <tag>` for the release tags; all returned "no". Concluded the `requiresCacheWarming` guard never reached master/tags and only lived on a feature branch.
+**What went wrong:** The guard *had* shipped — it reached master via a squash-merge, so the original commit SHA is not an ancestor of the tags even though the code change is present.
+**Root cause of the misstep:** Testing for a specific commit SHA's ancestry instead of testing for the *content* of the change. Squash/rebase merges make SHA-ancestry a false negative for "did this change ship."
+**Correction:** `git show <tag>:<path> | grep requiresCacheWarming` proved the guard is present in 4.15.0. Switched to content checks over SHA-ancestry checks.
+
+### Attempt 3: Raw grep across the 10k-file webapp repo (process misstep)
+**What was done:** After the graph gave the answer, dropped to `grep -rn getDisplayMedia` across the entire Rocket.Chat monorepo to "double-check", which auto-backgrounded and produced empty/slow output through the shell proxy.
+**What went wrong:** Slow, noisy, and redundant — the knowledge graph had already answered the structural question authoritatively.
+**Root cause of the misstep:** Reflexive grep on a large unfamiliar repo when a prebuilt code graph was available and already consulted.
+**Correction:** Returned to graph queries (`query`, `context`) for structural questions; reserved source reads for implementation detail.
+
+### Attempt 4: "child_process in the picker file will crash the renderer" (wrong, over-cautious)
+**What was done:** The builder added a synchronous `execSync('busctl ...')` D-Bus probe to `detectPickerType`. Noticing `createScreenPicker` is imported by `videoCallWindow/video-call-window.ts` (a renderer file that imports `ipcRenderer`), flagged it as a runtime crash: Node APIs unavailable in the renderer.
+**What went wrong:** The video-call `BrowserWindow` is created with `nodeIntegration: true` and `contextIsolation: false` (`videoCallWindow/ipc.ts`), so `require('child_process')` works there. No crash.
+**Root cause of the misstep:** Asserting a renderer-context constraint without checking that window's `webPreferences`.
+**Correction:** Verified `webPreferences` first. The crash claim was withdrawn. The `execSync` probe was still removed — for a different, valid reason (a synchronous ≤300ms subprocess spawn on the video-call render thread, and it was non-load-bearing for the fix).
+
+### Attempt 5: Correct root cause and fix (succeeded)
+**What was done:** Traced the real trigger to `prewarmDesktopCapturerCache()` → `desktopCapturer.getSources()` at `WEBVIEW_READY`. On Linux the app forces `--enable-features=WebRTCPipeWireCapturer` for all sessions, so `getSources()` on Wayland routes through the XDG portal and shows the picker. The guard skips prewarm only when `detectPickerType()` returns `'portal'` — but that function reads `XDG_SESSION_TYPE` / `XDG_CURRENT_DESKTOP`, which Flatpak/Snap sandboxes strip. On a Wayland host inside a sandbox, detection fell through to `'internal'` → `requiresCacheWarming = true` → prewarm ran → picker at launch.
+**Why it worked:** The fix flips the Linux default to `'portal'` and recovers `'internal'` only when a silent-capable session is positively confirmed (pure X11 via `XDG_SESSION_TYPE=x11`, or the `ROCKETCHAT_INTERNAL_SCREEN_PICKER=1` escape hatch). Wayland is detected via `XDG_SESSION_TYPE` OR a real `WAYLAND_DISPLAY` socket on disk (mirroring the ozone-platform decision already in `app.ts`), so sandbox env-stripping no longer causes a misdetect. With `'portal'` selected, the startup prewarm never runs.
+**Key insight:** The picker-vs-portal decision must not depend on environment variables that sandboxes strip. Default to the safe branch (portal — dialog only on user demand) and only leave it when a silent-capable environment is positively proven.
+
+## Lessons Learned
+
+### 1. Verify a hypothesis's foundational assumption before building on it
+Attempt 1 adopted "the webapp probes getDisplayMedia at load" — a checkable claim — as fact. It was false. When a diagnosis rests on one load-bearing assumption, verify that assumption first (here: query the code graph for load-time callers) before reasoning forward from it.
+
+### 2. "Did this change ship?" is a content question, not a SHA-ancestry question
+`git merge-base --is-ancestor <sha> <tag>` returns false for squash/rebase merges even when the change is present, because the original SHA is not in the tag's history. To check whether a change reached a release, inspect the *content* at that ref: `git show <tag>:<path> | grep <marker>`.
+
+### 3. On a graph-indexed codebase, use the graph for structural questions
+Rocket.Chat is indexed. The graph answered "who calls getDisplayMedia" instantly and authoritatively. Dropping to a repo-wide grep afterward was slow and redundant. Query the graph first for call chains / ownership / participation; read source only for implementation detail.
+
+### 4. Check `webPreferences` before asserting a renderer Node-API constraint
+Whether `fs` / `child_process` work in a renderer-reachable module depends on that window's `nodeIntegration` / `contextIsolation`. The video-call window runs with `nodeIntegration: true`. Confirm the actual `BrowserWindow` config before claiming a Node-in-renderer crash.
+
+### 5. Sandbox-safe environment detection: default to the safe branch, positively confirm the optimization
+Flatpak/Snap strip `XDG_SESSION_TYPE` / `XDG_CURRENT_DESKTOP`. Any Linux detection keyed on those vars silently misfires inside a sandbox. The robust shape: default to the branch that is always correct (here, portal — the picker appears only on user demand), and switch to the optimized branch (internal cache-warming) only when the enabling condition is positively proven (pure X11, or explicit opt-in). Reuse an existing robust signal when one exists — `app.ts` already validated the Wayland socket on disk for its ozone decision.
+
+## What this does NOT fix
+
+- It does not change screen-sharing behavior when the user actually initiates a share — the portal picker appears on demand, as intended, on Wayland.
+- It does not touch the Flathub package directly. `chat.rocket.RocketChat` on Flathub is community-maintained and separate from this repo's official builds; it will pick up the change after the next release flows downstream.
+- The reporter's original hypothesis (a webapp load-time `getDisplayMedia` probe) was not the mechanism. The trigger was the desktop app's own startup cache warm-up under portal routing, selected because environment detection misfired in the sandbox.

--- a/docs/postmortem-screen-picker-startup-enumeration.md
+++ b/docs/postmortem-screen-picker-startup-enumeration.md
@@ -1,0 +1,87 @@
+# Post-Mortem: Screen-share picker at launch — startup enumeration trigger (issue #3308, PR #3400)
+
+Continuation of [postmortem-screen-picker-sandbox-detection.md](./postmortem-screen-picker-sandbox-detection.md). That investigation shipped a sandbox-safe `detectPickerType()` in 4.15.1 and closed the cache-prewarm trigger. Field reports on 4.15.1 (Ubuntu 26.04 KDE/Cosmic, Wayland, deb) continued — this investigation found and removed a second, independent trigger, and explains why it evaded every software-rendered test environment.
+
+## Objective
+
+Root-cause why the XDG screen-share dialog still opened at every app launch on Wayland after the 4.15.1 detection fix, ship a verified fix, and close #3308.
+
+## Outcome
+
+PR #3400 (merged 2026-07-09): 4-line deletion of a mount-time `desktopCapturer.getSources()` in `src/screenSharing/screenSharePicker.tsx`. Verified at dbus level on GPU-passthrough Wayland: stock 4.15.2 issues `ScreenCast CreateSession + SelectSources` at every launch; the fixed build issues zero. Tracked as CORE-2400.
+
+## Timeline
+
+### Attempt 1: Enumerate every `getSources()` reacher at the shipped tag (succeeded — found the trigger in minutes)
+**What was done:** Instead of re-examining the previously fixed prewarm path, listed every call site that can reach `desktopCapturer.getSources()` at tag 4.15.1 (`git grep` at the tag, not the working tree).
+**What it found:** `ScreenSharePicker` is pre-mounted hidden in the root window (`Shell` → `RootScreenSharePicker`) at every startup, and its mount effect called `fetchSources()` unconditionally — before any user action, bypassing `detectPickerType()` entirely.
+**Key insight:** One symptom had two independent triggers. The 4.15.1 fix was correct for the trigger it addressed; reports continued because the second trigger was never enumerated.
+
+### Attempt 2: Verify the fix in software-rendered VMs (misleading results, multiple harness defects)
+**What was done:** mOSdat `confirm`/`verify-fix` runs on fedora42 (GNOME Wayland VM).
+**What went wrong (harness, fixed in passing):**
+- VLM verdicts 401'd: the TOML `[vlm]` block silently overrides `.env` credentials (config precedence), and the endpoint URL used `http://` — the https redirect turned POST into GET (405).
+- The scenario's precondition prompt required a visible login/chat UI; a blank window behind the picker overlay scored INCONCLUSIVE even when the bug was on screen.
+**What worked:** 4.14.1 (Electron 40) reproduced visually on first-launch-after-boot; the fixed build was clean 3/3. This was declared "verified" — prematurely.
+**Root cause of the misstep:** The A/B baseline (4.14.1, Electron 40) did not match the reported version (4.15.1, Electron 42). A control run with stock 4.15.2 came back clean on the same VM, collapsing the claim.
+
+### Attempt 3: KDE control on Manjaro (false positive from a contaminated VM)
+**What was done:** Same A/B on the Manjaro KDE Wayland VM. Stock "reproduced" — then the fixed build "reproduced" too.
+**What went wrong:** The VM had a pre-existing manual install at `/opt/Rocket.Chat` with a `~/.config/autostart` entry from earlier testing. It launched at every login and owned the observed dialog. The inventory had only checked flatpak and pacman — package managers do not list manual `/opt` installs.
+**Correction:** Killed/removed the old install and autostart entry, re-ran clean: stock 4.15.2 showed nothing on this VM either.
+
+### Attempt 4: dbus-level probes across the VM matrix (right instrument, wrong environments)
+**What was done:** Replaced visual assertions with `dbus-monitor` on `org.freedesktop.portal.ScreenCast` — the request is deterministic even when dialog rendering is flaky (portal dialogs on these VMs rendered only on the first request per boot).
+**What it showed:** Electron 42 issued zero ScreenCast calls at startup on every combination tried: Fedora 42 GNOME + Manjaro KDE, X11 and Wayland ozone, fresh and server-configured profiles, portal ≤ 1.20.
+**Discipline that paid off:** This was recorded as *inconclusive for the reported environment* rather than "the fix is irrelevant on Electron 42" — the reported environment (real hardware) had not actually been exercised.
+
+### Attempt 5: Webapp load-time `getDisplayMedia` probe hypothesis (killed statically — second time this hypothesis died)
+**What was done:** Reporters run server 7.10.7; the prior postmortem had only cleared the *latest* webapp. Checked the actual version: `git grep getDisplayMedia` at tag 7.10.7 — zero matches anywhere.
+**Root cause of the misstep:** The same hypothesis was eliminated in the prior investigation; re-checking for the older server version was legitimate, but the 30-second static check should have run before any VM cycles were spent around it.
+
+### Attempt 6: Ubuntu 26.04 environment build (near-miss + environment wall)
+**What was done:** Cloned the ubuntu2404 VM and dist-upgraded the clone to 26.04 (reporters' exact distro/kernel/portal).
+**Near-miss:** The clone kept the original's static IP. The first upgrade command, targeted by IP, landed on the **production** ubuntu2404 VM. It self-aborted harmlessly ("install all available updates first") before mutating anything; hostname was the only change and was restored. Rule extracted: mutate VMs by identity (guest-agent hostname), never by IP, immediately after cloning.
+**Environment wall:** On the finished 26.04 VM, Electron 42 + Wayland ozone + virtual std-VGA (Mesa 26 / llvmpipe) never mapped a window in 10+ minutes — renderer stalls pre-paint. The reported environment remained unverifiable in software-rendered VMs. (Also hit: Ubuntu 24.04+ AppArmor userns restriction requires `chrome-sandbox` root:4755 for extracted AppImages.)
+
+### Attempt 7: GPU passthrough (decisive)
+**What was done:** With IOMMU enabled on the Proxmox host, passed a GTX 970 to fedora42 (nouveau, GNOME Wayland) and re-ran the dbus A/B with fresh profiles on the same boot.
+**Result:**
+| Build (both 4.15.2 / Electron 42) | ScreenCast calls at launch |
+|---|---|
+| stock | `CreateSession` + `SelectSources` every launch (2/2 runs) |
+| with the fix | zero (2/2 runs) |
+**Why it worked:** Electron 42's Chromium initializes the PipeWire capture path only when hardware GL is available. Software-rendered VMs return from `getSources()` without touching the portal — masking the trigger in every earlier test environment — while all real machines (all reporters) hit the portal on each launch. Electron 40 portal'd even under software GL, which is why the 4.14-era trigger *was* reproducible in plain VMs.
+**Note:** With passthrough, the Proxmox VNC console is black (output goes to the physical GPU head) — evidence must come from dbus/journal or guest-side capture.
+
+## Lessons Learned
+
+### 1. One symptom can have multiple independent triggers — enumerate all reachers at the shipped tag
+When reports continue after a correct fix, don't re-litigate the fixed trigger. List every call site that can reach the side effect (`git grep <api>` at the release tag) and audit each one. The second trigger here was findable in minutes once the question changed from "why didn't the fix work" to "what else reaches getSources".
+
+### 2. Software-rendered VMs are not representative for Chromium capture/media behavior
+Chromium gates the PipeWire capture path on hardware GL (behavior differs across Electron/Chromium versions). "Does not reproduce in a VM" is not evidence of absence for capture-stack, WebRTC, or portal behavior — validate on hardware GL (GPU passthrough or physical machine) before concluding non-repro, and label VM-only results as environment-limited.
+
+### 3. The A/B baseline must match the reported version
+Verifying the fix against a 4.14.1 baseline proved only the Electron 40 trigger. The "fix verified" claim collapsed the moment a same-version control (stock 4.15.2) ran. Always run the control with the exact reported version before declaring a report resolved.
+
+### 4. Inventory a shared VM beyond package managers before trusting results from it
+Check `/opt`, `~/.config/autostart`, and running processes (`pgrep`) — manual installs and autostart entries don't appear in flatpak/pacman/dpkg listings. A pre-existing autostarted install produced a convincing false CONFIRMED and a false bug-still-present on the fixed build.
+
+### 5. Mutate cloned VMs by identity, never by IP
+Clones keep statically configured IPs; the address may still belong to the source VM. Verify the target via guest-agent hostname (`/agent/get-host-name`) before any mutating command. This near-missed a dist-upgrade of a production test VM.
+
+### 6. Assert on the protocol, not the pixels, when the UI layer is flaky
+Portal dialog *rendering* on these VMs was boot-state dependent (rendered once per boot, then "Failed to associate portal window"). The dbus *request* (`CreateSession`/`SelectSources`) fires deterministically per launch. When a visual assertion is environment-flaky, find the deterministic protocol-level signal underneath it.
+
+### 7. Config precedence chains hide credential failures
+mOSdat's TOML `[vlm]` block silently overrode fresh `.env` credentials (stale hosted-API key → 401 mid-run). When creds fail despite being "set", walk the full precedence chain before minting new keys. Related: `http://` base URLs on https-only APIs turn POST into GET via redirect (405) — always https.
+
+### 8. `pkill -f` patterns must not appear in your own command line
+Twice, a remote cleanup killed its own SSH session because the pattern string appeared in the shell's cmdline (once via the pattern itself, once via an unrelated filename later in the same command). Use `pkill -x` with exact (≤15 char) process names, or split the kill into its own SSH invocation with a `[b]racketed` pattern and no other occurrence of the string.
+
+## What this does NOT fix
+
+- On-demand screen sharing is unchanged: when the user initiates a share, the portal (Wayland) or internal picker appears as designed — the fix removes only the un-requested enumeration at startup.
+- The mOSdat harness gaps found along the way (VLM config precedence, precondition strictness, watcher agents not reporting results back) were patched or worked around in-session but belong to the mOSdat repo's own backlog.
+- Flathub's community package picks up the fix only after the next release flows downstream.


### PR DESCRIPTION
Documents the two-phase #3308 investigation and extracts the testing rule it produced.

- Adds `docs/postmortem-screen-picker-startup-enumeration.md` — phase 2: the startup-enumeration trigger fixed by #3400, the Electron 40 vs 42 manifestation split (hardware-GL gate on the PipeWire capture path), and the dbus-level verification protocol
- Commits `docs/postmortem-screen-picker-sandbox-detection.md` — phase 1 (#3386), previously untracked
- CLAUDE.md: adds the capture-testing rule (software-rendered VMs cannot validate Chromium capture/portal behavior; assert on ScreenCast dbus requests, not dialog visibility) and the pending tool-generated GitNexus section refresh

Docs only — no runtime changes.

Related: #3308, #3400, CORE-2400

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added two new postmortem documents covering a resolved screen-sharing picker issue, the investigation process, and lessons learned.
* **Chores**
  * Updated contributor guidance with clearer testing limits for screen capture and portal behavior in virtualized environments.
  * Refreshed internal workflow notes and command references used for GitNexus-related tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->