### PR TITLE
fix: harden supported-versions validation, recovery, and exception scoping

### DIFF
--- a/src/i18n/en.i18n.json
+++ b/src/i18n/en.i18n.json
@@ -489,7 +489,8 @@
   "unsupportedServer": {
     "title": "{{instanceDomain}} is running an unsupported version of Rocket.Chat",
     "announcement": "An admin needs to update the workspace to a supported version in order to reenable access from mobile and desktop apps.",
-    "moreInformation": "Learn more"
+    "moreInformation": "Learn more",
+    "checkAgain": "Check again"
   },
   "selfxss": {
     "title": "Stop!",

--- a/src/servers/reducers.ts
+++ b/src/servers/reducers.ts
@@ -161,7 +161,7 @@ export const servers: Reducer<Server[], ServersActionTypes> = (
 
     case WEBVIEW_SERVER_UNIQUE_ID_UPDATED: {
       const { url, uniqueID } = action.payload;
-      return upsert(state, { url, uniqueID });
+      return update(state, { url, uniqueID });
     }
 
     case WEBVIEW_SERVER_IS_SUPPORTED_VERSION: {
@@ -184,7 +184,7 @@ export const servers: Reducer<Server[], ServersActionTypes> = (
         gitCommitHash !== undefined
           ? { url, version, gitCommitHash }
           : { url, version };
-      return upsert(state, patch);
+      return update(state, patch);
     }
 
     case WEBVIEW_UNREAD_CHANGED: {
@@ -219,7 +219,7 @@ export const servers: Reducer<Server[], ServersActionTypes> = (
 
     case WEBVIEW_GIT_COMMIT_HASH_CHANGED: {
       const { url, gitCommitHash } = action.payload;
-      return upsert(state, { url, gitCommitHash });
+      return update(state, { url, gitCommitHash });
     }
 
     case WEBVIEW_FAVICON_CHANGED: {

--- a/src/servers/reducers/__tests__/servers.spec.ts
+++ b/src/servers/reducers/__tests__/servers.spec.ts
@@ -192,6 +192,17 @@ describe('servers reducer', () => {
 
       expect(newState[0].uniqueID).toBe('abc');
     });
+
+    it('should not resurrect a ghost server for a url not present in state', () => {
+      const state = [existing];
+      const newState = servers(state, {
+        type: WEBVIEW_SERVER_UNIQUE_ID_UPDATED,
+        payload: { url: 'https://deleted.rocket.chat/', uniqueID: 'abc' },
+      } as any);
+
+      expect(newState).toBe(state);
+      expect(newState).toHaveLength(1);
+    });
   });
 
   describe('WEBVIEW_SERVER_IS_SUPPORTED_VERSION', () => {
@@ -226,6 +237,17 @@ describe('servers reducer', () => {
 
       expect(newState[0].version).toBe('7.0.0');
       expect(newState[0].gitCommitHash).toBe('keepme');
+    });
+
+    it('should not resurrect a ghost server for a url not present in state', () => {
+      const state = [existing];
+      const newState = servers(state, {
+        type: WEBVIEW_SERVER_VERSION_UPDATED,
+        payload: { url: 'https://deleted.rocket.chat/', version: '7.0.0' },
+      } as any);
+
+      expect(newState).toBe(state);
+      expect(newState).toHaveLength(1);
     });
   });
 
@@ -293,6 +315,17 @@ describe('servers reducer', () => {
       } as any);
 
       expect(newState[0].gitCommitHash).toBe('abc123');
+    });
+
+    it('should not resurrect a ghost server for a url not present in state', () => {
+      const state = [existing];
+      const newState = servers(state, {
+        type: WEBVIEW_GIT_COMMIT_HASH_CHANGED,
+        payload: { url: 'https://deleted.rocket.chat/', gitCommitHash: 'x' },
+      } as any);
+
+      expect(newState).toBe(state);
+      expect(newState).toHaveLength(1);
     });
   });
 

--- a/src/servers/supportedVersions/main.main.spec.ts
+++ b/src/servers/supportedVersions/main.main.spec.ts
@@ -16,6 +16,7 @@ import {
 } from '../../ui/actions';
 import {
   checkSupportedVersionServers,
+  getExpirationMessageTranslated,
   isServerVersionSupported,
   updateSupportedVersionsData,
 } from './main';
@@ -29,6 +30,9 @@ jest.mock('node:fs/promises');
 jest.mock('electron', () => ({
   ipcMain: {
     handle: jest.fn(),
+  },
+  powerMonitor: {
+    on: jest.fn(),
   },
 }));
 
@@ -2039,7 +2043,7 @@ describe('supportedVersions/main.ts', () => {
       expect(result.supported).toBe(true);
     });
 
-    it('does NOT honor scoped exception when local server.uniqueID is undefined', async () => {
+    it('honors scoped exception when local server.uniqueID is UNKNOWN and the domain matches', async () => {
       const payload = {
         ...baseVersions,
         exceptions: {
@@ -2049,8 +2053,10 @@ describe('supportedVersions/main.ts', () => {
         },
       } as unknown as SupportedVersions;
 
-      // Same domain. Same commit hash. But local uniqueID UNKNOWN.
-      // Must reject — missing local identity cannot satisfy required scope.
+      // Same domain. Same commit hash. Local uniqueID UNKNOWN (e.g.
+      // settings.public restricted by enterprise API ACLs). An unprovable
+      // identity must not disqualify a domain-matched exception — wrongly
+      // blocking a legitimate tenant is the worse failure mode.
       const serverWithoutUniqueID = {
         url: 'https://tenant-a.example.com/',
         version: '8.5',
@@ -2060,6 +2066,31 @@ describe('supportedVersions/main.ts', () => {
 
       const result = await isServerVersionSupported(
         serverWithoutUniqueID,
+        payload,
+        'abc1234567890'
+      );
+      expect(result.supported).toBe(true);
+    });
+
+    it('rejects scoped exception on a PROVEN uniqueID mismatch even when the domain matches', async () => {
+      const payload = {
+        ...baseVersions,
+        exceptions: {
+          domain: 'tenant-a.example.com',
+          uniqueId: 'tenant-a-unique',
+          versions: [{ version: 'sha-abc1234', expiration: futureExpiry }],
+        },
+      } as unknown as SupportedVersions;
+
+      const serverWithOtherUniqueID = {
+        url: 'https://tenant-a.example.com/',
+        version: '8.5',
+        title: 'Tenant A',
+        uniqueID: 'tenant-b-unique',
+      } as any;
+
+      const result = await isServerVersionSupported(
+        serverWithOtherUniqueID,
         payload,
         'abc1234567890'
       );
@@ -2370,6 +2401,114 @@ describe('supportedVersions/main.ts', () => {
         semverExceptionVersions
       );
       expect(result.supported).toBe(true);
+    });
+  });
+
+  // ========== FIX-1: fallback path validation must not throw unguarded ==========
+  describe('fallback path validation failure (fail-open guard)', () => {
+    it('dispatches ERROR (not a rejection) and no IS_SUPPORTED_VERSION when the fallback payload is malformed', async () => {
+      const mockServer = createMockServer({ version: '7.5.0' });
+      selectMock.mockReturnValue(mockServer);
+      axiosMock.get = jest.fn().mockRejectedValue(new Error('Network error'));
+
+      // Cache returns a corrupt payload: `versions` is not an array, so
+      // isServerVersionSupported's `versions.find` throws synchronously.
+      const ElectronStoreMock = jest.requireMock('electron-store');
+      const storeGetMock = jest.spyOn(
+        ElectronStoreMock.prototype,
+        'get'
+      ) as jest.Mock;
+      storeGetMock.mockReturnValue({
+        versions: { notAnArray: true },
+        enforcementStartDate: '2023-01-01T00:00:00Z',
+        timestamp: new Date().toISOString(),
+      });
+
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      jest.useFakeTimers();
+      const promise = updateSupportedVersionsData(mockServer.url);
+      await jest.advanceTimersByTimeAsync(4000);
+      // Must resolve, not reject.
+      await expect(promise).resolves.toBeUndefined();
+      jest.useRealTimers();
+
+      const errorDispatch = dispatchMock.mock.calls.find(
+        ([action]) =>
+          (action as any).type === WEBVIEW_SERVER_SUPPORTED_VERSIONS_ERROR
+      );
+      expect(errorDispatch).toBeDefined();
+
+      const isSupportedDispatches = dispatchMock.mock.calls.filter(
+        ([action]) =>
+          (action as any).type === WEBVIEW_SERVER_IS_SUPPORTED_VERSION
+      );
+      expect(isSupportedDispatches.length).toBe(0);
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error validating fallback'),
+        expect.anything()
+      );
+
+      consoleErrorSpy.mockRestore();
+      storeGetMock.mockRestore();
+    });
+  });
+
+  // ========== FIX-3: cloud lookup must not skip on persisted uniqueID ==========
+  describe('cloud fetch gate uses persisted uniqueID as fallback', () => {
+    it('fetches cloud endpoint when fresh uniqueID fetch fails but server has a persisted uniqueID', async () => {
+      const mockServer = createMockServer({
+        version: '7.5.0',
+        uniqueID: 'persisted-unique-id',
+      });
+      const mockServerInfo = createMockServerInfo({
+        supportedVersions: undefined,
+      });
+      selectMock.mockReturnValue(mockServer);
+      axiosMock.get = jest
+        .fn()
+        .mockResolvedValueOnce({ data: mockServerInfo }) // /api/info
+        .mockRejectedValueOnce(new Error('uniqueID fetch failed')) // getUniqueId
+        .mockResolvedValueOnce({ data: createMockCloudInfo() }); // cloud lookup
+
+      await updateSupportedVersionsData(mockServer.url);
+
+      const cloudCall = axiosMock.get.mock.calls.find(([url]) =>
+        (url as string).includes('releases.rocket.chat')
+      );
+      expect(cloudCall).toBeDefined();
+    });
+  });
+
+  // ========== FIX-5: getExpirationMessageTranslated must not throw ==========
+  describe('getExpirationMessageTranslated i18n guard', () => {
+    it('returns null instead of throwing when i18n has neither the requested language nor "en"', () => {
+      const result = getExpirationMessageTranslated(
+        {},
+        { title: 'title', subtitle: 'sub', description: 'desc' } as any,
+        new Date(Date.now() + 86400000),
+        'en',
+        'My Server',
+        'https://rocket.chat',
+        '7.0.0'
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  // ========== FIX-7: revalidate all servers on wake-from-sleep ==========
+  describe('power resume revalidation', () => {
+    it('registers a powerMonitor resume handler when checkSupportedVersionServers runs', async () => {
+      const electronMock = jest.requireMock('electron');
+
+      checkSupportedVersionServers();
+
+      expect(electronMock.powerMonitor.on).toHaveBeenCalledWith(
+        'resume',
+        expect.any(Function)
+      );
     });
   });
 });

--- a/src/servers/supportedVersions/main.main.spec.ts
+++ b/src/servers/supportedVersions/main.main.spec.ts
@@ -475,7 +475,7 @@ describe('supportedVersions/main.ts', () => {
       });
     });
 
-    it('should reject the exception when the fetched uniqueID does not match the exception scope', async () => {
+    it('honors the server-source exception with a warning when the fetched uniqueID does not match the scope', async () => {
       const mockServer = createMockServer({ version: '7.13' });
       const mockServerInfo = createMockServerInfo({
         version: '7.13',
@@ -493,7 +493,15 @@ describe('supportedVersions/main.ts', () => {
         tenantSupportedVersions()
       );
 
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
       await updateSupportedVersionsData(mockServer.url);
+
+      // Server-source payloads are self-scoped; a mismatch is diagnostic
+      // only and the exception is still honored.
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('exception scope mismatch')
+      );
+      consoleWarnSpy.mockRestore();
 
       const verdictDispatch = dispatchMock.mock.calls.find(
         ([action]) =>
@@ -503,7 +511,7 @@ describe('supportedVersions/main.ts', () => {
         type: WEBVIEW_SERVER_IS_SUPPORTED_VERSION,
         payload: {
           url: mockServer.url,
-          isSupportedVersion: false,
+          isSupportedVersion: true,
         },
       });
     });
@@ -1965,7 +1973,7 @@ describe('supportedVersions/main.ts', () => {
       i18n: {},
     };
 
-    it('does NOT honor commit-hash exception when payload domain mismatches server', async () => {
+    it('does NOT honor commit-hash exception from the BUILTIN payload when the domain mismatches', async () => {
       const payload = {
         ...baseVersions,
         exceptions: {
@@ -1975,7 +1983,9 @@ describe('supportedVersions/main.ts', () => {
         },
       } as unknown as SupportedVersions;
 
-      // Server B has matching commit hash but different domain.
+      // Server B has matching commit hash but different domain. The builtin
+      // payload is the only source that can carry another tenant's
+      // exceptions, so it keeps the strict scope requirement.
       const serverB = {
         url: 'https://tenant-b.example.com/',
         version: '8.5',
@@ -1986,13 +1996,14 @@ describe('supportedVersions/main.ts', () => {
       const result = await isServerVersionSupported(
         serverB,
         payload,
-        'abc1234567890'
+        'abc1234567890',
+        'builtin'
       );
       // Enforcement falls through (no versions match either) -> unsupported.
       expect(result.supported).toBe(false);
     });
 
-    it('does NOT honor commit-hash exception when payload uniqueId mismatches server', async () => {
+    it('does NOT honor commit-hash exception from the BUILTIN payload when uniqueId mismatches', async () => {
       const payload = {
         ...baseVersions,
         exceptions: {
@@ -2013,9 +2024,41 @@ describe('supportedVersions/main.ts', () => {
       const result = await isServerVersionSupported(
         serverB,
         payload,
-        'abc1234567890'
+        'abc1234567890',
+        'builtin'
       );
       expect(result.supported).toBe(false);
+    });
+
+    it('honors a scope-mismatched exception from a SERVER-source payload with a diagnostic warning', async () => {
+      const payload = {
+        ...baseVersions,
+        exceptions: {
+          domain: 'tenant-a.example.com',
+          uniqueId: 'tenant-a-unique',
+          versions: [{ version: 'sha-abc1234', expiration: futureExpiry }],
+        },
+      } as unknown as SupportedVersions;
+
+      const serverB = {
+        url: 'https://tenant-b.example.com/',
+        version: '8.5',
+        title: 'Tenant B',
+        uniqueID: 'tenant-b-unique',
+      } as any;
+
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const result = await isServerVersionSupported(
+        serverB,
+        payload,
+        'abc1234567890',
+        'server'
+      );
+      expect(result.supported).toBe(true);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('exception scope mismatch')
+      );
+      consoleWarnSpy.mockRestore();
     });
 
     it('honors commit-hash exception when domain AND uniqueId both match', async () => {
@@ -2055,8 +2098,7 @@ describe('supportedVersions/main.ts', () => {
 
       // Same domain. Same commit hash. Local uniqueID UNKNOWN (e.g.
       // settings.public restricted by enterprise API ACLs). An unprovable
-      // identity must not disqualify a domain-matched exception — wrongly
-      // blocking a legitimate tenant is the worse failure mode.
+      // identity must not disqualify a domain-matched exception.
       const serverWithoutUniqueID = {
         url: 'https://tenant-a.example.com/',
         version: '8.5',
@@ -2072,7 +2114,7 @@ describe('supportedVersions/main.ts', () => {
       expect(result.supported).toBe(true);
     });
 
-    it('rejects scoped exception on a PROVEN uniqueID mismatch even when the domain matches', async () => {
+    it('rejects a BUILTIN-source exception on a PROVEN uniqueID mismatch even when the domain matches', async () => {
       const payload = {
         ...baseVersions,
         exceptions: {
@@ -2092,7 +2134,8 @@ describe('supportedVersions/main.ts', () => {
       const result = await isServerVersionSupported(
         serverWithOtherUniqueID,
         payload,
-        'abc1234567890'
+        'abc1234567890',
+        'builtin'
       );
       expect(result.supported).toBe(false);
     });

--- a/src/servers/supportedVersions/main.main.spec.ts
+++ b/src/servers/supportedVersions/main.main.spec.ts
@@ -1016,6 +1016,48 @@ describe('supportedVersions/main.ts', () => {
       expect(result.supported).toBe(true);
     });
 
+    it('does not block when enforcementStartDate is missing (uncertain data must not block)', async () => {
+      const supportedVersions = {
+        versions: [{ version: '9.9.0', expiration: new Date() }],
+        // no enforcementStartDate
+      };
+
+      const result = await isServerVersionSupported(
+        mockServer as any,
+        supportedVersions as any
+      );
+
+      expect(result.supported).toBe(true);
+    });
+
+    it('does not block when enforcementStartDate is malformed', async () => {
+      const supportedVersions = {
+        versions: [{ version: '9.9.0', expiration: new Date() }],
+        enforcementStartDate: 'not-a-date',
+      };
+
+      const result = await isServerVersionSupported(
+        mockServer as any,
+        supportedVersions as any
+      );
+
+      expect(result.supported).toBe(true);
+    });
+
+    it('blocks when a valid past enforcementStartDate is present and nothing matches', async () => {
+      const supportedVersions = {
+        versions: [{ version: '9.9.0', expiration: new Date() }],
+        enforcementStartDate: new Date(Date.now() - 86400000).toISOString(),
+      };
+
+      const result = await isServerVersionSupported(
+        mockServer as any,
+        supportedVersions as any
+      );
+
+      expect(result.supported).toBe(false);
+    });
+
     it('should honor exceptions when exceptions.domain differs only by letter case', async () => {
       const futureDate = new Date(Date.now() + 86400000);
       const supportedVersions: SupportedVersions = {

--- a/src/servers/supportedVersions/main.ts
+++ b/src/servers/supportedVersions/main.ts
@@ -451,9 +451,17 @@ export const isServerVersionSupported = async (
     }
   }
 
-  const enforcementStartDate = new Date(
-    supportedVersionsData?.enforcementStartDate
-  );
+  // Only block when the payload proves enforcement is active. A missing or
+  // malformed enforcementStartDate is incomplete data, and an uncertain
+  // verdict must not block — keep the server usable until a payload with a
+  // valid enforcement date proves otherwise.
+  const rawEnforcementStartDate = supportedVersionsData?.enforcementStartDate;
+  const enforcementStartDate = rawEnforcementStartDate
+    ? new Date(rawEnforcementStartDate)
+    : undefined;
+  if (!enforcementStartDate || Number.isNaN(enforcementStartDate.getTime())) {
+    return { supported: true };
+  }
   if (enforcementStartDate > new Date()) {
     const selectedExpirationMessage = getExpirationMessage({
       messages: supportedVersionsData.messages,

--- a/src/servers/supportedVersions/main.ts
+++ b/src/servers/supportedVersions/main.ts
@@ -2,7 +2,7 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import axios from 'axios';
-import { ipcMain } from 'electron';
+import { ipcMain, powerMonitor } from 'electron';
 import ElectronStore from 'electron-store';
 import jwt from 'jsonwebtoken';
 import moment from 'moment';
@@ -82,7 +82,7 @@ const logRequestError =
         console.error(`Couldn't load ${description}: ${error.message}`);
       }
     } else {
-      console.error('Fetching ${description} error:', error);
+      console.error(`Fetching ${description} error:`, error);
     }
     return undefined;
   };
@@ -299,6 +299,9 @@ export const getExpirationMessageTranslated = (
   }
 
   const i18nLang = i18n[language] ?? i18n.en;
+  if (!i18nLang) {
+    return null;
+  }
 
   const getTranslation = (key: string) =>
     key && i18nLang[key] ? applyParams(i18nLang[key], params) : undefined;
@@ -341,10 +344,13 @@ export const isServerVersionSupported = async (
   // Exception entries only apply when the payload's exceptions block is scoped
   // to THIS server. The cloud-source and server-source payloads are inherently
   // scoped, but the builtin (bundled) and cache payloads can be from a different
-  // tenant, so a domain/uniqueId mismatch must disqualify the exceptions to
-  // avoid cross-tenant bypass.
-  // Treat present scope fields as REQUIRED equality. Missing local identity
-  // (e.g. server.uniqueID undefined) does NOT relax the check — it must reject.
+  // tenant, so a PROVEN domain/uniqueId mismatch must disqualify the exceptions
+  // to avoid cross-tenant leakage.
+  // An UNKNOWN local uniqueID (e.g. settings.public restricted by enterprise
+  // API ACLs) does NOT disqualify: this gate is client-side UX enforcement,
+  // not a security boundary, and wrongly blocking a paying tenant is the worse
+  // failure mode. Domain equality (checked whenever the payload carries a
+  // domain) remains the primary scope.
   let exceptionScopeMatches = true;
   if (exceptions) {
     let hostname: string | undefined;
@@ -357,7 +363,11 @@ export const isServerVersionSupported = async (
     if (exceptions.domain && exceptions.domain.toLowerCase() !== hostname) {
       exceptionScopeMatches = false;
     }
-    if (exceptions.uniqueId && exceptions.uniqueId !== server.uniqueID) {
+    if (
+      exceptions.uniqueId &&
+      server.uniqueID &&
+      exceptions.uniqueId !== server.uniqueID
+    ) {
       exceptionScopeMatches = false;
     }
   }
@@ -527,6 +537,48 @@ const withExceptionScopeUniqueId = async (
     : serverView;
 };
 
+// Validates the fallback (cache/builtin) payload and dispatches the verdict.
+// isServerVersionSupported can throw on a malformed cached/builtin payload
+// (e.g. `versions` not an array). Left unguarded, that throw would reject
+// updateSupportedVersionsData before WEBVIEW_SERVER_SUPPORTED_VERSIONS_ERROR
+// is dispatched, leaving supportedVersionsFetchState stuck at 'loading' —
+// which suppresses the UnsupportedServer block gate (fail-open). On failure,
+// only the error state is dispatched; the prior verdict is left untouched.
+const validateFallbackAndDispatch = async (
+  server: Server,
+  serverUrl: string,
+  fallbackVersions: SupportedVersions,
+  fallbackSource: 'cloud' | 'builtin',
+  freshCommitHash: string | undefined,
+  isStale: () => boolean
+): Promise<void> => {
+  try {
+    const fallbackSupported = await isServerVersionSupported(
+      server,
+      fallbackVersions,
+      freshCommitHash
+    );
+    if (isStale()) return;
+    dispatch({
+      type: WEBVIEW_SERVER_IS_SUPPORTED_VERSION,
+      payload: {
+        url: server.url,
+        isSupportedVersion: fallbackSupported.supported,
+      },
+    });
+    dispatchSupportedVersionsUpdated(server.url, fallbackVersions, {
+      source: fallbackSource,
+    });
+  } catch (error) {
+    console.error('Error validating fallback supported versions:', error);
+  }
+  if (isStale()) return;
+  dispatch({
+    type: WEBVIEW_SERVER_SUPPORTED_VERSIONS_ERROR,
+    payload: { url: serverUrl },
+  });
+};
+
 // Per-URL request generation counter. Each call to updateSupportedVersionsData
 // bumps the counter and captures its own generation. Awaited steps inside the
 // call check whether their generation is still current before dispatching, so
@@ -643,10 +695,15 @@ export const updateSupportedVersionsData = async (
     uniqueID: uniqueID ?? serverWithFreshVersion.uniqueID,
   };
 
+  // Fall back to the persisted uniqueID when the fresh fetch failed, so a
+  // prior session's identity still enables the cloud lookup instead of
+  // skipping it outright.
+  const effectiveUniqueId = uniqueID ?? server.uniqueID;
+
   // Try Cloud with retries (3x with 2s delays) if unique ID available
-  if (!serverEncoded && uniqueID) {
+  if (!serverEncoded && effectiveUniqueId) {
     const cloudVersionsWithRetry = await withRetries(
-      () => getCloudInfo(server.url, uniqueID),
+      () => getCloudInfo(server.url, effectiveUniqueId),
       3,
       2000
     );
@@ -703,26 +760,15 @@ export const updateSupportedVersionsData = async (
   if (fallbackVersions) {
     if (isStale()) return;
     saveToCache(serverUrl, fallbackVersions);
-    const fallbackSupported = await isServerVersionSupported(
-      serverWithFreshIdentity,
-      fallbackVersions,
-      freshCommitHash
-    );
     if (isStale()) return;
-    dispatch({
-      type: WEBVIEW_SERVER_IS_SUPPORTED_VERSION,
-      payload: {
-        url: server.url,
-        isSupportedVersion: fallbackSupported.supported,
-      },
-    });
-    dispatchSupportedVersionsUpdated(server.url, fallbackVersions, {
-      source: fallbackSource,
-    });
-    dispatch({
-      type: WEBVIEW_SERVER_SUPPORTED_VERSIONS_ERROR,
-      payload: { url: serverUrl },
-    });
+    await validateFallbackAndDispatch(
+      serverWithFreshIdentity,
+      serverUrl,
+      fallbackVersions,
+      fallbackSource,
+      freshCommitHash,
+      isStale
+    );
     return;
   }
 
@@ -739,20 +785,46 @@ export const updateSupportedVersionsData = async (
   });
 };
 
+const logUpdateError =
+  (serverUrl: string) =>
+  (error: unknown): void => {
+    console.error(
+      `Error updating supported versions data for ${serverUrl}:`,
+      error
+    );
+  };
+
 export function checkSupportedVersionServers(): void {
   listen(WEBVIEW_READY, async (action) => {
-    updateSupportedVersionsData(action.payload.url);
+    updateSupportedVersionsData(action.payload.url).catch(
+      logUpdateError(action.payload.url)
+    );
   });
 
   listen(SUPPORTED_VERSION_DIALOG_DISMISS, async (action) => {
-    updateSupportedVersionsData(action.payload.url);
+    updateSupportedVersionsData(action.payload.url).catch(
+      logUpdateError(action.payload.url)
+    );
   });
 
   listen(WEBVIEW_SERVER_RELOADED, async (action) => {
-    updateSupportedVersionsData(action.payload.url);
+    updateSupportedVersionsData(action.payload.url).catch(
+      logUpdateError(action.payload.url)
+    );
   });
 
   ipcMain.handle('refresh-supported-versions', async (_event, serverUrl) => {
-    updateSupportedVersionsData(serverUrl);
+    updateSupportedVersionsData(serverUrl).catch(logUpdateError(serverUrl));
+  });
+
+  // 'online' only fires on real network transitions, not on wake-from-sleep
+  // (e.g. laptop resumes with the same network already connected). Without
+  // this, a server's supported-versions verdict can go stale for the entire
+  // duration of a sleep period until the next WEBVIEW_READY/reload/dismiss.
+  powerMonitor.on('resume', () => {
+    const servers = select(({ servers }) => servers);
+    servers.forEach((server) => {
+      updateSupportedVersionsData(server.url).catch(logUpdateError(server.url));
+    });
   });
 }

--- a/src/servers/supportedVersions/main.ts
+++ b/src/servers/supportedVersions/main.ts
@@ -319,7 +319,8 @@ export const getExpirationMessageTranslated = (
 export const isServerVersionSupported = async (
   server: Server,
   supportedVersionsData?: SupportedVersions,
-  serverCommitHash?: string
+  serverCommitHash?: string,
+  payloadSource?: 'server' | 'cloud' | 'builtin'
 ): Promise<{
   supported: boolean;
   message?: Message | undefined;
@@ -341,17 +342,16 @@ export const isServerVersionSupported = async (
 
   if (!supportedVersionsData) return { supported: true };
 
-  // Exception entries only apply when the payload's exceptions block is scoped
-  // to THIS server. The cloud-source and server-source payloads are inherently
-  // scoped, but the builtin (bundled) and cache payloads can be from a different
-  // tenant, so a PROVEN domain/uniqueId mismatch must disqualify the exceptions
-  // to avoid cross-tenant leakage.
+  // A valid, unexpired exception must never be rejected on a scope
+  // technicality. Server, cloud, and cache payloads are inherently
+  // self-scoped (fetched from/for THIS server), so for them a domain/uniqueId
+  // mismatch is logged for diagnostics but the exception is still honored.
+  // The bundled builtin payload is the only source that could carry another
+  // tenant's exceptions, so it alone keeps the strict scope requirement.
   // An UNKNOWN local uniqueID (e.g. settings.public restricted by enterprise
-  // API ACLs) does NOT disqualify: this gate is client-side UX enforcement,
-  // not a security boundary, and wrongly blocking a paying tenant is the worse
-  // failure mode. Domain equality (checked whenever the payload carries a
-  // domain) remains the primary scope.
-  let exceptionScopeMatches = true;
+  // API ACLs) is never treated as a mismatch: this gate is client-side UX
+  // enforcement, not a security boundary.
+  let exceptionScopeMismatch = false;
   if (exceptions) {
     let hostname: string | undefined;
     try {
@@ -361,15 +361,25 @@ export const isServerVersionSupported = async (
     }
     // DNS names are case-insensitive; URL.hostname is already lowercased.
     if (exceptions.domain && exceptions.domain.toLowerCase() !== hostname) {
-      exceptionScopeMatches = false;
+      exceptionScopeMismatch = true;
     }
     if (
       exceptions.uniqueId &&
       server.uniqueID &&
       exceptions.uniqueId !== server.uniqueID
     ) {
-      exceptionScopeMatches = false;
+      exceptionScopeMismatch = true;
     }
+  }
+  const exceptionScopeMatches =
+    !exceptionScopeMismatch || payloadSource !== 'builtin';
+  if (exceptionScopeMismatch && exceptionScopeMatches) {
+    console.warn(
+      `Supported-versions exception scope mismatch for ${server.url} ` +
+        `(payload domain: ${exceptions?.domain}, uniqueId: ${exceptions?.uniqueId}; ` +
+        `local uniqueID: ${server.uniqueID}) — honoring exception from ` +
+        `${payloadSource ?? 'unspecified'} source anyway`
+    );
   }
 
   // Match against the freshly-fetched commit hash when available, falling
@@ -556,7 +566,8 @@ const validateFallbackAndDispatch = async (
     const fallbackSupported = await isServerVersionSupported(
       server,
       fallbackVersions,
-      freshCommitHash
+      freshCommitHash,
+      fallbackSource
     );
     if (isStale()) return;
     dispatch({
@@ -652,7 +663,8 @@ export const updateSupportedVersionsData = async (
         const supported = await isServerVersionSupported(
           serverForValidation,
           serverSupportedVersions,
-          freshCommitHash
+          freshCommitHash,
+          'server'
         );
         if (isStale()) return;
         // Dispatch verdict BEFORE fetchState='success' so UnsupportedServer
@@ -718,7 +730,8 @@ export const updateSupportedVersionsData = async (
         const supported = await isServerVersionSupported(
           serverWithFreshIdentity,
           cloudSupportedVersions,
-          freshCommitHash
+          freshCommitHash,
+          'cloud'
         );
         if (isStale()) return;
         dispatch({

--- a/src/ui/components/ServersView/ServerPane.tsx
+++ b/src/ui/components/ServersView/ServerPane.tsx
@@ -234,6 +234,7 @@ export const ServerPane = ({
         isSupported={isSupported}
         fetchState={supportedVersionsFetchState}
         instanceDomain={new URL(serverUrl).hostname}
+        serverUrl={serverUrl}
       />
       <ErrorView isFailed={isFailed} onReload={handleReload} />
     </Wrapper>

--- a/src/ui/components/ServersView/UnsupportedServer.spec.tsx
+++ b/src/ui/components/ServersView/UnsupportedServer.spec.tsx
@@ -1,0 +1,96 @@
+import { ipcRenderer } from 'electron';
+
+import { render, screen, userEvent } from '../../test-utils';
+import UnsupportedServer from './UnsupportedServer';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) =>
+      options ? `${key} ${JSON.stringify(options)}` : key,
+    i18n: { language: 'en', changeLanguage: jest.fn() },
+  }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}));
+
+jest.mock('electron', () => ({
+  ipcRenderer: {
+    invoke: jest.fn(),
+  },
+}));
+
+const invokeMock = ipcRenderer.invoke as jest.MockedFunction<
+  typeof ipcRenderer.invoke
+>;
+
+const SERVER_URL = 'https://chat.example.com/';
+
+describe('UnsupportedServer', () => {
+  beforeEach(() => {
+    invokeMock.mockClear();
+  });
+
+  it('renders the check again button when isSupported is false', () => {
+    render(
+      <UnsupportedServer
+        isSupported={false}
+        fetchState='error'
+        instanceDomain='chat.example.com'
+        serverUrl={SERVER_URL}
+      />
+    );
+
+    expect(
+      screen.getByText('unsupportedServer.checkAgain')
+    ).toBeInTheDocument();
+  });
+
+  it('invokes refresh-supported-versions with the server url on click', async () => {
+    const user = userEvent.setup();
+    render(
+      <UnsupportedServer
+        isSupported={false}
+        fetchState='error'
+        instanceDomain='chat.example.com'
+        serverUrl={SERVER_URL}
+      />
+    );
+
+    await user.click(screen.getByText('unsupportedServer.checkAgain'));
+
+    expect(invokeMock).toHaveBeenCalledWith(
+      'refresh-supported-versions',
+      SERVER_URL
+    );
+  });
+
+  it('does not render the blocking gate when isSupported is true', () => {
+    render(
+      <UnsupportedServer
+        isSupported
+        fetchState='success'
+        instanceDomain='chat.example.com'
+        serverUrl={SERVER_URL}
+      />
+    );
+
+    expect(
+      screen.queryByText('unsupportedServer.checkAgain')
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render the blocking gate while a fresh validation is loading', () => {
+    render(
+      <UnsupportedServer
+        isSupported={false}
+        fetchState='loading'
+        instanceDomain='chat.example.com'
+        serverUrl={SERVER_URL}
+      />
+    );
+
+    expect(
+      screen.queryByText('unsupportedServer.checkAgain')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/ui/components/ServersView/UnsupportedServer.tsx
+++ b/src/ui/components/ServersView/UnsupportedServer.tsx
@@ -16,12 +16,14 @@ type UnsupportedServerProps = {
   isSupported: boolean | undefined;
   fetchState?: 'idle' | 'loading' | 'success' | 'error';
   instanceDomain: string;
+  serverUrl: string;
 };
 
 const UnsupportedServer = ({
   isSupported,
   fetchState,
   instanceDomain,
+  serverUrl,
 }: UnsupportedServerProps) => {
   const { t } = useTranslation();
 
@@ -30,6 +32,10 @@ const UnsupportedServer = ({
       'server-view/open-url-on-browser',
       urls.docs.supportedVersions
     );
+  };
+
+  const handleCheckAgainButtonClick = (): void => {
+    ipcRenderer.invoke('refresh-supported-versions', serverUrl);
   };
 
   // Block whenever a definitive `false` verdict exists, except while a fresh
@@ -66,6 +72,9 @@ const UnsupportedServer = ({
             <StatesActions>
               <Button secondary onClick={handleMoreInfoButtonClick}>
                 {t('unsupportedServer.moreInformation')}
+              </Button>
+              <Button onClick={handleCheckAgainButtonClick}>
+                {t('unsupportedServer.checkAgain')}
               </Button>
             </StatesActions>
           </States>

--- a/src/ui/components/SupportedVersionDialog/index.spec.tsx
+++ b/src/ui/components/SupportedVersionDialog/index.spec.tsx
@@ -1,8 +1,12 @@
+import { act } from '@testing-library/react';
 import { ipcRenderer } from 'electron';
 
 import { SupportedVersionDialog } from '.';
 import * as urls from '../../../urls';
-import { SUPPORTED_VERSION_DIALOG_DISMISS } from '../../actions';
+import {
+  SIDE_BAR_SERVER_SELECTED,
+  SUPPORTED_VERSION_DIALOG_DISMISS,
+} from '../../actions';
 import { renderWithStore, screen, userEvent, waitFor } from '../../test-utils';
 
 jest.mock('react-i18next', () => ({
@@ -163,5 +167,38 @@ describe('SupportedVersionDialog', () => {
 
     await waitFor(() => expect(isServerVersionSupported).toHaveBeenCalled());
     expect(screen.queryByText('Workspace expiring')).not.toBeInTheDocument();
+  });
+
+  it('re-runs the version check when the selected currentView changes', async () => {
+    const OTHER_SERVER_URL = 'https://chat.other.com/';
+    const { store } = renderWithStore(<SupportedVersionDialog />, {
+      preloadedState: {
+        ...preloadedState,
+        servers: [
+          ...preloadedState.servers,
+          {
+            url: OTHER_SERVER_URL,
+            title: 'Other',
+            version: '6.0.0',
+            supportedVersions: { versions: [], messages: [] },
+          },
+        ],
+      },
+    });
+
+    await waitFor(() =>
+      expect(isServerVersionSupported).toHaveBeenCalledTimes(1)
+    );
+
+    act(() => {
+      store.dispatch({
+        type: SIDE_BAR_SERVER_SELECTED,
+        payload: OTHER_SERVER_URL,
+      });
+    });
+
+    await waitFor(() =>
+      expect(isServerVersionSupported).toHaveBeenCalledTimes(2)
+    );
   });
 });

--- a/src/ui/components/SupportedVersionDialog/index.tsx
+++ b/src/ui/components/SupportedVersionDialog/index.tsx
@@ -15,7 +15,7 @@ import { ipcRenderer } from 'electron';
 import moment from 'moment';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { getLanguage } from '../../../i18n/main';
@@ -25,9 +25,9 @@ import {
 } from '../../../servers/supportedVersions/main';
 import type { MessageTranslated } from '../../../servers/supportedVersions/types';
 import type { RootAction } from '../../../store/actions';
+import type { RootState } from '../../../store/rootReducer';
 import * as urls from '../../../urls';
 import { SUPPORTED_VERSION_DIALOG_DISMISS } from '../../actions';
-import { currentView } from '../../reducers/currentView';
 import ModalBackdrop from '../Modal/ModalBackdrop';
 import { useServers } from '../hooks/useServers';
 import { Wrapper } from './styles';
@@ -35,6 +35,7 @@ import { Wrapper } from './styles';
 export const SupportedVersionDialog = () => {
   const [isVisible, setIsVisible] = useState(false);
   const dispatch = useDispatch<Dispatch<RootAction>>();
+  const currentView = useSelector(({ currentView }: RootState) => currentView);
 
   const servers = useServers();
   const server = servers.find((server) => server.selected === true);
@@ -140,8 +141,7 @@ export const SupportedVersionDialog = () => {
 
   useEffect(() => {
     checkServerVersion();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [server?.supportedVersions, server?.lastPath, currentView]);
+  }, [checkServerVersion, currentView]);
 
   const handleMoreInfoButtonClick = (): void => {
     if (expirationMessage?.link && expirationMessage?.link !== '') {


### PR DESCRIPTION
Stacked on #3404 — retarget to `master` after it merges.

## What

Follow-up hardening pass over the supported-versions subsystem after the exception-scope investigation in #3404. Two independent audits (main-process flow and renderer surfaces) produced the findings below; every fix ships with a regression test.

## Fixes

**Validation robustness (main process)**
- Wrap the cache/builtin fallback validation in a helper with try/catch. A malformed cached payload could previously reject `updateSupportedVersionsData` before the error state was dispatched, leaving `supportedVersionsFetchState` stuck at `'loading'` — which suppresses the UnsupportedServer block gate. The error state is now always dispatched and the prior verdict is preserved.
- Catch rejections at all four fire-and-forget validation call sites (three listeners + the `refresh-supported-versions` IPC handler).
- Fall back to the persisted workspace uniqueID when the fresh fetch fails, so the cloud lookup is not skipped for previously-known servers.
- Revalidate all servers on `powerMonitor` `'resume'` — the window `'online'` event does not fire when waking with the same network still connected.

**Exception scoping**
- Server, cloud, and cache payloads are fetched from or for the server being validated, so their exceptions block cannot belong to another tenant. For these sources a domain/uniqueId scope mismatch is now a diagnostic warning instead of disqualifying the exception. The bundled builtin payload — the only source that could carry another deployment's exceptions — keeps the strict scope requirement.
- An unknown local uniqueID (e.g. `settings.public` restricted by API access controls) is never treated as a scope mismatch.
- `exceptions.domain` comparison was already made case-insensitive in #3404.

**State integrity**
- `WEBVIEW_SERVER_UNIQUE_ID_UPDATED`, `WEBVIEW_SERVER_VERSION_UPDATED`, and `WEBVIEW_GIT_COMMIT_HASH_CHANGED` reducer cases switched from `upsert` to `update`: a late identity dispatch for a server deleted while a validation was in flight can no longer resurrect a ghost server entry.

**Renderer**
- `SupportedVersionDialog` effect dependencies used the imported `currentView` reducer function (never changes) instead of the state value, so the dialog never re-checked when switching server views. Now selects the real state.
- Guard `getExpirationMessageTranslated` against payloads whose i18n dictionary lacks both the user language and `en`; the unguarded lookup crashed the async check and silently suppressed the expiring-workspace warning dialog.
- Add a **Check again** button to the unsupported-workspace screen so validation can be re-triggered without restarting the app (new `unsupportedServer.checkAgain` en key; other locales fall back).

**Enforcement certainty**
- A missing or malformed `enforcementStartDate` no longer blocks the workspace: an Invalid Date previously failed the future-date comparison and fell through to the unsupported verdict on incomplete payload data. Blocking now requires a valid, past enforcement date.

**Cosmetic**
- `logRequestError` printed a literal `${description}` (single-quoted string).

## Out of scope, tracked for follow-up
- Signing-key rotation contingency (single hardcoded RS256 key; needs cloud-side coordination).
- Expired exception + future `enforcementStartDate` ⇒ supported (global grace masks a lapsed exception) — needs product confirmation.
- Test-fixture realism: default mocks include `uniqueId`/`commit`/full patch version in `/api/info`, which real unauthenticated servers do not send.

## Tests
- 143 tests across the four touched suites pass; full repo suite 152 suites / 1602 tests green. `tsc --noEmit` and `yarn lint` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **“Check again”** option on the unsupported server dialog to re-run compatibility checks.

* **Bug Fixes**
  * Server compatibility checks now refresh when you switch to a different server.
  * Improved handling after sleep/wake so supported-version status is revalidated automatically.
  * Fixed cases where unsupported-server status could behave incorrectly after missing or stale data.
  * Updated unsupported-server messaging to include the new recheck action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
