### PR TITLE
fix: align supported-versions with the real /api/info contract; exception-aware fallback

### DIFF
--- a/src/servers/supportedVersions/apiContract.main.spec.ts
+++ b/src/servers/supportedVersions/apiContract.main.spec.ts
@@ -1,0 +1,127 @@
+// Live wire-contract test for the Rocket.Chat /api/info endpoint.
+//
+// WHY THIS EXISTS: a `uniqueId` field that the desktop's ServerInfo type
+// assumed the endpoint returned was fictional — it was never actually part
+// of the real /api/info response, and this went uncaught for 2.5 years
+// because every test that exercised this code path did so against
+// self-referential mocks (fixtures the desktop repo wrote itself) rather
+// than the real server. Mocks can only fail the same way the code that
+// authored them already fails, so they can't catch this class of drift.
+//
+// This spec instead fetches the LIVE public /api/info endpoint
+// (https://open.rocket.chat/api/info — same unauthenticated call the
+// desktop makes in src/servers/supportedVersions/main.ts) and asserts the
+// shape the desktop actually depends on, sourced from the server-side
+// implementation (apps/meteor/server/api/lib/getServerInfo.ts) rather than
+// from the desktop's own types.
+//
+// SKIP SEMANTICS: a network outage must not fail CI, but a reachable server
+// that has drifted from the contract must. The suite is skipped (with a
+// console.warn explaining why) only when the endpoint could not be reached
+// for network reasons (timeout/DNS/5xx) or when SKIP_CONTRACT_TESTS=1 is
+// set. Any other outcome — including a 2xx response with an unexpected
+// shape — runs the assertions and fails normally.
+
+import axios from 'axios';
+
+const ENDPOINT = 'https://open.rocket.chat/api/info';
+const FETCH_TIMEOUT_MS = 15000;
+const MAX_ATTEMPTS = 2;
+
+let body: Record<string, unknown> | undefined;
+let skipReason: string | undefined;
+
+const isNetworkFailure = (error: unknown): boolean => {
+  if (!axios.isAxiosError(error)) return false;
+  // No response at all → timeout, DNS failure, connection refused, etc.
+  if (!error.response) return true;
+  // 5xx means the server itself is unhealthy, not that the contract changed.
+  return error.response.status >= 500;
+};
+
+const fetchServerInfo = async (): Promise<Record<string, unknown>> => {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    try {
+      // Each retry must wait for the previous attempt's outcome, not run
+      // concurrently with it.
+      // eslint-disable-next-line no-await-in-loop
+      const response = await axios.get(ENDPOINT, {
+        timeout: FETCH_TIMEOUT_MS,
+      });
+      return response.data;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError;
+};
+
+beforeAll(
+  async () => {
+    if (process.env.SKIP_CONTRACT_TESTS === '1') {
+      skipReason = 'SKIP_CONTRACT_TESTS=1 is set';
+      console.warn(`Skipping /api/info contract tests: ${skipReason}.`);
+      return;
+    }
+
+    try {
+      body = await fetchServerInfo();
+    } catch (error) {
+      if (isNetworkFailure(error)) {
+        skipReason = `network error reaching ${ENDPOINT}: ${
+          axios.isAxiosError(error) ? error.message : String(error)
+        }`;
+        console.warn(`Skipping /api/info contract tests: ${skipReason}.`);
+        return;
+      }
+      throw error;
+    }
+  },
+  FETCH_TIMEOUT_MS * MAX_ATTEMPTS + 5000
+);
+
+describe('/api/info wire contract', () => {
+  test('version is trimmed major.minor, not three segments', () => {
+    if (skipReason) return;
+    expect(typeof body?.version).toBe('string');
+    expect(body?.version).toMatch(/^\d+\.\d+$/);
+  });
+
+  test('uniqueId is not present on the unauthenticated response', () => {
+    if (skipReason) return;
+    expect(body && 'uniqueId' in body).toBe(false);
+  });
+
+  test('commit and info blocks are not present to unauthenticated callers', () => {
+    if (skipReason) return;
+    expect(body && 'commit' in body).toBe(false);
+    expect(body && 'info' in body).toBe(false);
+  });
+
+  test('minimumClientVersions has string desktop and mobile versions', () => {
+    if (skipReason) return;
+    const minimumClientVersions = body?.minimumClientVersions as
+      | Record<string, unknown>
+      | undefined;
+    expect(typeof minimumClientVersions).toBe('object');
+    expect(typeof minimumClientVersions?.desktop).toBe('string');
+    expect(typeof minimumClientVersions?.mobile).toBe('string');
+  });
+
+  test('supportedVersions.signed, when present, is a non-empty JWT', () => {
+    if (skipReason) return;
+    const supportedVersions = body?.supportedVersions as
+      | Record<string, unknown>
+      | undefined;
+    if (supportedVersions === undefined) return;
+    expect(typeof supportedVersions.signed).toBe('string');
+    expect((supportedVersions.signed as string).length).toBeGreaterThan(0);
+    expect((supportedVersions.signed as string).split('.').length).toBe(3);
+  });
+
+  test('success is true', () => {
+    if (skipReason) return;
+    expect(body?.success).toBe(true);
+  });
+});

--- a/src/servers/supportedVersions/main.main.spec.ts
+++ b/src/servers/supportedVersions/main.main.spec.ts
@@ -1,3 +1,5 @@
+import type * as fsPromisesType from 'node:fs/promises';
+
 import axios from 'axios';
 import * as jsonwebtoken from 'jsonwebtoken';
 
@@ -41,33 +43,22 @@ const selectMock = select as jest.MockedFunction<typeof select>;
 const listenMock = listen as jest.MockedFunction<typeof listen>;
 const axiosMock = axios as jest.Mocked<typeof axios>;
 
-// Mock data factories
+// Mock data factories.
+// Default shape mirrors the REAL unauthenticated GET /api/info response
+// (apps/meteor/server/api/lib/getServerInfo.ts): version is TRIMMED to
+// major.minor, and `build`/`marketplaceApiVersion`/`commit` are absent
+// because those only appear for authenticated view-statistics callers.
 const createMockServerInfo = (overrides?: Partial<ServerInfo>): ServerInfo => ({
-  version: '7.1.0',
-  uniqueId: 'test-unique-id',
-  build: {
-    date: '2024-01-01',
-    nodeVersion: '18.0.0',
-    arch: 'x64',
-    platform: 'darwin',
-    osRelease: '13.0.0',
-    totalMemory: 16000000000,
-    freeMemory: 8000000000,
-    cpus: 4,
+  version: '7.13',
+  minimumClientVersions: {
+    desktop: '3.9.6',
+    mobile: '4.39.0',
   },
-  marketplaceApiVersion: '1.30.0',
-  commit: {
-    hash: 'abc123',
-    date: new Date(),
-    author: 'Test Author',
-    subject: 'Test Commit',
-    tag: 'v7.1.0',
-    branch: 'main',
-  },
-  success: true,
   supportedVersions: {
     signed: 'mock-jwt-token',
   },
+  cloudWorkspaceId: 'mock-cloud-workspace-id',
+  success: true,
   ...overrides,
 });
 
@@ -107,7 +98,10 @@ const createMockServer = (overrides?: Partial<any>) => ({
 
 describe('supportedVersions/main.ts', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    // resetAllMocks (not clearAllMocks) so a jsonwebtoken.verify
+    // mockReturnValue/mockImplementation set by one test cannot leak into
+    // the next — clearAllMocks only clears call history, not implementations.
+    jest.resetAllMocks();
   });
 
   // ========== INITIALIZATION & SETUP TESTS ==========
@@ -167,7 +161,9 @@ describe('supportedVersions/main.ts', () => {
       // Should call axios.get once (success on first try)
       expect(axiosMock.get).toHaveBeenCalledTimes(1);
 
-      // Should dispatch VERSION_UPDATED with server info
+      // Should dispatch VERSION_UPDATED with server info. /api/info never
+      // carries `commit` for the desktop's unauthenticated request, so
+      // gitCommitHash is undefined here.
       const versionDispatch = dispatchMock.mock.calls.find(
         ([action]) => action.type === WEBVIEW_SERVER_VERSION_UPDATED
       );
@@ -177,19 +173,25 @@ describe('supportedVersions/main.ts', () => {
         payload: {
           url: mockServer.url,
           version: mockServerInfo.version,
-          gitCommitHash: mockServerInfo.commit.hash,
+          gitCommitHash: undefined,
         },
       });
     });
 
     it('should dispatch git commit hash from server info', async () => {
       const mockServer = createMockServer();
+      // `commit` only occurs for authenticated view-statistics calls; passed
+      // here explicitly to unit-test the dispatch wiring in isolation.
       const mockServerInfo = createMockServerInfo({
         commit: {
-          ...createMockServerInfo().commit,
           hash: 'bb83777b51a42d',
+          date: new Date(),
+          author: 'Test Author',
+          subject: 'Test Commit',
+          tag: 'v7.13',
+          branch: 'main',
         },
-      });
+      } as any);
       selectMock.mockReturnValue(mockServer);
       axiosMock.get = jest.fn().mockResolvedValue({ data: mockServerInfo });
 
@@ -289,8 +291,10 @@ describe('supportedVersions/main.ts', () => {
       selectMock.mockReturnValue(mockServer);
       axiosMock.get = jest.fn().mockResolvedValue({ data: mockServerInfo });
 
+      // No uniqueId-scoped exceptions here — this test is about the
+      // supportedVersions.signed decode path, not exception scope resolution.
       (jest.spyOn(jsonwebtoken, 'verify') as jest.Mock).mockReturnValue(
-        createMockSupportedVersions()
+        createMockSupportedVersions({ exceptions: undefined })
       );
 
       await updateSupportedVersionsData(mockServer.url);
@@ -403,7 +407,6 @@ describe('supportedVersions/main.ts', () => {
       const mockServer = createMockServer({ version: '7.13' });
       const mockServerInfo = createMockServerInfo({
         version: '7.13',
-        uniqueId: undefined,
       });
       selectMock.mockReturnValue(mockServer);
       axiosMock.get = jest
@@ -446,7 +449,6 @@ describe('supportedVersions/main.ts', () => {
       });
       const mockServerInfo = createMockServerInfo({
         version: '7.13',
-        uniqueId: undefined,
       });
       selectMock.mockReturnValue(mockServer);
       axiosMock.get = jest
@@ -479,7 +481,6 @@ describe('supportedVersions/main.ts', () => {
       const mockServer = createMockServer({ version: '7.13' });
       const mockServerInfo = createMockServerInfo({
         version: '7.13',
-        uniqueId: undefined,
       });
       selectMock.mockReturnValue(mockServer);
       axiosMock.get = jest
@@ -523,7 +524,6 @@ describe('supportedVersions/main.ts', () => {
       });
       const mockServerInfo = createMockServerInfo({
         version: '7.13',
-        uniqueId: undefined,
       });
       selectMock.mockReturnValue(mockServer);
       axiosMock.get = jest.fn().mockResolvedValueOnce({ data: mockServerInfo });
@@ -614,8 +614,10 @@ describe('supportedVersions/main.ts', () => {
       selectMock.mockReturnValue(mockServer);
       axiosMock.get = jest.fn().mockResolvedValue({ data: mockServerInfo });
 
+      // No uniqueId-scoped exceptions here — this test is about the cloud
+      // fetch being skipped, not exception scope resolution.
       (jest.spyOn(jsonwebtoken, 'verify') as jest.Mock).mockReturnValue(
-        createMockSupportedVersions()
+        createMockSupportedVersions({ exceptions: undefined })
       );
 
       await updateSupportedVersionsData(mockServer.url);
@@ -829,7 +831,12 @@ describe('supportedVersions/main.ts', () => {
     it('should return early after successful server decode and dispatch', async () => {
       const mockServer = createMockServer();
       const mockServerInfo = createMockServerInfo();
-      const mockSupportedVersions = createMockSupportedVersions();
+      // No uniqueId-scoped exceptions here — this test is about the
+      // early-return after a successful decode, not exception scope
+      // resolution.
+      const mockSupportedVersions = createMockSupportedVersions({
+        exceptions: undefined,
+      });
       selectMock.mockReturnValue(mockServer);
       axiosMock.get = jest.fn().mockResolvedValue({ data: mockServerInfo });
 
@@ -1811,6 +1818,279 @@ describe('supportedVersions/main.ts', () => {
     });
   });
 
+  // ========== FALLBACK: either source granting support must win (#3388 regression guard) ==========
+  describe('fallback candidate selection: either source supporting must win', () => {
+    // Each test needs a fresh builtinSupportedVersions singleton with a
+    // SPECIFIC payload distinct from the cache payload, so isolate modules
+    // the same way the stale-cache-after-update test above does.
+    const runIsolated = async (
+      setup: (ctx: {
+        dispatchMock: jest.MockedFunction<typeof dispatch>;
+        selectMock: jest.MockedFunction<typeof select>;
+        axiosMock: jest.Mocked<typeof axios>;
+        storeGetMock: jest.Mock;
+        fsPromises: typeof fsPromisesType;
+        jwt: typeof jsonwebtoken;
+        update: typeof updateSupportedVersionsData;
+      }) => Promise<void>
+    ): Promise<void> => {
+      await jest.isolateModulesAsync(async () => {
+        jest.mock('../../store');
+        jest.mock('axios');
+        jest.mock('jsonwebtoken');
+        jest.mock('electron-store');
+        jest.mock('node:fs/promises');
+        jest.mock('electron', () => ({
+          ipcMain: { handle: jest.fn() },
+        }));
+
+        const { dispatch: isolatedDispatch, select: isolatedSelect } =
+          await import('../../store');
+        const isolatedAxios = (await import('axios')).default;
+        const isolatedJwt = await import('jsonwebtoken');
+        const { updateSupportedVersionsData: isolatedUpdate } = await import(
+          './main'
+        );
+        const isolatedFs = await import('node:fs/promises');
+
+        const isolatedDispatchMock = isolatedDispatch as jest.MockedFunction<
+          typeof isolatedDispatch
+        >;
+        const isolatedSelectMock = isolatedSelect as jest.MockedFunction<
+          typeof isolatedSelect
+        >;
+        const isolatedAxiosMock = isolatedAxios as jest.Mocked<
+          typeof isolatedAxios
+        >;
+
+        const IsolatedElectronStoreMock = jest.requireMock('electron-store');
+        const isolatedStoreGetMock = jest.spyOn(
+          IsolatedElectronStoreMock.prototype,
+          'get'
+        ) as jest.Mock;
+        isolatedStoreGetMock.mockReturnValue(undefined);
+
+        await setup({
+          dispatchMock: isolatedDispatchMock,
+          selectMock: isolatedSelectMock,
+          axiosMock: isolatedAxiosMock,
+          storeGetMock: isolatedStoreGetMock,
+          fsPromises: isolatedFs,
+          jwt: isolatedJwt as unknown as typeof jsonwebtoken,
+          update: isolatedUpdate,
+        });
+      });
+    };
+
+    it('T-A: fresher builtin without the exception must not drop a cached tenant exception that grants support', async () => {
+      await runIsolated(
+        async ({
+          dispatchMock: isolatedDispatchMock,
+          selectMock: isolatedSelectMock,
+          axiosMock: isolatedAxiosMock,
+          storeGetMock: isolatedStoreGetMock,
+          fsPromises: isolatedFs,
+          jwt: isolatedJwt,
+          update: isolatedUpdate,
+        }) => {
+          const mockServer = createMockServer({
+            url: 'https://example.com',
+            version: '7.5.0',
+            uniqueID: 'test-unique-id',
+          });
+          isolatedSelectMock.mockReturnValue(mockServer);
+          isolatedAxiosMock.get = jest
+            .fn()
+            .mockRejectedValue(new Error('Network error'));
+
+          const futureExpiry = new Date(Date.now() + 86400000 * 365);
+
+          // Cache: base versions don't cover 7.5, but a tenant-scoped exception does.
+          const cachedVersions = createMockSupportedVersions({
+            versions: [{ version: '6.0.0', expiration: futureExpiry }],
+            exceptions: {
+              domain: 'example.com',
+              uniqueId: 'test-unique-id',
+              versions: [{ version: '7.5.0', expiration: futureExpiry }],
+            },
+            enforcementStartDate: '2023-01-01T00:00:00Z',
+            timestamp: '2020-01-01T00:00:00Z',
+          });
+          isolatedStoreGetMock.mockReturnValue(cachedVersions);
+
+          // Builtin: FRESHER than cache, but has no exceptions and doesn't
+          // list 7.5 as supported.
+          const freshBuiltinVersions = createMockSupportedVersions({
+            versions: [{ version: '6.0.0', expiration: futureExpiry }],
+            exceptions: undefined,
+            enforcementStartDate: '2023-01-01T00:00:00Z',
+            timestamp: new Date().toISOString(),
+          });
+          (isolatedFs.readFile as jest.Mock).mockResolvedValue(
+            'builtin-jwt-token'
+          );
+          (isolatedJwt.verify as jest.Mock).mockReturnValue(
+            freshBuiltinVersions
+          );
+
+          jest.useFakeTimers();
+          const promise = isolatedUpdate(mockServer.url);
+          // server.uniqueID is set, so both the server-info retry AND the
+          // cloud-fallback retry run (3 attempts x 2000ms delay each).
+          await jest.advanceTimersByTimeAsync(10000);
+          await promise;
+          jest.useRealTimers();
+
+          const isSupportedDispatch = isolatedDispatchMock.mock.calls.find(
+            ([action]) =>
+              (action as any).type === WEBVIEW_SERVER_IS_SUPPORTED_VERSION
+          );
+          expect(isSupportedDispatch).toBeDefined();
+          // Cache rescues the server despite builtin's freshness preference.
+          expect(
+            (isSupportedDispatch?.[0] as any)?.payload?.isSupportedVersion
+          ).toBe(true);
+
+          const updatedDispatch = isolatedDispatchMock.mock.calls.find(
+            ([action]) =>
+              (action as any).type === WEBVIEW_SERVER_SUPPORTED_VERSIONS_UPDATED
+          );
+          expect((updatedDispatch?.[0] as any)?.payload?.source).toBe('cloud');
+        }
+      );
+    }, 15000);
+
+    it('T-B: fresher builtin that supports the version still wins over a stale, unsupportive cache (#3388 fix preserved)', async () => {
+      await runIsolated(
+        async ({
+          dispatchMock: isolatedDispatchMock,
+          selectMock: isolatedSelectMock,
+          axiosMock: isolatedAxiosMock,
+          storeGetMock: isolatedStoreGetMock,
+          fsPromises: isolatedFs,
+          jwt: isolatedJwt,
+          update: isolatedUpdate,
+        }) => {
+          const mockServer = createMockServer({ version: '8.5.1' });
+          isolatedSelectMock.mockReturnValue(mockServer);
+          isolatedAxiosMock.get = jest
+            .fn()
+            .mockRejectedValue(new Error('Network error'));
+
+          const futureExpiry = new Date(Date.now() + 86400000 * 365);
+
+          // Stale cache: does not know about 8.5 -> unsupported, no exception.
+          const staleCachedVersions = createMockSupportedVersions({
+            versions: [{ version: '7.0.0', expiration: futureExpiry }],
+            exceptions: undefined,
+            enforcementStartDate: '2023-01-01T00:00:00Z',
+            timestamp: '2020-01-01T00:00:00Z',
+          });
+          isolatedStoreGetMock.mockReturnValue(staleCachedVersions);
+
+          // Fresh builtin: bundled with the current app version, knows 8.5 is supported.
+          const freshBuiltinVersions = createMockSupportedVersions({
+            versions: [{ version: '8.5.0', expiration: futureExpiry }],
+            exceptions: undefined,
+            enforcementStartDate: '2023-01-01T00:00:00Z',
+            timestamp: new Date().toISOString(),
+          });
+          (isolatedFs.readFile as jest.Mock).mockResolvedValue(
+            'builtin-jwt-token'
+          );
+          (isolatedJwt.verify as jest.Mock).mockReturnValue(
+            freshBuiltinVersions
+          );
+
+          jest.useFakeTimers();
+          const promise = isolatedUpdate(mockServer.url);
+          await jest.advanceTimersByTimeAsync(4000);
+          await promise;
+          jest.useRealTimers();
+
+          const isSupportedDispatch = isolatedDispatchMock.mock.calls.find(
+            ([action]) =>
+              (action as any).type === WEBVIEW_SERVER_IS_SUPPORTED_VERSION
+          );
+          expect(isSupportedDispatch).toBeDefined();
+          expect(
+            (isSupportedDispatch?.[0] as any)?.payload?.isSupportedVersion
+          ).toBe(true);
+
+          const updatedDispatch = isolatedDispatchMock.mock.calls.find(
+            ([action]) =>
+              (action as any).type === WEBVIEW_SERVER_SUPPORTED_VERSIONS_UPDATED
+          );
+          expect((updatedDispatch?.[0] as any)?.payload?.source).toBe(
+            'builtin'
+          );
+        }
+      );
+    });
+
+    it('T-C: neither cache nor builtin supports the version -> blocked', async () => {
+      await runIsolated(
+        async ({
+          dispatchMock: isolatedDispatchMock,
+          selectMock: isolatedSelectMock,
+          axiosMock: isolatedAxiosMock,
+          storeGetMock: isolatedStoreGetMock,
+          fsPromises: isolatedFs,
+          jwt: isolatedJwt,
+          update: isolatedUpdate,
+        }) => {
+          const mockServer = createMockServer({ version: '9.0.0' });
+          isolatedSelectMock.mockReturnValue(mockServer);
+          isolatedAxiosMock.get = jest
+            .fn()
+            .mockRejectedValue(new Error('Network error'));
+
+          const futureExpiry = new Date(Date.now() + 86400000 * 365);
+
+          const cachedVersions = createMockSupportedVersions({
+            versions: [{ version: '7.0.0', expiration: futureExpiry }],
+            exceptions: undefined,
+            enforcementStartDate: '2023-01-01T00:00:00Z',
+            timestamp: '2020-01-01T00:00:00Z',
+          });
+          isolatedStoreGetMock.mockReturnValue(cachedVersions);
+
+          const builtinVersions = createMockSupportedVersions({
+            versions: [{ version: '8.0.0', expiration: futureExpiry }],
+            exceptions: undefined,
+            enforcementStartDate: '2023-01-01T00:00:00Z',
+            timestamp: new Date().toISOString(),
+          });
+          (isolatedFs.readFile as jest.Mock).mockResolvedValue(
+            'builtin-jwt-token'
+          );
+          (isolatedJwt.verify as jest.Mock).mockReturnValue(builtinVersions);
+
+          jest.useFakeTimers();
+          const promise = isolatedUpdate(mockServer.url);
+          await jest.advanceTimersByTimeAsync(4000);
+          await promise;
+          jest.useRealTimers();
+
+          const isSupportedDispatch = isolatedDispatchMock.mock.calls.find(
+            ([action]) =>
+              (action as any).type === WEBVIEW_SERVER_IS_SUPPORTED_VERSION
+          );
+          expect(isSupportedDispatch).toBeDefined();
+          expect(
+            (isSupportedDispatch?.[0] as any)?.payload?.isSupportedVersion
+          ).toBe(false);
+
+          const errorDispatch = isolatedDispatchMock.mock.calls.find(
+            ([action]) =>
+              (action as any).type === WEBVIEW_SERVER_SUPPORTED_VERSIONS_ERROR
+          );
+          expect(errorDispatch).toBeDefined();
+        }
+      );
+    });
+  });
+
   // ========== CONCURRENCY: overlapping requests must not stale-overwrite ==========
   describe('overlapping request guard', () => {
     it('older slower request does not overwrite newer request verdict', async () => {
@@ -2238,10 +2518,11 @@ describe('supportedVersions/main.ts', () => {
         enforcementStartDate: '2023-01-01T00:00:00Z',
       });
 
+      // `commit` only occurs for authenticated view-statistics calls; passed
+      // here explicitly to unit-test the gitCommitHash dispatch wiring.
       axiosMock.get = jest.fn().mockResolvedValue({
         data: {
           version: '7.5.0',
-          uniqueId: 'fresh-unique',
           commit: { hash: 'abcdef1234567890' },
           supportedVersions: { signed: 'jwt' },
         },
@@ -2261,62 +2542,6 @@ describe('supportedVersions/main.ts', () => {
       expect((versionDispatch?.[0] as any)?.payload?.gitCommitHash).toBe(
         'abcdef1234567890'
       );
-    });
-  });
-
-  describe('server-source exception scope uses fresh /api/info uniqueId', () => {
-    it('honors scoped exception on first load when persisted server.uniqueID is undefined but /api/info returns uniqueId', async () => {
-      // Mock server with NO persisted uniqueID (first launch).
-      const mockServer = {
-        url: 'https://tenant-a.example.com/',
-        version: '7.5.0',
-        title: 'Tenant A',
-        // uniqueID undefined
-      } as any;
-      selectMock.mockReturnValue(mockServer);
-
-      const futureExpiry = new Date(Date.now() + 86400000 * 365);
-      // Payload with scoped exception that requires uniqueId match.
-      const payloadWithScopedException = {
-        versions: [],
-        enforcementStartDate: '2023-01-01T00:00:00Z',
-        timestamp: new Date().toISOString(),
-        messages: [],
-        i18n: {},
-        exceptions: {
-          domain: 'tenant-a.example.com',
-          uniqueId: 'tenant-a-fresh-unique',
-          versions: [{ version: 'sha-abc1234', expiration: futureExpiry }],
-        },
-      };
-
-      // /api/info returns fresh uniqueId + signed JWT
-      axiosMock.get = jest.fn().mockResolvedValue({
-        data: {
-          version: '7.5.0',
-          uniqueId: 'tenant-a-fresh-unique',
-          commit: { hash: 'abc1234567890' },
-          supportedVersions: { signed: 'server-jwt' },
-        },
-      });
-      (jest.spyOn(jsonwebtoken, 'verify') as jest.Mock).mockReturnValue(
-        payloadWithScopedException
-      );
-
-      await updateSupportedVersionsData(mockServer.url);
-
-      const isSupportedDispatch = dispatchMock.mock.calls.find(
-        ([action]) =>
-          (action as any).type === WEBVIEW_SERVER_IS_SUPPORTED_VERSION
-      );
-      expect(isSupportedDispatch).toBeDefined();
-      // Without fix: server.uniqueID undefined -> scope check rejects ->
-      // exception ignored -> falls through to enforcement -> false.
-      // With fix: serverWithFreshVersion gets serverInfoResult.uniqueId ->
-      // scope matches -> exception honored -> true.
-      expect(
-        (isSupportedDispatch?.[0] as any)?.payload?.isSupportedVersion
-      ).toBe(true);
     });
   });
 

--- a/src/servers/supportedVersions/main.ts
+++ b/src/servers/supportedVersions/main.ts
@@ -97,6 +97,37 @@ const parseTimestamp = (value?: string): number => {
   return Number.isNaN(time) ? 0 : time;
 };
 
+// Orders the cache and builtin fallback sources by `timestamp` — freshest
+// first — instead of always trusting the cache: a persisted cache entry can
+// predate the app's own bundled builtin data (e.g. right after an app
+// update ships a refreshed builtin list), in which case trusting the stale
+// cache indefinitely blocks servers the new builtin already recognizes as
+// supported. Both sources are included when both exist; the caller tries
+// each in order and only falls through to the second when the first fails
+// to support the server (see validateFallbackAndDispatch).
+const buildFallbackCandidates = (
+  cachedVersions: SupportedVersions | undefined,
+  builtinVersions: SupportedVersions | undefined
+): { versions: SupportedVersions; source: 'cloud' | 'builtin' }[] => {
+  if (!cachedVersions && !builtinVersions) return [];
+  if (!builtinVersions) return [{ versions: cachedVersions!, source: 'cloud' }];
+  if (!cachedVersions)
+    return [{ versions: builtinVersions, source: 'builtin' }];
+
+  const useBuiltinOverCache =
+    parseTimestamp(builtinVersions.timestamp) >
+    parseTimestamp(cachedVersions.timestamp);
+  const first: { versions: SupportedVersions; source: 'cloud' | 'builtin' } =
+    useBuiltinOverCache
+      ? { versions: builtinVersions, source: 'builtin' }
+      : { versions: cachedVersions, source: 'cloud' };
+  const second: { versions: SupportedVersions; source: 'cloud' | 'builtin' } =
+    useBuiltinOverCache
+      ? { versions: cachedVersions, source: 'cloud' }
+      : { versions: builtinVersions, source: 'builtin' };
+  return [first, second];
+};
+
 const loadFromCache = (serverUrl: string): SupportedVersions | undefined => {
   try {
     const cached = supportedVersionsStore.get(getCacheKey(serverUrl));
@@ -555,38 +586,65 @@ const withExceptionScopeUniqueId = async (
     : serverView;
 };
 
-// Validates the fallback (cache/builtin) payload and dispatches the verdict.
-// isServerVersionSupported can throw on a malformed cached/builtin payload
-// (e.g. `versions` not an array). Left unguarded, that throw would reject
-// updateSupportedVersionsData before WEBVIEW_SERVER_SUPPORTED_VERSIONS_ERROR
-// is dispatched, leaving supportedVersionsFetchState stuck at 'loading' —
-// which suppresses the UnsupportedServer block gate (fail-open). On failure,
-// only the error state is dispatched; the prior verdict is left untouched.
+// Validates the fallback (cache/builtin) candidates, in order, and dispatches
+// the verdict. isServerVersionSupported can throw on a malformed
+// cached/builtin payload (e.g. `versions` not an array). Left unguarded, that
+// throw would reject updateSupportedVersionsData before
+// WEBVIEW_SERVER_SUPPORTED_VERSIONS_ERROR is dispatched, leaving
+// supportedVersionsFetchState stuck at 'loading' — which suppresses the
+// UnsupportedServer block gate (fail-open). On failure, only the error state
+// is dispatched; the prior verdict is left untouched.
+//
+// Blocking on the fallback path is only correct when NO available source
+// supports the server: the builtin payload can rescue a server that a stale
+// cache wrongly blocks, but the cache is the only fallback source that can
+// carry this tenant's own exceptions (the builtin payload never does). So
+// candidates are tried in freshness order and the first one that supports
+// the server wins; only if every candidate fails to support it do we accept
+// the last-checked (freshest) verdict as the block reason.
 const validateFallbackAndDispatch = async (
   server: Server,
   serverUrl: string,
-  fallbackVersions: SupportedVersions,
-  fallbackSource: 'cloud' | 'builtin',
+  candidates: { versions: SupportedVersions; source: 'cloud' | 'builtin' }[],
   freshCommitHash: string | undefined,
   isStale: () => boolean
 ): Promise<void> => {
   try {
-    const fallbackSupported = await isServerVersionSupported(
+    // At most two candidates (cache + builtin) are ever passed. Check the
+    // freshness-preferred one first; only consult the second if the first
+    // fails to support the server, and prefer the second's verdict only
+    // when it succeeds where the first didn't.
+    let chosen = candidates[0];
+    let verdict = await isServerVersionSupported(
       server,
-      fallbackVersions,
+      chosen.versions,
       freshCommitHash,
-      fallbackSource
+      chosen.source
     );
+    const other = candidates[1];
+    if (!verdict.supported && other) {
+      const otherVerdict = await isServerVersionSupported(
+        server,
+        other.versions,
+        freshCommitHash,
+        other.source
+      );
+      if (otherVerdict.supported) {
+        chosen = other;
+        verdict = otherVerdict;
+      }
+    }
     if (isStale()) return;
+    saveToCache(serverUrl, chosen.versions);
     dispatch({
       type: WEBVIEW_SERVER_IS_SUPPORTED_VERSION,
       payload: {
         url: server.url,
-        isSupportedVersion: fallbackSupported.supported,
+        isSupportedVersion: verdict.supported,
       },
     });
-    dispatchSupportedVersionsUpdated(server.url, fallbackVersions, {
-      source: fallbackSource,
+    dispatchSupportedVersionsUpdated(server.url, chosen.versions, {
+      source: chosen.source,
     });
   } catch (error) {
     console.error('Error validating fallback supported versions:', error);
@@ -633,16 +691,16 @@ export const updateSupportedVersionsData = async (
     2000
   );
 
-  // Build a server view that reflects the freshly-fetched version and
-  // uniqueId when available, so every downstream support check
-  // (server/cloud/cache/builtin) is evaluated against the same authoritative
-  // identity. Current servers do NOT include `uniqueId` in /api/info, so the
-  // fallback to persisted server.uniqueID is the common path.
+  // Build a server view that reflects the freshly-fetched version, so every
+  // downstream support check (server/cloud/cache/builtin) is evaluated
+  // against the same authoritative identity. /api/info carries no workspace
+  // uniqueId, so the persisted server.uniqueID is used as-is here, and
+  // withExceptionScopeUniqueId resolves it on demand when it's missing.
   const serverWithFreshVersion: Server = serverInfoResult
     ? {
         ...server,
         version: serverInfoResult.version,
-        uniqueID: serverInfoResult.uniqueId ?? server.uniqueID,
+        uniqueID: server.uniqueID,
       }
     : server;
   const freshCommitHash = serverInfoResult?.commit?.hash;
@@ -759,34 +817,24 @@ export const updateSupportedVersionsData = async (
     }
   }
 
-  // Neither the server nor the cloud could be reached. Pick the freshest of
-  // the two remaining sources by `timestamp` instead of always trusting the
-  // cache: a persisted cache entry can predate the app's own bundled builtin
-  // data (e.g. right after an app update ships a refreshed builtin list), in
-  // which case trusting the stale cache indefinitely blocks servers the new
-  // builtin already recognizes as supported.
+  // Neither the server nor the cloud could be reached. Order the two
+  // remaining sources by `timestamp` instead of always trusting the cache
+  // (see buildFallbackCandidates): both are still tried (see
+  // validateFallbackAndDispatch) so the cache's tenant exceptions — which
+  // the builtin payload never carries — aren't lost to a fresher builtin
+  // that simply doesn't know about them.
   const cachedVersions = loadFromCache(serverUrl);
-  const useBuiltinOverCache =
-    !!builtinSupportedVersions &&
-    (!cachedVersions ||
-      parseTimestamp(builtinSupportedVersions.timestamp) >
-        parseTimestamp(cachedVersions.timestamp));
-  const fallbackVersions = useBuiltinOverCache
-    ? builtinSupportedVersions
-    : cachedVersions;
-  const fallbackSource: 'cloud' | 'builtin' = useBuiltinOverCache
-    ? 'builtin'
-    : 'cloud';
+  const fallbackCandidates = buildFallbackCandidates(
+    cachedVersions,
+    builtinSupportedVersions
+  );
 
-  if (fallbackVersions) {
-    if (isStale()) return;
-    saveToCache(serverUrl, fallbackVersions);
+  if (fallbackCandidates.length > 0) {
     if (isStale()) return;
     await validateFallbackAndDispatch(
       serverWithFreshIdentity,
       serverUrl,
-      fallbackVersions,
-      fallbackSource,
+      fallbackCandidates,
       freshCommitHash,
       isStale
     );

--- a/src/servers/supportedVersions/types.ts
+++ b/src/servers/supportedVersions/types.ts
@@ -54,8 +54,14 @@ export type SupportedVersions = {
 
 export type ServerInfo = {
   version: string;
-  uniqueId: string;
-  build: {
+  /**
+   * `build`, `marketplaceApiVersion`, and `commit` are only present when the
+   * caller is authenticated with the view-statistics permission. The
+   * desktop app always requests /api/info unauthenticated, so these fields
+   * never arrive on the wire in practice. The sha-exception path relies on
+   * the persisted `server.gitCommitHash` pushed by the web client instead.
+   */
+  build?: {
     date: string;
     nodeVersion: string;
     arch: string;
@@ -65,8 +71,8 @@ export type ServerInfo = {
     freeMemory: number;
     cpus: number;
   };
-  marketplaceApiVersion: string;
-  commit: {
+  marketplaceApiVersion?: string;
+  commit?: {
     hash: string;
     date: Date;
     author: string;
@@ -82,6 +88,9 @@ export type ServerInfo = {
     desktop: string;
     mobile: string;
   };
+  cloudWorkspaceId?: string;
+  workspaceUrl?: string;
+  hashedWorkspaceUrl?: string;
 };
 
 export type CloudInfo = {


### PR DESCRIPTION
Jira: [CORE-2409](https://rocketchat.atlassian.net/browse/CORE-2409)

Stacked on #3405 (which stacks on #3404) — retarget to `master` as the stack merges.

## What

Closes the contract-drift gap that let the exception-scope defect (#3404) pass CI for 2.5 years, and fixes an exception-loss window introduced by the fallback source selection in #3388.

## Contract alignment (verified against the server source, `apps/meteor/server/api/lib/getServerInfo.ts`)

The desktop's `ServerInfo` type declared fields the unauthenticated `/api/info` response never contains:

- **`uniqueId` removed** — no server version returns it (the field does not exist in the server's `IWorkspaceInfo`). The workspace uniqueID comes from `settings.public` and is resolved on demand. The dead `serverInfoResult.uniqueId` fallback is removed.
- **`commit` / `build` / `marketplaceApiVersion` marked optional** and documented as authenticated-only (`view-statistics`); the desktop always calls `/api/info` unauthenticated. sha-exception matching uses the persisted `server.gitCommitHash` pushed by the injected script (`Meteor.gitCommitHash`), which is its only real data source.
- **Default test fixtures rebuilt to the real wire shape** (trimmed `major.minor` version, no `uniqueId`/`commit`/`info`). The previous fixtures mirrored the fictional type, so CI validated the desktop against itself. Switching `beforeEach` to `jest.resetAllMocks()` fixed latent cross-test mock leakage the honest fixtures surfaced.

## Live wire-contract test

New `apiContract.main.spec.ts` asserts the unauthenticated `/api/info` shape against open.rocket.chat (6 assertions). Skips only on genuine network failure or `SKIP_CONTRACT_TESTS=1`; a reachable server with a drifted contract fails the suite.

## Exception-aware offline fallback

#3388 made the offline fallback prefer the bundled builtin payload when fresher than the cache. The builtin never carries tenant exceptions, so a workspace kept usable by a cached exception could lose it to a fresher builtin and be blocked. The fallback now tries BOTH sources in freshness order and the first one that supports the server wins — blocking requires every available source to fail. This preserves #3388's stale-cache rescue while never losing a cached exception to it. Covered by three new tests (cache-exception rescue, builtin rescue, certain block).

## Tests

- Touched suites: 148 tests pass; contract spec 6/6 live against open.rocket.chat.
- Full repo suite: 153 suites / 1615 tests pass. `tsc --noEmit` and `yarn lint` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved supported-version detection when server or cloud sources are unavailable.
  - Chooses the freshest available version data and tries alternate sources when needed.
  - Preserves correct exception handling across server, cloud, and bundled version data.
  - Refreshes supported-version information when the application resumes.
  - Improved compatibility with server information returned without authenticated build and commit details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[CORE-2409]: https://rocketchat.atlassian.net/browse/CORE-2409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ