### PR TITLE
fix: honor uniqueId-scoped support exceptions on server-signed path

### DIFF
--- a/src/servers/supportedVersions/main.main.spec.ts
+++ b/src/servers/supportedVersions/main.main.spec.ts
@@ -371,6 +371,173 @@ describe('supportedVersions/main.ts', () => {
     });
   });
 
+  // ========== EXCEPTION UNIQUE ID SCOPE (SERVER-SIGNED PATH) ==========
+  describe('Exception uniqueId scope resolution on server-signed path', () => {
+    const tenantSupportedVersions = (overrides?: Partial<SupportedVersions>) =>
+      createMockSupportedVersions({
+        versions: [
+          {
+            version: '8.6.0',
+            expiration: new Date(Date.now() + 86400000),
+          },
+        ],
+        exceptions: {
+          domain: 'test.rocket.chat',
+          uniqueId: 'tenant-unique-id',
+          versions: [
+            {
+              version: '7.13.9',
+              expiration: new Date(Date.now() + 86400000),
+            },
+          ],
+        },
+        enforcementStartDate: '2023-12-15T00:00:00Z',
+        ...overrides,
+      });
+
+    it('should fetch uniqueID before validating when /api/info omits uniqueId and exception is uniqueId-scoped', async () => {
+      const mockServer = createMockServer({ version: '7.13' });
+      const mockServerInfo = createMockServerInfo({
+        version: '7.13',
+        uniqueId: undefined,
+      });
+      selectMock.mockReturnValue(mockServer);
+      axiosMock.get = jest
+        .fn()
+        .mockResolvedValueOnce({ data: mockServerInfo })
+        .mockResolvedValueOnce({
+          data: { settings: [{ value: 'tenant-unique-id' }] },
+        });
+
+      (jest.spyOn(jsonwebtoken, 'verify') as jest.Mock).mockReturnValue(
+        tenantSupportedVersions()
+      );
+
+      await updateSupportedVersionsData(mockServer.url);
+
+      const uniqueIdDispatch = dispatchMock.mock.calls.find(
+        ([action]) =>
+          (action as any).type === WEBVIEW_SERVER_UNIQUE_ID_UPDATED &&
+          (action as any).payload?.uniqueID === 'tenant-unique-id'
+      );
+      expect(uniqueIdDispatch).toBeDefined();
+
+      const verdictDispatch = dispatchMock.mock.calls.find(
+        ([action]) =>
+          (action as any).type === WEBVIEW_SERVER_IS_SUPPORTED_VERSION
+      );
+      expect(verdictDispatch?.[0]).toEqual({
+        type: WEBVIEW_SERVER_IS_SUPPORTED_VERSION,
+        payload: {
+          url: mockServer.url,
+          isSupportedVersion: true,
+        },
+      });
+    });
+
+    it('should re-fetch uniqueID when persisted value is stale and honor the exception', async () => {
+      const mockServer = createMockServer({
+        version: '7.13',
+        uniqueID: 'stale-unique-id',
+      });
+      const mockServerInfo = createMockServerInfo({
+        version: '7.13',
+        uniqueId: undefined,
+      });
+      selectMock.mockReturnValue(mockServer);
+      axiosMock.get = jest
+        .fn()
+        .mockResolvedValueOnce({ data: mockServerInfo })
+        .mockResolvedValueOnce({
+          data: { settings: [{ value: 'tenant-unique-id' }] },
+        });
+
+      (jest.spyOn(jsonwebtoken, 'verify') as jest.Mock).mockReturnValue(
+        tenantSupportedVersions()
+      );
+
+      await updateSupportedVersionsData(mockServer.url);
+
+      const verdictDispatch = dispatchMock.mock.calls.find(
+        ([action]) =>
+          (action as any).type === WEBVIEW_SERVER_IS_SUPPORTED_VERSION
+      );
+      expect(verdictDispatch?.[0]).toEqual({
+        type: WEBVIEW_SERVER_IS_SUPPORTED_VERSION,
+        payload: {
+          url: mockServer.url,
+          isSupportedVersion: true,
+        },
+      });
+    });
+
+    it('should reject the exception when the fetched uniqueID does not match the exception scope', async () => {
+      const mockServer = createMockServer({ version: '7.13' });
+      const mockServerInfo = createMockServerInfo({
+        version: '7.13',
+        uniqueId: undefined,
+      });
+      selectMock.mockReturnValue(mockServer);
+      axiosMock.get = jest
+        .fn()
+        .mockResolvedValueOnce({ data: mockServerInfo })
+        .mockResolvedValueOnce({
+          data: { settings: [{ value: 'other-tenant-id' }] },
+        });
+
+      (jest.spyOn(jsonwebtoken, 'verify') as jest.Mock).mockReturnValue(
+        tenantSupportedVersions()
+      );
+
+      await updateSupportedVersionsData(mockServer.url);
+
+      const verdictDispatch = dispatchMock.mock.calls.find(
+        ([action]) =>
+          (action as any).type === WEBVIEW_SERVER_IS_SUPPORTED_VERSION
+      );
+      expect(verdictDispatch?.[0]).toEqual({
+        type: WEBVIEW_SERVER_IS_SUPPORTED_VERSION,
+        payload: {
+          url: mockServer.url,
+          isSupportedVersion: false,
+        },
+      });
+    });
+
+    it('should not fetch uniqueID when the persisted value already matches the exception scope', async () => {
+      const mockServer = createMockServer({
+        version: '7.13',
+        uniqueID: 'tenant-unique-id',
+      });
+      const mockServerInfo = createMockServerInfo({
+        version: '7.13',
+        uniqueId: undefined,
+      });
+      selectMock.mockReturnValue(mockServer);
+      axiosMock.get = jest.fn().mockResolvedValueOnce({ data: mockServerInfo });
+
+      (jest.spyOn(jsonwebtoken, 'verify') as jest.Mock).mockReturnValue(
+        tenantSupportedVersions()
+      );
+
+      await updateSupportedVersionsData(mockServer.url);
+
+      expect(axiosMock.get).toHaveBeenCalledTimes(1);
+
+      const verdictDispatch = dispatchMock.mock.calls.find(
+        ([action]) =>
+          (action as any).type === WEBVIEW_SERVER_IS_SUPPORTED_VERSION
+      );
+      expect(verdictDispatch?.[0]).toEqual({
+        type: WEBVIEW_SERVER_IS_SUPPORTED_VERSION,
+        payload: {
+          url: mockServer.url,
+          isSupportedVersion: true,
+        },
+      });
+    });
+  });
+
   // ========== CLOUD FETCH PATH TESTS ==========
   describe('Cloud Fetch Path', () => {
     it('should fetch cloud info with retries when server fails', async () => {
@@ -832,6 +999,42 @@ describe('supportedVersions/main.ts', () => {
       const result = await isServerVersionSupported(
         mockServer as any,
         supportedVersions as any
+      );
+
+      expect(result.supported).toBe(true);
+    });
+
+    it('should honor exceptions when exceptions.domain differs only by letter case', async () => {
+      const futureDate = new Date(Date.now() + 86400000);
+      const supportedVersions: SupportedVersions = {
+        enforcementStartDate: new Date(Date.now() - 86400000).toISOString(),
+        timestamp: new Date().toISOString(),
+        versions: [
+          {
+            version: '8.4.0',
+            expiration: futureDate,
+          },
+        ],
+        exceptions: {
+          domain: 'Open.Rocket.Chat',
+          uniqueId: 'test-unique-id',
+          versions: [
+            {
+              version: '8.5.1',
+              expiration: futureDate,
+            },
+          ],
+        },
+      };
+
+      const result = await isServerVersionSupported(
+        {
+          url: 'https://open.rocket.chat/',
+          version: '8.5',
+          title: 'Rocket.Chat Open',
+          uniqueID: 'test-unique-id',
+        } as any,
+        supportedVersions
       );
 
       expect(result.supported).toBe(true);

--- a/src/servers/supportedVersions/main.ts
+++ b/src/servers/supportedVersions/main.ts
@@ -353,7 +353,8 @@ export const isServerVersionSupported = async (
     } catch {
       hostname = undefined;
     }
-    if (exceptions.domain && exceptions.domain !== hostname) {
+    // DNS names are case-insensitive; URL.hostname is already lowercased.
+    if (exceptions.domain && exceptions.domain.toLowerCase() !== hostname) {
       exceptionScopeMatches = false;
     }
     if (exceptions.uniqueId && exceptions.uniqueId !== server.uniqueID) {
@@ -502,6 +503,30 @@ const dispatchSupportedVersionsUpdated = (
   });
 };
 
+// When a supported-versions payload carries a uniqueId-scoped exceptions
+// block, the scope check requires server.uniqueID to equal
+// exceptions.uniqueId. The server-signed fast path returns before the general
+// getUniqueId call, and /api/info does not include uniqueId, so a missing or
+// stale persisted uniqueID would permanently disqualify the tenant's own
+// exceptions. Resolve it from the server before validating (and persist it
+// for future runs, including offline cache validation).
+const withExceptionScopeUniqueId = async (
+  serverView: Server,
+  supportedVersionsData: SupportedVersions | undefined,
+  versionForUniqueId: string
+): Promise<Server> => {
+  const exceptionsUniqueId = supportedVersionsData?.exceptions?.uniqueId;
+  if (!exceptionsUniqueId || serverView.uniqueID === exceptionsUniqueId) {
+    return serverView;
+  }
+  const freshUniqueId = await getUniqueId(serverView.url, versionForUniqueId)
+    .then(dispatchUniqueIdUpdated(serverView.url))
+    .catch(logRequestError('unique ID'));
+  return freshUniqueId
+    ? { ...serverView, uniqueID: freshUniqueId }
+    : serverView;
+};
+
 // Per-URL request generation counter. Each call to updateSupportedVersionsData
 // bumps the counter and captures its own generation. Awaited steps inside the
 // call check whether their generation is still current before dispatching, so
@@ -540,9 +565,8 @@ export const updateSupportedVersionsData = async (
   // Build a server view that reflects the freshly-fetched version and
   // uniqueId when available, so every downstream support check
   // (server/cloud/cache/builtin) is evaluated against the same authoritative
-  // identity. /api/info returns `uniqueId`, which is required for exception
-  // scope matching to honor server-source exceptions on first launch (when
-  // persisted server.uniqueID may be undefined).
+  // identity. Current servers do NOT include `uniqueId` in /api/info, so the
+  // fallback to persisted server.uniqueID is the common path.
   const serverWithFreshVersion: Server = serverInfoResult
     ? {
         ...server,
@@ -567,8 +591,14 @@ export const updateSupportedVersionsData = async (
         const serverSupportedVersions = decodeSupportedVersions(serverEncoded);
         if (isStale()) return;
         saveToCache(serverUrl, serverSupportedVersions);
-        const supported = await isServerVersionSupported(
+        const serverForValidation = await withExceptionScopeUniqueId(
           serverWithFreshVersion,
+          serverSupportedVersions,
+          serverInfoResult.version
+        );
+        if (isStale()) return;
+        const supported = await isServerVersionSupported(
+          serverForValidation,
           serverSupportedVersions,
           freshCommitHash
         );


### PR DESCRIPTION
## What

Workspaces with a uniqueId-scoped support exception (issued via Rocket.Chat Cloud) were shown the "Unsupported" screen on desktop 4.15.0–4.15.2 even though the exception was valid and present in the server's signed `supportedVersions` payload. Reported through a customer support escalation (workspace running 7.13.9 with a valid exception; mobile unaffected).

## Why

The exception scope check added in #3323 requires `exceptions.uniqueId === server.uniqueID`. That check did not cover the common deployment path:

- `server.uniqueID` is only written by `getUniqueId()` inside `updateSupportedVersionsData`, but the server-signed validation path returns before that call — so the local uniqueID is never populated for servers whose `/api/info` succeeds.
- The intended fallback, `serverInfoResult.uniqueId`, never applies: `/api/info` does not include a `uniqueId` field (verified against servers running 7.13 and 8.7). The existing test fixtures included it, which is why the suite stayed green.

With the local uniqueID undefined, every uniqueId-scoped exception was disqualified and the version fell through to the supported-versions list, which no longer contains the excepted version.

## How

- New `withExceptionScopeUniqueId` helper on the server-signed path: when the payload carries a uniqueId-scoped exceptions block and the local uniqueID is missing or different, resolve it from the server (`settings.public?_id=uniqueID`), dispatch `WEBVIEW_SERVER_UNIQUE_ID_UPDATED` so it persists for subsequent runs (including offline cache validation), and validate against the resolved identity.
- Fail-secure: if the fetch fails or the fetched value does not match `exceptions.uniqueId`, the exception remains rejected. The cross-tenant scope check semantics from #3323 are unchanged.
- `exceptions.domain` is now compared case-insensitively (DNS names are case-insensitive per RFC 4343); `URL.hostname` is already lowercased.
- No extra network request in steady state: the uniqueID fetch only runs when the payload is uniqueId-scoped and the persisted value does not already match.

## Tests

- 5 new specs in `main.main.spec.ts`: exception honored when `/api/info` omits `uniqueId`; stale persisted uniqueID re-resolved; mismatched uniqueID still rejected; no extra fetch when persisted value matches; domain case-insensitive matching.
- `yarn jest src/servers/supportedVersions/main.main.spec.ts`: 82/82 pass. `tsc --noEmit` and `yarn lint` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server version checks to better handle exception rules tied to a unique server identity.
  * If the stored server identity is outdated, the app now refreshes it before deciding whether the server is supported.
  * Exception matching is now case-insensitive for server domains, reducing false negatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
