### PR TITLE
chore: back-merge 4.15.3 hotfix into master

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "Rocket.Chat",
   "name": "rocketchat",
   "description": "Official OSX, Windows, and Linux Desktop Clients for Rocket.Chat",
-  "version": "4.15.2",
+  "version": "4.15.3",
   "author": "Rocket.Chat Support <support@rocket.chat>",
   "copyright": "© 2016-2026, Rocket.Chat",
   "homepage": "https://rocket.chat",

--- a/src/i18n/en.i18n.json
+++ b/src/i18n/en.i18n.json
@@ -476,7 +476,8 @@
   "unsupportedServer": {
     "title": "{{instanceDomain}} is running an unsupported version of Rocket.Chat",
     "announcement": "An admin needs to update the workspace to a supported version in order to reenable access from mobile and desktop apps.",
-    "moreInformation": "Learn more"
+    "moreInformation": "Learn more",
+    "checkAgain": "Check again"
   },
   "selfxss": {
     "title": "Stop!",

--- a/src/screenSharing/screenSharePicker.tsx
+++ b/src/screenSharing/screenSharePicker.tsx
@@ -100,10 +100,6 @@ export function ScreenSharePicker({
   }, [visible, permissionChannel]);
 
   useEffect(() => {
-    fetchSources();
-  }, [fetchSources]);
-
-  useEffect(() => {
     if (onMounted) {
       onMounted(setVisible);
     }

--- a/src/servers/reducers.ts
+++ b/src/servers/reducers.ts
@@ -161,7 +161,7 @@ export const servers: Reducer<Server[], ServersActionTypes> = (
 
     case WEBVIEW_SERVER_UNIQUE_ID_UPDATED: {
       const { url, uniqueID } = action.payload;
-      return upsert(state, { url, uniqueID });
+      return update(state, { url, uniqueID });
     }
 
     case WEBVIEW_SERVER_IS_SUPPORTED_VERSION: {
@@ -184,7 +184,7 @@ export const servers: Reducer<Server[], ServersActionTypes> = (
         gitCommitHash !== undefined
           ? { url, version, gitCommitHash }
           : { url, version };
-      return upsert(state, patch);
+      return update(state, patch);
     }
 
     case WEBVIEW_UNREAD_CHANGED: {
@@ -219,7 +219,7 @@ export const servers: Reducer<Server[], ServersActionTypes> = (
 
     case WEBVIEW_GIT_COMMIT_HASH_CHANGED: {
       const { url, gitCommitHash } = action.payload;
-      return upsert(state, { url, gitCommitHash });
+      return update(state, { url, gitCommitHash });
     }
 
     case WEBVIEW_FAVICON_CHANGED: {

--- a/src/servers/reducers/__tests__/servers.spec.ts
+++ b/src/servers/reducers/__tests__/servers.spec.ts
@@ -192,6 +192,17 @@ describe('servers reducer', () => {
 
       expect(newState[0].uniqueID).toBe('abc');
     });
+
+    it('should not resurrect a ghost server for a url not present in state', () => {
+      const state = [existing];
+      const newState = servers(state, {
+        type: WEBVIEW_SERVER_UNIQUE_ID_UPDATED,
+        payload: { url: 'https://deleted.rocket.chat/', uniqueID: 'abc' },
+      } as any);
+
+      expect(newState).toBe(state);
+      expect(newState).toHaveLength(1);
+    });
   });
 
   describe('WEBVIEW_SERVER_IS_SUPPORTED_VERSION', () => {
@@ -226,6 +237,17 @@ describe('servers reducer', () => {
 
       expect(newState[0].version).toBe('7.0.0');
       expect(newState[0].gitCommitHash).toBe('keepme');
+    });
+
+    it('should not resurrect a ghost server for a url not present in state', () => {
+      const state = [existing];
+      const newState = servers(state, {
+        type: WEBVIEW_SERVER_VERSION_UPDATED,
+        payload: { url: 'https://deleted.rocket.chat/', version: '7.0.0' },
+      } as any);
+
+      expect(newState).toBe(state);
+      expect(newState).toHaveLength(1);
     });
   });
 
@@ -293,6 +315,17 @@ describe('servers reducer', () => {
       } as any);
 
       expect(newState[0].gitCommitHash).toBe('abc123');
+    });
+
+    it('should not resurrect a ghost server for a url not present in state', () => {
+      const state = [existing];
+      const newState = servers(state, {
+        type: WEBVIEW_GIT_COMMIT_HASH_CHANGED,
+        payload: { url: 'https://deleted.rocket.chat/', gitCommitHash: 'x' },
+      } as any);
+
+      expect(newState).toBe(state);
+      expect(newState).toHaveLength(1);
     });
   });
 

--- a/src/servers/supportedVersions/apiContract.main.spec.ts
+++ b/src/servers/supportedVersions/apiContract.main.spec.ts
@@ -1,0 +1,127 @@
+// Live wire-contract test for the Rocket.Chat /api/info endpoint.
+//
+// WHY THIS EXISTS: a `uniqueId` field that the desktop's ServerInfo type
+// assumed the endpoint returned was fictional — it was never actually part
+// of the real /api/info response, and this went uncaught for 2.5 years
+// because every test that exercised this code path did so against
+// self-referential mocks (fixtures the desktop repo wrote itself) rather
+// than the real server. Mocks can only fail the same way the code that
+// authored them already fails, so they can't catch this class of drift.
+//
+// This spec instead fetches the LIVE public /api/info endpoint
+// (https://open.rocket.chat/api/info — same unauthenticated call the
+// desktop makes in src/servers/supportedVersions/main.ts) and asserts the
+// shape the desktop actually depends on, sourced from the server-side
+// implementation (apps/meteor/server/api/lib/getServerInfo.ts) rather than
+// from the desktop's own types.
+//
+// SKIP SEMANTICS: a network outage must not fail CI, but a reachable server
+// that has drifted from the contract must. The suite is skipped (with a
+// console.warn explaining why) only when the endpoint could not be reached
+// for network reasons (timeout/DNS/5xx) or when SKIP_CONTRACT_TESTS=1 is
+// set. Any other outcome — including a 2xx response with an unexpected
+// shape — runs the assertions and fails normally.
+
+import axios from 'axios';
+
+const ENDPOINT = 'https://open.rocket.chat/api/info';
+const FETCH_TIMEOUT_MS = 15000;
+const MAX_ATTEMPTS = 2;
+
+let body: Record<string, unknown> | undefined;
+let skipReason: string | undefined;
+
+const isNetworkFailure = (error: unknown): boolean => {
+  if (!axios.isAxiosError(error)) return false;
+  // No response at all → timeout, DNS failure, connection refused, etc.
+  if (!error.response) return true;
+  // 5xx means the server itself is unhealthy, not that the contract changed.
+  return error.response.status >= 500;
+};
+
+const fetchServerInfo = async (): Promise<Record<string, unknown>> => {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    try {
+      // Each retry must wait for the previous attempt's outcome, not run
+      // concurrently with it.
+      // eslint-disable-next-line no-await-in-loop
+      const response = await axios.get(ENDPOINT, {
+        timeout: FETCH_TIMEOUT_MS,
+      });
+      return response.data;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError;
+};
+
+beforeAll(
+  async () => {
+    if (process.env.SKIP_CONTRACT_TESTS === '1') {
+      skipReason = 'SKIP_CONTRACT_TESTS=1 is set';
+      console.warn(`Skipping /api/info contract tests: ${skipReason}.`);
+      return;
+    }
+
+    try {
+      body = await fetchServerInfo();
+    } catch (error) {
+      if (isNetworkFailure(error)) {
+        skipReason = `network error reaching ${ENDPOINT}: ${
+          axios.isAxiosError(error) ? error.message : String(error)
+        }`;
+        console.warn(`Skipping /api/info contract tests: ${skipReason}.`);
+        return;
+      }
+      throw error;
+    }
+  },
+  FETCH_TIMEOUT_MS * MAX_ATTEMPTS + 5000
+);
+
+describe('/api/info wire contract', () => {
+  test('version is trimmed major.minor, not three segments', () => {
+    if (skipReason) return;
+    expect(typeof body?.version).toBe('string');
+    expect(body?.version).toMatch(/^\d+\.\d+$/);
+  });
+
+  test('uniqueId is not present on the unauthenticated response', () => {
+    if (skipReason) return;
+    expect(body && 'uniqueId' in body).toBe(false);
+  });
+
+  test('commit and info blocks are not present to unauthenticated callers', () => {
+    if (skipReason) return;
+    expect(body && 'commit' in body).toBe(false);
+    expect(body && 'info' in body).toBe(false);
+  });
+
+  test('minimumClientVersions has string desktop and mobile versions', () => {
+    if (skipReason) return;
+    const minimumClientVersions = body?.minimumClientVersions as
+      | Record<string, unknown>
+      | undefined;
+    expect(typeof minimumClientVersions).toBe('object');
+    expect(typeof minimumClientVersions?.desktop).toBe('string');
+    expect(typeof minimumClientVersions?.mobile).toBe('string');
+  });
+
+  test('supportedVersions.signed, when present, is a non-empty JWT', () => {
+    if (skipReason) return;
+    const supportedVersions = body?.supportedVersions as
+      | Record<string, unknown>
+      | undefined;
+    if (supportedVersions === undefined) return;
+    expect(typeof supportedVersions.signed).toBe('string');
+    expect((supportedVersions.signed as string).length).toBeGreaterThan(0);
+    expect((supportedVersions.signed as string).split('.').length).toBe(3);
+  });
+
+  test('success is true', () => {
+    if (skipReason) return;
+    expect(body?.success).toBe(true);
+  });
+});

--- a/src/servers/supportedVersions/main.main.spec.ts
+++ b/src/servers/supportedVersions/main.main.spec.ts
@@ -16,6 +16,7 @@ import {
 } from '../../ui/actions';
 import {
   checkSupportedVersionServers,
+  getExpirationMessageTranslated,
   isServerVersionSupported,
   updateSupportedVersionsData,
 } from './main';
@@ -29,6 +30,9 @@ jest.mock('node:fs/promises');
 jest.mock('electron', () => ({
   ipcMain: {
     handle: jest.fn(),
+  },
+  powerMonitor: {
+    on: jest.fn(),
   },
 }));
 
@@ -2039,7 +2043,7 @@ describe('supportedVersions/main.ts', () => {
       expect(result.supported).toBe(true);
     });
 
-    it('does NOT honor scoped exception when local server.uniqueID is undefined', async () => {
+    it('honors scoped exception when local server.uniqueID is UNKNOWN and the domain matches', async () => {
       const payload = {
         ...baseVersions,
         exceptions: {
@@ -2049,8 +2053,10 @@ describe('supportedVersions/main.ts', () => {
         },
       } as unknown as SupportedVersions;
 
-      // Same domain. Same commit hash. But local uniqueID UNKNOWN.
-      // Must reject — missing local identity cannot satisfy required scope.
+      // Same domain. Same commit hash. Local uniqueID UNKNOWN (e.g.
+      // settings.public restricted by enterprise API ACLs). An unprovable
+      // identity must not disqualify a domain-matched exception — wrongly
+      // blocking a legitimate tenant is the worse failure mode.
       const serverWithoutUniqueID = {
         url: 'https://tenant-a.example.com/',
         version: '8.5',
@@ -2060,6 +2066,31 @@ describe('supportedVersions/main.ts', () => {
 
       const result = await isServerVersionSupported(
         serverWithoutUniqueID,
+        payload,
+        'abc1234567890'
+      );
+      expect(result.supported).toBe(true);
+    });
+
+    it('rejects scoped exception on a PROVEN uniqueID mismatch even when the domain matches', async () => {
+      const payload = {
+        ...baseVersions,
+        exceptions: {
+          domain: 'tenant-a.example.com',
+          uniqueId: 'tenant-a-unique',
+          versions: [{ version: 'sha-abc1234', expiration: futureExpiry }],
+        },
+      } as unknown as SupportedVersions;
+
+      const serverWithOtherUniqueID = {
+        url: 'https://tenant-a.example.com/',
+        version: '8.5',
+        title: 'Tenant A',
+        uniqueID: 'tenant-b-unique',
+      } as any;
+
+      const result = await isServerVersionSupported(
+        serverWithOtherUniqueID,
         payload,
         'abc1234567890'
       );
@@ -2370,6 +2401,114 @@ describe('supportedVersions/main.ts', () => {
         semverExceptionVersions
       );
       expect(result.supported).toBe(true);
+    });
+  });
+
+  // ========== FIX-1: fallback path validation must not throw unguarded ==========
+  describe('fallback path validation failure (fail-open guard)', () => {
+    it('dispatches ERROR (not a rejection) and no IS_SUPPORTED_VERSION when the fallback payload is malformed', async () => {
+      const mockServer = createMockServer({ version: '7.5.0' });
+      selectMock.mockReturnValue(mockServer);
+      axiosMock.get = jest.fn().mockRejectedValue(new Error('Network error'));
+
+      // Cache returns a corrupt payload: `versions` is not an array, so
+      // isServerVersionSupported's `versions.find` throws synchronously.
+      const ElectronStoreMock = jest.requireMock('electron-store');
+      const storeGetMock = jest.spyOn(
+        ElectronStoreMock.prototype,
+        'get'
+      ) as jest.Mock;
+      storeGetMock.mockReturnValue({
+        versions: { notAnArray: true },
+        enforcementStartDate: '2023-01-01T00:00:00Z',
+        timestamp: new Date().toISOString(),
+      });
+
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      jest.useFakeTimers();
+      const promise = updateSupportedVersionsData(mockServer.url);
+      await jest.advanceTimersByTimeAsync(4000);
+      // Must resolve, not reject.
+      await expect(promise).resolves.toBeUndefined();
+      jest.useRealTimers();
+
+      const errorDispatch = dispatchMock.mock.calls.find(
+        ([action]) =>
+          (action as any).type === WEBVIEW_SERVER_SUPPORTED_VERSIONS_ERROR
+      );
+      expect(errorDispatch).toBeDefined();
+
+      const isSupportedDispatches = dispatchMock.mock.calls.filter(
+        ([action]) =>
+          (action as any).type === WEBVIEW_SERVER_IS_SUPPORTED_VERSION
+      );
+      expect(isSupportedDispatches.length).toBe(0);
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error validating fallback'),
+        expect.anything()
+      );
+
+      consoleErrorSpy.mockRestore();
+      storeGetMock.mockRestore();
+    });
+  });
+
+  // ========== FIX-3: cloud lookup must not skip on persisted uniqueID ==========
+  describe('cloud fetch gate uses persisted uniqueID as fallback', () => {
+    it('fetches cloud endpoint when fresh uniqueID fetch fails but server has a persisted uniqueID', async () => {
+      const mockServer = createMockServer({
+        version: '7.5.0',
+        uniqueID: 'persisted-unique-id',
+      });
+      const mockServerInfo = createMockServerInfo({
+        supportedVersions: undefined,
+      });
+      selectMock.mockReturnValue(mockServer);
+      axiosMock.get = jest
+        .fn()
+        .mockResolvedValueOnce({ data: mockServerInfo }) // /api/info
+        .mockRejectedValueOnce(new Error('uniqueID fetch failed')) // getUniqueId
+        .mockResolvedValueOnce({ data: createMockCloudInfo() }); // cloud lookup
+
+      await updateSupportedVersionsData(mockServer.url);
+
+      const cloudCall = axiosMock.get.mock.calls.find(([url]) =>
+        (url as string).includes('releases.rocket.chat')
+      );
+      expect(cloudCall).toBeDefined();
+    });
+  });
+
+  // ========== FIX-5: getExpirationMessageTranslated must not throw ==========
+  describe('getExpirationMessageTranslated i18n guard', () => {
+    it('returns null instead of throwing when i18n has neither the requested language nor "en"', () => {
+      const result = getExpirationMessageTranslated(
+        {},
+        { title: 'title', subtitle: 'sub', description: 'desc' } as any,
+        new Date(Date.now() + 86400000),
+        'en',
+        'My Server',
+        'https://rocket.chat',
+        '7.0.0'
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  // ========== FIX-7: revalidate all servers on wake-from-sleep ==========
+  describe('power resume revalidation', () => {
+    it('registers a powerMonitor resume handler when checkSupportedVersionServers runs', async () => {
+      const electronMock = jest.requireMock('electron');
+
+      checkSupportedVersionServers();
+
+      expect(electronMock.powerMonitor.on).toHaveBeenCalledWith(
+        'resume',
+        expect.any(Function)
+      );
     });
   });
 });

--- a/src/servers/supportedVersions/main.main.spec.ts
+++ b/src/servers/supportedVersions/main.main.spec.ts
@@ -371,6 +371,173 @@ describe('supportedVersions/main.ts', () => {
     });
   });
 
+  // ========== EXCEPTION UNIQUE ID SCOPE (SERVER-SIGNED PATH) ==========
+  describe('Exception uniqueId scope resolution on server-signed path', () => {
+    const tenantSupportedVersions = (overrides?: Partial<SupportedVersions>) =>
+      createMockSupportedVersions({
+        versions: [
+          {
+            version: '8.6.0',
+            expiration: new Date(Date.now() + 86400000),
+          },
+        ],
+        exceptions: {
+          domain: 'test.rocket.chat',
+          uniqueId: 'tenant-unique-id',
+          versions: [
+            {
+              version: '7.13.9',
+              expiration: new Date(Date.now() + 86400000),
+            },
+          ],
+        },
+        enforcementStartDate: '2023-12-15T00:00:00Z',
+        ...overrides,
+      });
+
+    it('should fetch uniqueID before validating when /api/info omits uniqueId and exception is uniqueId-scoped', async () => {
+      const mockServer = createMockServer({ version: '7.13' });
+      const mockServerInfo = createMockServerInfo({
+        version: '7.13',
+        uniqueId: undefined,
+      });
+      selectMock.mockReturnValue(mockServer);
+      axiosMock.get = jest
+        .fn()
+        .mockResolvedValueOnce({ data: mockServerInfo })
+        .mockResolvedValueOnce({
+          data: { settings: [{ value: 'tenant-unique-id' }] },
+        });
+
+      (jest.spyOn(jsonwebtoken, 'verify') as jest.Mock).mockReturnValue(
+        tenantSupportedVersions()
+      );
+
+      await updateSupportedVersionsData(mockServer.url);
+
+      const uniqueIdDispatch = dispatchMock.mock.calls.find(
+        ([action]) =>
+          (action as any).type === WEBVIEW_SERVER_UNIQUE_ID_UPDATED &&
+          (action as any).payload?.uniqueID === 'tenant-unique-id'
+      );
+      expect(uniqueIdDispatch).toBeDefined();
+
+      const verdictDispatch = dispatchMock.mock.calls.find(
+        ([action]) =>
+          (action as any).type === WEBVIEW_SERVER_IS_SUPPORTED_VERSION
+      );
+      expect(verdictDispatch?.[0]).toEqual({
+        type: WEBVIEW_SERVER_IS_SUPPORTED_VERSION,
+        payload: {
+          url: mockServer.url,
+          isSupportedVersion: true,
+        },
+      });
+    });
+
+    it('should re-fetch uniqueID when persisted value is stale and honor the exception', async () => {
+      const mockServer = createMockServer({
+        version: '7.13',
+        uniqueID: 'stale-unique-id',
+      });
+      const mockServerInfo = createMockServerInfo({
+        version: '7.13',
+        uniqueId: undefined,
+      });
+      selectMock.mockReturnValue(mockServer);
+      axiosMock.get = jest
+        .fn()
+        .mockResolvedValueOnce({ data: mockServerInfo })
+        .mockResolvedValueOnce({
+          data: { settings: [{ value: 'tenant-unique-id' }] },
+        });
+
+      (jest.spyOn(jsonwebtoken, 'verify') as jest.Mock).mockReturnValue(
+        tenantSupportedVersions()
+      );
+
+      await updateSupportedVersionsData(mockServer.url);
+
+      const verdictDispatch = dispatchMock.mock.calls.find(
+        ([action]) =>
+          (action as any).type === WEBVIEW_SERVER_IS_SUPPORTED_VERSION
+      );
+      expect(verdictDispatch?.[0]).toEqual({
+        type: WEBVIEW_SERVER_IS_SUPPORTED_VERSION,
+        payload: {
+          url: mockServer.url,
+          isSupportedVersion: true,
+        },
+      });
+    });
+
+    it('should reject the exception when the fetched uniqueID does not match the exception scope', async () => {
+      const mockServer = createMockServer({ version: '7.13' });
+      const mockServerInfo = createMockServerInfo({
+        version: '7.13',
+        uniqueId: undefined,
+      });
+      selectMock.mockReturnValue(mockServer);
+      axiosMock.get = jest
+        .fn()
+        .mockResolvedValueOnce({ data: mockServerInfo })
+        .mockResolvedValueOnce({
+          data: { settings: [{ value: 'other-tenant-id' }] },
+        });
+
+      (jest.spyOn(jsonwebtoken, 'verify') as jest.Mock).mockReturnValue(
+        tenantSupportedVersions()
+      );
+
+      await updateSupportedVersionsData(mockServer.url);
+
+      const verdictDispatch = dispatchMock.mock.calls.find(
+        ([action]) =>
+          (action as any).type === WEBVIEW_SERVER_IS_SUPPORTED_VERSION
+      );
+      expect(verdictDispatch?.[0]).toEqual({
+        type: WEBVIEW_SERVER_IS_SUPPORTED_VERSION,
+        payload: {
+          url: mockServer.url,
+          isSupportedVersion: false,
+        },
+      });
+    });
+
+    it('should not fetch uniqueID when the persisted value already matches the exception scope', async () => {
+      const mockServer = createMockServer({
+        version: '7.13',
+        uniqueID: 'tenant-unique-id',
+      });
+      const mockServerInfo = createMockServerInfo({
+        version: '7.13',
+        uniqueId: undefined,
+      });
+      selectMock.mockReturnValue(mockServer);
+      axiosMock.get = jest.fn().mockResolvedValueOnce({ data: mockServerInfo });
+
+      (jest.spyOn(jsonwebtoken, 'verify') as jest.Mock).mockReturnValue(
+        tenantSupportedVersions()
+      );
+
+      await updateSupportedVersionsData(mockServer.url);
+
+      expect(axiosMock.get).toHaveBeenCalledTimes(1);
+
+      const verdictDispatch = dispatchMock.mock.calls.find(
+        ([action]) =>
+          (action as any).type === WEBVIEW_SERVER_IS_SUPPORTED_VERSION
+      );
+      expect(verdictDispatch?.[0]).toEqual({
+        type: WEBVIEW_SERVER_IS_SUPPORTED_VERSION,
+        payload: {
+          url: mockServer.url,
+          isSupportedVersion: true,
+        },
+      });
+    });
+  });
+
   // ========== CLOUD FETCH PATH TESTS ==========
   describe('Cloud Fetch Path', () => {
     it('should fetch cloud info with retries when server fails', async () => {
@@ -832,6 +999,42 @@ describe('supportedVersions/main.ts', () => {
       const result = await isServerVersionSupported(
         mockServer as any,
         supportedVersions as any
+      );
+
+      expect(result.supported).toBe(true);
+    });
+
+    it('should honor exceptions when exceptions.domain differs only by letter case', async () => {
+      const futureDate = new Date(Date.now() + 86400000);
+      const supportedVersions: SupportedVersions = {
+        enforcementStartDate: new Date(Date.now() - 86400000).toISOString(),
+        timestamp: new Date().toISOString(),
+        versions: [
+          {
+            version: '8.4.0',
+            expiration: futureDate,
+          },
+        ],
+        exceptions: {
+          domain: 'Open.Rocket.Chat',
+          uniqueId: 'test-unique-id',
+          versions: [
+            {
+              version: '8.5.1',
+              expiration: futureDate,
+            },
+          ],
+        },
+      };
+
+      const result = await isServerVersionSupported(
+        {
+          url: 'https://open.rocket.chat/',
+          version: '8.5',
+          title: 'Rocket.Chat Open',
+          uniqueID: 'test-unique-id',
+        } as any,
+        supportedVersions
       );
 
       expect(result.supported).toBe(true);

--- a/src/servers/supportedVersions/main.main.spec.ts
+++ b/src/servers/supportedVersions/main.main.spec.ts
@@ -1,3 +1,5 @@
+import type * as fsPromisesType from 'node:fs/promises';
+
 import axios from 'axios';
 import * as jsonwebtoken from 'jsonwebtoken';
 
@@ -41,33 +43,22 @@ const selectMock = select as jest.MockedFunction<typeof select>;
 const listenMock = listen as jest.MockedFunction<typeof listen>;
 const axiosMock = axios as jest.Mocked<typeof axios>;
 
-// Mock data factories
+// Mock data factories.
+// Default shape mirrors the REAL unauthenticated GET /api/info response
+// (apps/meteor/server/api/lib/getServerInfo.ts): version is TRIMMED to
+// major.minor, and `build`/`marketplaceApiVersion`/`commit` are absent
+// because those only appear for authenticated view-statistics callers.
 const createMockServerInfo = (overrides?: Partial<ServerInfo>): ServerInfo => ({
-  version: '7.1.0',
-  uniqueId: 'test-unique-id',
-  build: {
-    date: '2024-01-01',
-    nodeVersion: '18.0.0',
-    arch: 'x64',
-    platform: 'darwin',
-    osRelease: '13.0.0',
-    totalMemory: 16000000000,
-    freeMemory: 8000000000,
-    cpus: 4,
+  version: '7.13',
+  minimumClientVersions: {
+    desktop: '3.9.6',
+    mobile: '4.39.0',
   },
-  marketplaceApiVersion: '1.30.0',
-  commit: {
-    hash: 'abc123',
-    date: new Date(),
-    author: 'Test Author',
-    subject: 'Test Commit',
-    tag: 'v7.1.0',
-    branch: 'main',
-  },
-  success: true,
   supportedVersions: {
     signed: 'mock-jwt-token',
   },
+  cloudWorkspaceId: 'mock-cloud-workspace-id',
+  success: true,
   ...overrides,
 });
 
@@ -107,7 +98,10 @@ const createMockServer = (overrides?: Partial<any>) => ({
 
 describe('supportedVersions/main.ts', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    // resetAllMocks (not clearAllMocks) so a jsonwebtoken.verify
+    // mockReturnValue/mockImplementation set by one test cannot leak into
+    // the next — clearAllMocks only clears call history, not implementations.
+    jest.resetAllMocks();
   });
 
   // ========== INITIALIZATION & SETUP TESTS ==========
@@ -167,7 +161,9 @@ describe('supportedVersions/main.ts', () => {
       // Should call axios.get once (success on first try)
       expect(axiosMock.get).toHaveBeenCalledTimes(1);
 
-      // Should dispatch VERSION_UPDATED with server info
+      // Should dispatch VERSION_UPDATED with server info. /api/info never
+      // carries `commit` for the desktop's unauthenticated request, so
+      // gitCommitHash is undefined here.
       const versionDispatch = dispatchMock.mock.calls.find(
         ([action]) => action.type === WEBVIEW_SERVER_VERSION_UPDATED
       );
@@ -177,19 +173,25 @@ describe('supportedVersions/main.ts', () => {
         payload: {
           url: mockServer.url,
           version: mockServerInfo.version,
-          gitCommitHash: mockServerInfo.commit.hash,
+          gitCommitHash: undefined,
         },
       });
     });
 
     it('should dispatch git commit hash from server info', async () => {
       const mockServer = createMockServer();
+      // `commit` only occurs for authenticated view-statistics calls; passed
+      // here explicitly to unit-test the dispatch wiring in isolation.
       const mockServerInfo = createMockServerInfo({
         commit: {
-          ...createMockServerInfo().commit,
           hash: 'bb83777b51a42d',
+          date: new Date(),
+          author: 'Test Author',
+          subject: 'Test Commit',
+          tag: 'v7.13',
+          branch: 'main',
         },
-      });
+      } as any);
       selectMock.mockReturnValue(mockServer);
       axiosMock.get = jest.fn().mockResolvedValue({ data: mockServerInfo });
 
@@ -289,8 +291,10 @@ describe('supportedVersions/main.ts', () => {
       selectMock.mockReturnValue(mockServer);
       axiosMock.get = jest.fn().mockResolvedValue({ data: mockServerInfo });
 
+      // No uniqueId-scoped exceptions here — this test is about the
+      // supportedVersions.signed decode path, not exception scope resolution.
       (jest.spyOn(jsonwebtoken, 'verify') as jest.Mock).mockReturnValue(
-        createMockSupportedVersions()
+        createMockSupportedVersions({ exceptions: undefined })
       );
 
       await updateSupportedVersionsData(mockServer.url);
@@ -403,7 +407,6 @@ describe('supportedVersions/main.ts', () => {
       const mockServer = createMockServer({ version: '7.13' });
       const mockServerInfo = createMockServerInfo({
         version: '7.13',
-        uniqueId: undefined,
       });
       selectMock.mockReturnValue(mockServer);
       axiosMock.get = jest
@@ -446,7 +449,6 @@ describe('supportedVersions/main.ts', () => {
       });
       const mockServerInfo = createMockServerInfo({
         version: '7.13',
-        uniqueId: undefined,
       });
       selectMock.mockReturnValue(mockServer);
       axiosMock.get = jest
@@ -479,7 +481,6 @@ describe('supportedVersions/main.ts', () => {
       const mockServer = createMockServer({ version: '7.13' });
       const mockServerInfo = createMockServerInfo({
         version: '7.13',
-        uniqueId: undefined,
       });
       selectMock.mockReturnValue(mockServer);
       axiosMock.get = jest
@@ -523,7 +524,6 @@ describe('supportedVersions/main.ts', () => {
       });
       const mockServerInfo = createMockServerInfo({
         version: '7.13',
-        uniqueId: undefined,
       });
       selectMock.mockReturnValue(mockServer);
       axiosMock.get = jest.fn().mockResolvedValueOnce({ data: mockServerInfo });
@@ -614,8 +614,10 @@ describe('supportedVersions/main.ts', () => {
       selectMock.mockReturnValue(mockServer);
       axiosMock.get = jest.fn().mockResolvedValue({ data: mockServerInfo });
 
+      // No uniqueId-scoped exceptions here — this test is about the cloud
+      // fetch being skipped, not exception scope resolution.
       (jest.spyOn(jsonwebtoken, 'verify') as jest.Mock).mockReturnValue(
-        createMockSupportedVersions()
+        createMockSupportedVersions({ exceptions: undefined })
       );
 
       await updateSupportedVersionsData(mockServer.url);
@@ -829,7 +831,12 @@ describe('supportedVersions/main.ts', () => {
     it('should return early after successful server decode and dispatch', async () => {
       const mockServer = createMockServer();
       const mockServerInfo = createMockServerInfo();
-      const mockSupportedVersions = createMockSupportedVersions();
+      // No uniqueId-scoped exceptions here — this test is about the
+      // early-return after a successful decode, not exception scope
+      // resolution.
+      const mockSupportedVersions = createMockSupportedVersions({
+        exceptions: undefined,
+      });
       selectMock.mockReturnValue(mockServer);
       axiosMock.get = jest.fn().mockResolvedValue({ data: mockServerInfo });
 
@@ -1811,6 +1818,279 @@ describe('supportedVersions/main.ts', () => {
     });
   });
 
+  // ========== FALLBACK: either source granting support must win (#3388 regression guard) ==========
+  describe('fallback candidate selection: either source supporting must win', () => {
+    // Each test needs a fresh builtinSupportedVersions singleton with a
+    // SPECIFIC payload distinct from the cache payload, so isolate modules
+    // the same way the stale-cache-after-update test above does.
+    const runIsolated = async (
+      setup: (ctx: {
+        dispatchMock: jest.MockedFunction<typeof dispatch>;
+        selectMock: jest.MockedFunction<typeof select>;
+        axiosMock: jest.Mocked<typeof axios>;
+        storeGetMock: jest.Mock;
+        fsPromises: typeof fsPromisesType;
+        jwt: typeof jsonwebtoken;
+        update: typeof updateSupportedVersionsData;
+      }) => Promise<void>
+    ): Promise<void> => {
+      await jest.isolateModulesAsync(async () => {
+        jest.mock('../../store');
+        jest.mock('axios');
+        jest.mock('jsonwebtoken');
+        jest.mock('electron-store');
+        jest.mock('node:fs/promises');
+        jest.mock('electron', () => ({
+          ipcMain: { handle: jest.fn() },
+        }));
+
+        const { dispatch: isolatedDispatch, select: isolatedSelect } =
+          await import('../../store');
+        const isolatedAxios = (await import('axios')).default;
+        const isolatedJwt = await import('jsonwebtoken');
+        const { updateSupportedVersionsData: isolatedUpdate } = await import(
+          './main'
+        );
+        const isolatedFs = await import('node:fs/promises');
+
+        const isolatedDispatchMock = isolatedDispatch as jest.MockedFunction<
+          typeof isolatedDispatch
+        >;
+        const isolatedSelectMock = isolatedSelect as jest.MockedFunction<
+          typeof isolatedSelect
+        >;
+        const isolatedAxiosMock = isolatedAxios as jest.Mocked<
+          typeof isolatedAxios
+        >;
+
+        const IsolatedElectronStoreMock = jest.requireMock('electron-store');
+        const isolatedStoreGetMock = jest.spyOn(
+          IsolatedElectronStoreMock.prototype,
+          'get'
+        ) as jest.Mock;
+        isolatedStoreGetMock.mockReturnValue(undefined);
+
+        await setup({
+          dispatchMock: isolatedDispatchMock,
+          selectMock: isolatedSelectMock,
+          axiosMock: isolatedAxiosMock,
+          storeGetMock: isolatedStoreGetMock,
+          fsPromises: isolatedFs,
+          jwt: isolatedJwt as unknown as typeof jsonwebtoken,
+          update: isolatedUpdate,
+        });
+      });
+    };
+
+    it('T-A: fresher builtin without the exception must not drop a cached tenant exception that grants support', async () => {
+      await runIsolated(
+        async ({
+          dispatchMock: isolatedDispatchMock,
+          selectMock: isolatedSelectMock,
+          axiosMock: isolatedAxiosMock,
+          storeGetMock: isolatedStoreGetMock,
+          fsPromises: isolatedFs,
+          jwt: isolatedJwt,
+          update: isolatedUpdate,
+        }) => {
+          const mockServer = createMockServer({
+            url: 'https://example.com',
+            version: '7.5.0',
+            uniqueID: 'test-unique-id',
+          });
+          isolatedSelectMock.mockReturnValue(mockServer);
+          isolatedAxiosMock.get = jest
+            .fn()
+            .mockRejectedValue(new Error('Network error'));
+
+          const futureExpiry = new Date(Date.now() + 86400000 * 365);
+
+          // Cache: base versions don't cover 7.5, but a tenant-scoped exception does.
+          const cachedVersions = createMockSupportedVersions({
+            versions: [{ version: '6.0.0', expiration: futureExpiry }],
+            exceptions: {
+              domain: 'example.com',
+              uniqueId: 'test-unique-id',
+              versions: [{ version: '7.5.0', expiration: futureExpiry }],
+            },
+            enforcementStartDate: '2023-01-01T00:00:00Z',
+            timestamp: '2020-01-01T00:00:00Z',
+          });
+          isolatedStoreGetMock.mockReturnValue(cachedVersions);
+
+          // Builtin: FRESHER than cache, but has no exceptions and doesn't
+          // list 7.5 as supported.
+          const freshBuiltinVersions = createMockSupportedVersions({
+            versions: [{ version: '6.0.0', expiration: futureExpiry }],
+            exceptions: undefined,
+            enforcementStartDate: '2023-01-01T00:00:00Z',
+            timestamp: new Date().toISOString(),
+          });
+          (isolatedFs.readFile as jest.Mock).mockResolvedValue(
+            'builtin-jwt-token'
+          );
+          (isolatedJwt.verify as jest.Mock).mockReturnValue(
+            freshBuiltinVersions
+          );
+
+          jest.useFakeTimers();
+          const promise = isolatedUpdate(mockServer.url);
+          // server.uniqueID is set, so both the server-info retry AND the
+          // cloud-fallback retry run (3 attempts x 2000ms delay each).
+          await jest.advanceTimersByTimeAsync(10000);
+          await promise;
+          jest.useRealTimers();
+
+          const isSupportedDispatch = isolatedDispatchMock.mock.calls.find(
+            ([action]) =>
+              (action as any).type === WEBVIEW_SERVER_IS_SUPPORTED_VERSION
+          );
+          expect(isSupportedDispatch).toBeDefined();
+          // Cache rescues the server despite builtin's freshness preference.
+          expect(
+            (isSupportedDispatch?.[0] as any)?.payload?.isSupportedVersion
+          ).toBe(true);
+
+          const updatedDispatch = isolatedDispatchMock.mock.calls.find(
+            ([action]) =>
+              (action as any).type === WEBVIEW_SERVER_SUPPORTED_VERSIONS_UPDATED
+          );
+          expect((updatedDispatch?.[0] as any)?.payload?.source).toBe('cloud');
+        }
+      );
+    }, 15000);
+
+    it('T-B: fresher builtin that supports the version still wins over a stale, unsupportive cache (#3388 fix preserved)', async () => {
+      await runIsolated(
+        async ({
+          dispatchMock: isolatedDispatchMock,
+          selectMock: isolatedSelectMock,
+          axiosMock: isolatedAxiosMock,
+          storeGetMock: isolatedStoreGetMock,
+          fsPromises: isolatedFs,
+          jwt: isolatedJwt,
+          update: isolatedUpdate,
+        }) => {
+          const mockServer = createMockServer({ version: '8.5.1' });
+          isolatedSelectMock.mockReturnValue(mockServer);
+          isolatedAxiosMock.get = jest
+            .fn()
+            .mockRejectedValue(new Error('Network error'));
+
+          const futureExpiry = new Date(Date.now() + 86400000 * 365);
+
+          // Stale cache: does not know about 8.5 -> unsupported, no exception.
+          const staleCachedVersions = createMockSupportedVersions({
+            versions: [{ version: '7.0.0', expiration: futureExpiry }],
+            exceptions: undefined,
+            enforcementStartDate: '2023-01-01T00:00:00Z',
+            timestamp: '2020-01-01T00:00:00Z',
+          });
+          isolatedStoreGetMock.mockReturnValue(staleCachedVersions);
+
+          // Fresh builtin: bundled with the current app version, knows 8.5 is supported.
+          const freshBuiltinVersions = createMockSupportedVersions({
+            versions: [{ version: '8.5.0', expiration: futureExpiry }],
+            exceptions: undefined,
+            enforcementStartDate: '2023-01-01T00:00:00Z',
+            timestamp: new Date().toISOString(),
+          });
+          (isolatedFs.readFile as jest.Mock).mockResolvedValue(
+            'builtin-jwt-token'
+          );
+          (isolatedJwt.verify as jest.Mock).mockReturnValue(
+            freshBuiltinVersions
+          );
+
+          jest.useFakeTimers();
+          const promise = isolatedUpdate(mockServer.url);
+          await jest.advanceTimersByTimeAsync(4000);
+          await promise;
+          jest.useRealTimers();
+
+          const isSupportedDispatch = isolatedDispatchMock.mock.calls.find(
+            ([action]) =>
+              (action as any).type === WEBVIEW_SERVER_IS_SUPPORTED_VERSION
+          );
+          expect(isSupportedDispatch).toBeDefined();
+          expect(
+            (isSupportedDispatch?.[0] as any)?.payload?.isSupportedVersion
+          ).toBe(true);
+
+          const updatedDispatch = isolatedDispatchMock.mock.calls.find(
+            ([action]) =>
+              (action as any).type === WEBVIEW_SERVER_SUPPORTED_VERSIONS_UPDATED
+          );
+          expect((updatedDispatch?.[0] as any)?.payload?.source).toBe(
+            'builtin'
+          );
+        }
+      );
+    });
+
+    it('T-C: neither cache nor builtin supports the version -> blocked', async () => {
+      await runIsolated(
+        async ({
+          dispatchMock: isolatedDispatchMock,
+          selectMock: isolatedSelectMock,
+          axiosMock: isolatedAxiosMock,
+          storeGetMock: isolatedStoreGetMock,
+          fsPromises: isolatedFs,
+          jwt: isolatedJwt,
+          update: isolatedUpdate,
+        }) => {
+          const mockServer = createMockServer({ version: '9.0.0' });
+          isolatedSelectMock.mockReturnValue(mockServer);
+          isolatedAxiosMock.get = jest
+            .fn()
+            .mockRejectedValue(new Error('Network error'));
+
+          const futureExpiry = new Date(Date.now() + 86400000 * 365);
+
+          const cachedVersions = createMockSupportedVersions({
+            versions: [{ version: '7.0.0', expiration: futureExpiry }],
+            exceptions: undefined,
+            enforcementStartDate: '2023-01-01T00:00:00Z',
+            timestamp: '2020-01-01T00:00:00Z',
+          });
+          isolatedStoreGetMock.mockReturnValue(cachedVersions);
+
+          const builtinVersions = createMockSupportedVersions({
+            versions: [{ version: '8.0.0', expiration: futureExpiry }],
+            exceptions: undefined,
+            enforcementStartDate: '2023-01-01T00:00:00Z',
+            timestamp: new Date().toISOString(),
+          });
+          (isolatedFs.readFile as jest.Mock).mockResolvedValue(
+            'builtin-jwt-token'
+          );
+          (isolatedJwt.verify as jest.Mock).mockReturnValue(builtinVersions);
+
+          jest.useFakeTimers();
+          const promise = isolatedUpdate(mockServer.url);
+          await jest.advanceTimersByTimeAsync(4000);
+          await promise;
+          jest.useRealTimers();
+
+          const isSupportedDispatch = isolatedDispatchMock.mock.calls.find(
+            ([action]) =>
+              (action as any).type === WEBVIEW_SERVER_IS_SUPPORTED_VERSION
+          );
+          expect(isSupportedDispatch).toBeDefined();
+          expect(
+            (isSupportedDispatch?.[0] as any)?.payload?.isSupportedVersion
+          ).toBe(false);
+
+          const errorDispatch = isolatedDispatchMock.mock.calls.find(
+            ([action]) =>
+              (action as any).type === WEBVIEW_SERVER_SUPPORTED_VERSIONS_ERROR
+          );
+          expect(errorDispatch).toBeDefined();
+        }
+      );
+    });
+  });
+
   // ========== CONCURRENCY: overlapping requests must not stale-overwrite ==========
   describe('overlapping request guard', () => {
     it('older slower request does not overwrite newer request verdict', async () => {
@@ -2238,10 +2518,11 @@ describe('supportedVersions/main.ts', () => {
         enforcementStartDate: '2023-01-01T00:00:00Z',
       });
 
+      // `commit` only occurs for authenticated view-statistics calls; passed
+      // here explicitly to unit-test the gitCommitHash dispatch wiring.
       axiosMock.get = jest.fn().mockResolvedValue({
         data: {
           version: '7.5.0',
-          uniqueId: 'fresh-unique',
           commit: { hash: 'abcdef1234567890' },
           supportedVersions: { signed: 'jwt' },
         },
@@ -2261,62 +2542,6 @@ describe('supportedVersions/main.ts', () => {
       expect((versionDispatch?.[0] as any)?.payload?.gitCommitHash).toBe(
         'abcdef1234567890'
       );
-    });
-  });
-
-  describe('server-source exception scope uses fresh /api/info uniqueId', () => {
-    it('honors scoped exception on first load when persisted server.uniqueID is undefined but /api/info returns uniqueId', async () => {
-      // Mock server with NO persisted uniqueID (first launch).
-      const mockServer = {
-        url: 'https://tenant-a.example.com/',
-        version: '7.5.0',
-        title: 'Tenant A',
-        // uniqueID undefined
-      } as any;
-      selectMock.mockReturnValue(mockServer);
-
-      const futureExpiry = new Date(Date.now() + 86400000 * 365);
-      // Payload with scoped exception that requires uniqueId match.
-      const payloadWithScopedException = {
-        versions: [],
-        enforcementStartDate: '2023-01-01T00:00:00Z',
-        timestamp: new Date().toISOString(),
-        messages: [],
-        i18n: {},
-        exceptions: {
-          domain: 'tenant-a.example.com',
-          uniqueId: 'tenant-a-fresh-unique',
-          versions: [{ version: 'sha-abc1234', expiration: futureExpiry }],
-        },
-      };
-
-      // /api/info returns fresh uniqueId + signed JWT
-      axiosMock.get = jest.fn().mockResolvedValue({
-        data: {
-          version: '7.5.0',
-          uniqueId: 'tenant-a-fresh-unique',
-          commit: { hash: 'abc1234567890' },
-          supportedVersions: { signed: 'server-jwt' },
-        },
-      });
-      (jest.spyOn(jsonwebtoken, 'verify') as jest.Mock).mockReturnValue(
-        payloadWithScopedException
-      );
-
-      await updateSupportedVersionsData(mockServer.url);
-
-      const isSupportedDispatch = dispatchMock.mock.calls.find(
-        ([action]) =>
-          (action as any).type === WEBVIEW_SERVER_IS_SUPPORTED_VERSION
-      );
-      expect(isSupportedDispatch).toBeDefined();
-      // Without fix: server.uniqueID undefined -> scope check rejects ->
-      // exception ignored -> falls through to enforcement -> false.
-      // With fix: serverWithFreshVersion gets serverInfoResult.uniqueId ->
-      // scope matches -> exception honored -> true.
-      expect(
-        (isSupportedDispatch?.[0] as any)?.payload?.isSupportedVersion
-      ).toBe(true);
     });
   });
 

--- a/src/servers/supportedVersions/main.main.spec.ts
+++ b/src/servers/supportedVersions/main.main.spec.ts
@@ -475,7 +475,7 @@ describe('supportedVersions/main.ts', () => {
       });
     });
 
-    it('should reject the exception when the fetched uniqueID does not match the exception scope', async () => {
+    it('honors the server-source exception with a warning when the fetched uniqueID does not match the scope', async () => {
       const mockServer = createMockServer({ version: '7.13' });
       const mockServerInfo = createMockServerInfo({
         version: '7.13',
@@ -493,7 +493,15 @@ describe('supportedVersions/main.ts', () => {
         tenantSupportedVersions()
       );
 
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
       await updateSupportedVersionsData(mockServer.url);
+
+      // Server-source payloads are self-scoped; a mismatch is diagnostic
+      // only and the exception is still honored.
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('exception scope mismatch')
+      );
+      consoleWarnSpy.mockRestore();
 
       const verdictDispatch = dispatchMock.mock.calls.find(
         ([action]) =>
@@ -503,7 +511,7 @@ describe('supportedVersions/main.ts', () => {
         type: WEBVIEW_SERVER_IS_SUPPORTED_VERSION,
         payload: {
           url: mockServer.url,
-          isSupportedVersion: false,
+          isSupportedVersion: true,
         },
       });
     });
@@ -1965,7 +1973,7 @@ describe('supportedVersions/main.ts', () => {
       i18n: {},
     };
 
-    it('does NOT honor commit-hash exception when payload domain mismatches server', async () => {
+    it('does NOT honor commit-hash exception from the BUILTIN payload when the domain mismatches', async () => {
       const payload = {
         ...baseVersions,
         exceptions: {
@@ -1975,7 +1983,9 @@ describe('supportedVersions/main.ts', () => {
         },
       } as unknown as SupportedVersions;
 
-      // Server B has matching commit hash but different domain.
+      // Server B has matching commit hash but different domain. The builtin
+      // payload is the only source that can carry another tenant's
+      // exceptions, so it keeps the strict scope requirement.
       const serverB = {
         url: 'https://tenant-b.example.com/',
         version: '8.5',
@@ -1986,13 +1996,14 @@ describe('supportedVersions/main.ts', () => {
       const result = await isServerVersionSupported(
         serverB,
         payload,
-        'abc1234567890'
+        'abc1234567890',
+        'builtin'
       );
       // Enforcement falls through (no versions match either) -> unsupported.
       expect(result.supported).toBe(false);
     });
 
-    it('does NOT honor commit-hash exception when payload uniqueId mismatches server', async () => {
+    it('does NOT honor commit-hash exception from the BUILTIN payload when uniqueId mismatches', async () => {
       const payload = {
         ...baseVersions,
         exceptions: {
@@ -2013,9 +2024,41 @@ describe('supportedVersions/main.ts', () => {
       const result = await isServerVersionSupported(
         serverB,
         payload,
-        'abc1234567890'
+        'abc1234567890',
+        'builtin'
       );
       expect(result.supported).toBe(false);
+    });
+
+    it('honors a scope-mismatched exception from a SERVER-source payload with a diagnostic warning', async () => {
+      const payload = {
+        ...baseVersions,
+        exceptions: {
+          domain: 'tenant-a.example.com',
+          uniqueId: 'tenant-a-unique',
+          versions: [{ version: 'sha-abc1234', expiration: futureExpiry }],
+        },
+      } as unknown as SupportedVersions;
+
+      const serverB = {
+        url: 'https://tenant-b.example.com/',
+        version: '8.5',
+        title: 'Tenant B',
+        uniqueID: 'tenant-b-unique',
+      } as any;
+
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const result = await isServerVersionSupported(
+        serverB,
+        payload,
+        'abc1234567890',
+        'server'
+      );
+      expect(result.supported).toBe(true);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('exception scope mismatch')
+      );
+      consoleWarnSpy.mockRestore();
     });
 
     it('honors commit-hash exception when domain AND uniqueId both match', async () => {
@@ -2055,8 +2098,7 @@ describe('supportedVersions/main.ts', () => {
 
       // Same domain. Same commit hash. Local uniqueID UNKNOWN (e.g.
       // settings.public restricted by enterprise API ACLs). An unprovable
-      // identity must not disqualify a domain-matched exception — wrongly
-      // blocking a legitimate tenant is the worse failure mode.
+      // identity must not disqualify a domain-matched exception.
       const serverWithoutUniqueID = {
         url: 'https://tenant-a.example.com/',
         version: '8.5',
@@ -2072,7 +2114,7 @@ describe('supportedVersions/main.ts', () => {
       expect(result.supported).toBe(true);
     });
 
-    it('rejects scoped exception on a PROVEN uniqueID mismatch even when the domain matches', async () => {
+    it('rejects a BUILTIN-source exception on a PROVEN uniqueID mismatch even when the domain matches', async () => {
       const payload = {
         ...baseVersions,
         exceptions: {
@@ -2092,7 +2134,8 @@ describe('supportedVersions/main.ts', () => {
       const result = await isServerVersionSupported(
         serverWithOtherUniqueID,
         payload,
-        'abc1234567890'
+        'abc1234567890',
+        'builtin'
       );
       expect(result.supported).toBe(false);
     });

--- a/src/servers/supportedVersions/main.main.spec.ts
+++ b/src/servers/supportedVersions/main.main.spec.ts
@@ -1016,6 +1016,48 @@ describe('supportedVersions/main.ts', () => {
       expect(result.supported).toBe(true);
     });
 
+    it('does not block when enforcementStartDate is missing (uncertain data must not block)', async () => {
+      const supportedVersions = {
+        versions: [{ version: '9.9.0', expiration: new Date() }],
+        // no enforcementStartDate
+      };
+
+      const result = await isServerVersionSupported(
+        mockServer as any,
+        supportedVersions as any
+      );
+
+      expect(result.supported).toBe(true);
+    });
+
+    it('does not block when enforcementStartDate is malformed', async () => {
+      const supportedVersions = {
+        versions: [{ version: '9.9.0', expiration: new Date() }],
+        enforcementStartDate: 'not-a-date',
+      };
+
+      const result = await isServerVersionSupported(
+        mockServer as any,
+        supportedVersions as any
+      );
+
+      expect(result.supported).toBe(true);
+    });
+
+    it('blocks when a valid past enforcementStartDate is present and nothing matches', async () => {
+      const supportedVersions = {
+        versions: [{ version: '9.9.0', expiration: new Date() }],
+        enforcementStartDate: new Date(Date.now() - 86400000).toISOString(),
+      };
+
+      const result = await isServerVersionSupported(
+        mockServer as any,
+        supportedVersions as any
+      );
+
+      expect(result.supported).toBe(false);
+    });
+
     it('should honor exceptions when exceptions.domain differs only by letter case', async () => {
       const futureDate = new Date(Date.now() + 86400000);
       const supportedVersions: SupportedVersions = {

--- a/src/servers/supportedVersions/main.ts
+++ b/src/servers/supportedVersions/main.ts
@@ -451,9 +451,17 @@ export const isServerVersionSupported = async (
     }
   }
 
-  const enforcementStartDate = new Date(
-    supportedVersionsData?.enforcementStartDate
-  );
+  // Only block when the payload proves enforcement is active. A missing or
+  // malformed enforcementStartDate is incomplete data, and an uncertain
+  // verdict must not block — keep the server usable until a payload with a
+  // valid enforcement date proves otherwise.
+  const rawEnforcementStartDate = supportedVersionsData?.enforcementStartDate;
+  const enforcementStartDate = rawEnforcementStartDate
+    ? new Date(rawEnforcementStartDate)
+    : undefined;
+  if (!enforcementStartDate || Number.isNaN(enforcementStartDate.getTime())) {
+    return { supported: true };
+  }
   if (enforcementStartDate > new Date()) {
     const selectedExpirationMessage = getExpirationMessage({
       messages: supportedVersionsData.messages,

--- a/src/servers/supportedVersions/main.ts
+++ b/src/servers/supportedVersions/main.ts
@@ -2,7 +2,7 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import axios from 'axios';
-import { ipcMain } from 'electron';
+import { ipcMain, powerMonitor } from 'electron';
 import ElectronStore from 'electron-store';
 import jwt from 'jsonwebtoken';
 import moment from 'moment';
@@ -82,7 +82,7 @@ const logRequestError =
         console.error(`Couldn't load ${description}: ${error.message}`);
       }
     } else {
-      console.error('Fetching ${description} error:', error);
+      console.error(`Fetching ${description} error:`, error);
     }
     return undefined;
   };
@@ -299,6 +299,9 @@ export const getExpirationMessageTranslated = (
   }
 
   const i18nLang = i18n[language] ?? i18n.en;
+  if (!i18nLang) {
+    return null;
+  }
 
   const getTranslation = (key: string) =>
     key && i18nLang[key] ? applyParams(i18nLang[key], params) : undefined;
@@ -341,10 +344,13 @@ export const isServerVersionSupported = async (
   // Exception entries only apply when the payload's exceptions block is scoped
   // to THIS server. The cloud-source and server-source payloads are inherently
   // scoped, but the builtin (bundled) and cache payloads can be from a different
-  // tenant, so a domain/uniqueId mismatch must disqualify the exceptions to
-  // avoid cross-tenant bypass.
-  // Treat present scope fields as REQUIRED equality. Missing local identity
-  // (e.g. server.uniqueID undefined) does NOT relax the check — it must reject.
+  // tenant, so a PROVEN domain/uniqueId mismatch must disqualify the exceptions
+  // to avoid cross-tenant leakage.
+  // An UNKNOWN local uniqueID (e.g. settings.public restricted by enterprise
+  // API ACLs) does NOT disqualify: this gate is client-side UX enforcement,
+  // not a security boundary, and wrongly blocking a paying tenant is the worse
+  // failure mode. Domain equality (checked whenever the payload carries a
+  // domain) remains the primary scope.
   let exceptionScopeMatches = true;
   if (exceptions) {
     let hostname: string | undefined;
@@ -357,7 +363,11 @@ export const isServerVersionSupported = async (
     if (exceptions.domain && exceptions.domain.toLowerCase() !== hostname) {
       exceptionScopeMatches = false;
     }
-    if (exceptions.uniqueId && exceptions.uniqueId !== server.uniqueID) {
+    if (
+      exceptions.uniqueId &&
+      server.uniqueID &&
+      exceptions.uniqueId !== server.uniqueID
+    ) {
       exceptionScopeMatches = false;
     }
   }
@@ -527,6 +537,48 @@ const withExceptionScopeUniqueId = async (
     : serverView;
 };
 
+// Validates the fallback (cache/builtin) payload and dispatches the verdict.
+// isServerVersionSupported can throw on a malformed cached/builtin payload
+// (e.g. `versions` not an array). Left unguarded, that throw would reject
+// updateSupportedVersionsData before WEBVIEW_SERVER_SUPPORTED_VERSIONS_ERROR
+// is dispatched, leaving supportedVersionsFetchState stuck at 'loading' —
+// which suppresses the UnsupportedServer block gate (fail-open). On failure,
+// only the error state is dispatched; the prior verdict is left untouched.
+const validateFallbackAndDispatch = async (
+  server: Server,
+  serverUrl: string,
+  fallbackVersions: SupportedVersions,
+  fallbackSource: 'cloud' | 'builtin',
+  freshCommitHash: string | undefined,
+  isStale: () => boolean
+): Promise<void> => {
+  try {
+    const fallbackSupported = await isServerVersionSupported(
+      server,
+      fallbackVersions,
+      freshCommitHash
+    );
+    if (isStale()) return;
+    dispatch({
+      type: WEBVIEW_SERVER_IS_SUPPORTED_VERSION,
+      payload: {
+        url: server.url,
+        isSupportedVersion: fallbackSupported.supported,
+      },
+    });
+    dispatchSupportedVersionsUpdated(server.url, fallbackVersions, {
+      source: fallbackSource,
+    });
+  } catch (error) {
+    console.error('Error validating fallback supported versions:', error);
+  }
+  if (isStale()) return;
+  dispatch({
+    type: WEBVIEW_SERVER_SUPPORTED_VERSIONS_ERROR,
+    payload: { url: serverUrl },
+  });
+};
+
 // Per-URL request generation counter. Each call to updateSupportedVersionsData
 // bumps the counter and captures its own generation. Awaited steps inside the
 // call check whether their generation is still current before dispatching, so
@@ -643,10 +695,15 @@ export const updateSupportedVersionsData = async (
     uniqueID: uniqueID ?? serverWithFreshVersion.uniqueID,
   };
 
+  // Fall back to the persisted uniqueID when the fresh fetch failed, so a
+  // prior session's identity still enables the cloud lookup instead of
+  // skipping it outright.
+  const effectiveUniqueId = uniqueID ?? server.uniqueID;
+
   // Try Cloud with retries (3x with 2s delays) if unique ID available
-  if (!serverEncoded && uniqueID) {
+  if (!serverEncoded && effectiveUniqueId) {
     const cloudVersionsWithRetry = await withRetries(
-      () => getCloudInfo(server.url, uniqueID),
+      () => getCloudInfo(server.url, effectiveUniqueId),
       3,
       2000
     );
@@ -703,26 +760,15 @@ export const updateSupportedVersionsData = async (
   if (fallbackVersions) {
     if (isStale()) return;
     saveToCache(serverUrl, fallbackVersions);
-    const fallbackSupported = await isServerVersionSupported(
-      serverWithFreshIdentity,
-      fallbackVersions,
-      freshCommitHash
-    );
     if (isStale()) return;
-    dispatch({
-      type: WEBVIEW_SERVER_IS_SUPPORTED_VERSION,
-      payload: {
-        url: server.url,
-        isSupportedVersion: fallbackSupported.supported,
-      },
-    });
-    dispatchSupportedVersionsUpdated(server.url, fallbackVersions, {
-      source: fallbackSource,
-    });
-    dispatch({
-      type: WEBVIEW_SERVER_SUPPORTED_VERSIONS_ERROR,
-      payload: { url: serverUrl },
-    });
+    await validateFallbackAndDispatch(
+      serverWithFreshIdentity,
+      serverUrl,
+      fallbackVersions,
+      fallbackSource,
+      freshCommitHash,
+      isStale
+    );
     return;
   }
 
@@ -739,20 +785,46 @@ export const updateSupportedVersionsData = async (
   });
 };
 
+const logUpdateError =
+  (serverUrl: string) =>
+  (error: unknown): void => {
+    console.error(
+      `Error updating supported versions data for ${serverUrl}:`,
+      error
+    );
+  };
+
 export function checkSupportedVersionServers(): void {
   listen(WEBVIEW_READY, async (action) => {
-    updateSupportedVersionsData(action.payload.url);
+    updateSupportedVersionsData(action.payload.url).catch(
+      logUpdateError(action.payload.url)
+    );
   });
 
   listen(SUPPORTED_VERSION_DIALOG_DISMISS, async (action) => {
-    updateSupportedVersionsData(action.payload.url);
+    updateSupportedVersionsData(action.payload.url).catch(
+      logUpdateError(action.payload.url)
+    );
   });
 
   listen(WEBVIEW_SERVER_RELOADED, async (action) => {
-    updateSupportedVersionsData(action.payload.url);
+    updateSupportedVersionsData(action.payload.url).catch(
+      logUpdateError(action.payload.url)
+    );
   });
 
   ipcMain.handle('refresh-supported-versions', async (_event, serverUrl) => {
-    updateSupportedVersionsData(serverUrl);
+    updateSupportedVersionsData(serverUrl).catch(logUpdateError(serverUrl));
+  });
+
+  // 'online' only fires on real network transitions, not on wake-from-sleep
+  // (e.g. laptop resumes with the same network already connected). Without
+  // this, a server's supported-versions verdict can go stale for the entire
+  // duration of a sleep period until the next WEBVIEW_READY/reload/dismiss.
+  powerMonitor.on('resume', () => {
+    const servers = select(({ servers }) => servers);
+    servers.forEach((server) => {
+      updateSupportedVersionsData(server.url).catch(logUpdateError(server.url));
+    });
   });
 }

--- a/src/servers/supportedVersions/main.ts
+++ b/src/servers/supportedVersions/main.ts
@@ -319,7 +319,8 @@ export const getExpirationMessageTranslated = (
 export const isServerVersionSupported = async (
   server: Server,
   supportedVersionsData?: SupportedVersions,
-  serverCommitHash?: string
+  serverCommitHash?: string,
+  payloadSource?: 'server' | 'cloud' | 'builtin'
 ): Promise<{
   supported: boolean;
   message?: Message | undefined;
@@ -341,17 +342,16 @@ export const isServerVersionSupported = async (
 
   if (!supportedVersionsData) return { supported: true };
 
-  // Exception entries only apply when the payload's exceptions block is scoped
-  // to THIS server. The cloud-source and server-source payloads are inherently
-  // scoped, but the builtin (bundled) and cache payloads can be from a different
-  // tenant, so a PROVEN domain/uniqueId mismatch must disqualify the exceptions
-  // to avoid cross-tenant leakage.
+  // A valid, unexpired exception must never be rejected on a scope
+  // technicality. Server, cloud, and cache payloads are inherently
+  // self-scoped (fetched from/for THIS server), so for them a domain/uniqueId
+  // mismatch is logged for diagnostics but the exception is still honored.
+  // The bundled builtin payload is the only source that could carry another
+  // tenant's exceptions, so it alone keeps the strict scope requirement.
   // An UNKNOWN local uniqueID (e.g. settings.public restricted by enterprise
-  // API ACLs) does NOT disqualify: this gate is client-side UX enforcement,
-  // not a security boundary, and wrongly blocking a paying tenant is the worse
-  // failure mode. Domain equality (checked whenever the payload carries a
-  // domain) remains the primary scope.
-  let exceptionScopeMatches = true;
+  // API ACLs) is never treated as a mismatch: this gate is client-side UX
+  // enforcement, not a security boundary.
+  let exceptionScopeMismatch = false;
   if (exceptions) {
     let hostname: string | undefined;
     try {
@@ -361,15 +361,25 @@ export const isServerVersionSupported = async (
     }
     // DNS names are case-insensitive; URL.hostname is already lowercased.
     if (exceptions.domain && exceptions.domain.toLowerCase() !== hostname) {
-      exceptionScopeMatches = false;
+      exceptionScopeMismatch = true;
     }
     if (
       exceptions.uniqueId &&
       server.uniqueID &&
       exceptions.uniqueId !== server.uniqueID
     ) {
-      exceptionScopeMatches = false;
+      exceptionScopeMismatch = true;
     }
+  }
+  const exceptionScopeMatches =
+    !exceptionScopeMismatch || payloadSource !== 'builtin';
+  if (exceptionScopeMismatch && exceptionScopeMatches) {
+    console.warn(
+      `Supported-versions exception scope mismatch for ${server.url} ` +
+        `(payload domain: ${exceptions?.domain}, uniqueId: ${exceptions?.uniqueId}; ` +
+        `local uniqueID: ${server.uniqueID}) — honoring exception from ` +
+        `${payloadSource ?? 'unspecified'} source anyway`
+    );
   }
 
   // Match against the freshly-fetched commit hash when available, falling
@@ -556,7 +566,8 @@ const validateFallbackAndDispatch = async (
     const fallbackSupported = await isServerVersionSupported(
       server,
       fallbackVersions,
-      freshCommitHash
+      freshCommitHash,
+      fallbackSource
     );
     if (isStale()) return;
     dispatch({
@@ -652,7 +663,8 @@ export const updateSupportedVersionsData = async (
         const supported = await isServerVersionSupported(
           serverForValidation,
           serverSupportedVersions,
-          freshCommitHash
+          freshCommitHash,
+          'server'
         );
         if (isStale()) return;
         // Dispatch verdict BEFORE fetchState='success' so UnsupportedServer
@@ -718,7 +730,8 @@ export const updateSupportedVersionsData = async (
         const supported = await isServerVersionSupported(
           serverWithFreshIdentity,
           cloudSupportedVersions,
-          freshCommitHash
+          freshCommitHash,
+          'cloud'
         );
         if (isStale()) return;
         dispatch({

--- a/src/servers/supportedVersions/main.ts
+++ b/src/servers/supportedVersions/main.ts
@@ -353,7 +353,8 @@ export const isServerVersionSupported = async (
     } catch {
       hostname = undefined;
     }
-    if (exceptions.domain && exceptions.domain !== hostname) {
+    // DNS names are case-insensitive; URL.hostname is already lowercased.
+    if (exceptions.domain && exceptions.domain.toLowerCase() !== hostname) {
       exceptionScopeMatches = false;
     }
     if (exceptions.uniqueId && exceptions.uniqueId !== server.uniqueID) {
@@ -502,6 +503,30 @@ const dispatchSupportedVersionsUpdated = (
   });
 };
 
+// When a supported-versions payload carries a uniqueId-scoped exceptions
+// block, the scope check requires server.uniqueID to equal
+// exceptions.uniqueId. The server-signed fast path returns before the general
+// getUniqueId call, and /api/info does not include uniqueId, so a missing or
+// stale persisted uniqueID would permanently disqualify the tenant's own
+// exceptions. Resolve it from the server before validating (and persist it
+// for future runs, including offline cache validation).
+const withExceptionScopeUniqueId = async (
+  serverView: Server,
+  supportedVersionsData: SupportedVersions | undefined,
+  versionForUniqueId: string
+): Promise<Server> => {
+  const exceptionsUniqueId = supportedVersionsData?.exceptions?.uniqueId;
+  if (!exceptionsUniqueId || serverView.uniqueID === exceptionsUniqueId) {
+    return serverView;
+  }
+  const freshUniqueId = await getUniqueId(serverView.url, versionForUniqueId)
+    .then(dispatchUniqueIdUpdated(serverView.url))
+    .catch(logRequestError('unique ID'));
+  return freshUniqueId
+    ? { ...serverView, uniqueID: freshUniqueId }
+    : serverView;
+};
+
 // Per-URL request generation counter. Each call to updateSupportedVersionsData
 // bumps the counter and captures its own generation. Awaited steps inside the
 // call check whether their generation is still current before dispatching, so
@@ -540,9 +565,8 @@ export const updateSupportedVersionsData = async (
   // Build a server view that reflects the freshly-fetched version and
   // uniqueId when available, so every downstream support check
   // (server/cloud/cache/builtin) is evaluated against the same authoritative
-  // identity. /api/info returns `uniqueId`, which is required for exception
-  // scope matching to honor server-source exceptions on first launch (when
-  // persisted server.uniqueID may be undefined).
+  // identity. Current servers do NOT include `uniqueId` in /api/info, so the
+  // fallback to persisted server.uniqueID is the common path.
   const serverWithFreshVersion: Server = serverInfoResult
     ? {
         ...server,
@@ -567,8 +591,14 @@ export const updateSupportedVersionsData = async (
         const serverSupportedVersions = decodeSupportedVersions(serverEncoded);
         if (isStale()) return;
         saveToCache(serverUrl, serverSupportedVersions);
-        const supported = await isServerVersionSupported(
+        const serverForValidation = await withExceptionScopeUniqueId(
           serverWithFreshVersion,
+          serverSupportedVersions,
+          serverInfoResult.version
+        );
+        if (isStale()) return;
+        const supported = await isServerVersionSupported(
+          serverForValidation,
           serverSupportedVersions,
           freshCommitHash
         );

--- a/src/servers/supportedVersions/main.ts
+++ b/src/servers/supportedVersions/main.ts
@@ -97,6 +97,37 @@ const parseTimestamp = (value?: string): number => {
   return Number.isNaN(time) ? 0 : time;
 };
 
+// Orders the cache and builtin fallback sources by `timestamp` — freshest
+// first — instead of always trusting the cache: a persisted cache entry can
+// predate the app's own bundled builtin data (e.g. right after an app
+// update ships a refreshed builtin list), in which case trusting the stale
+// cache indefinitely blocks servers the new builtin already recognizes as
+// supported. Both sources are included when both exist; the caller tries
+// each in order and only falls through to the second when the first fails
+// to support the server (see validateFallbackAndDispatch).
+const buildFallbackCandidates = (
+  cachedVersions: SupportedVersions | undefined,
+  builtinVersions: SupportedVersions | undefined
+): { versions: SupportedVersions; source: 'cloud' | 'builtin' }[] => {
+  if (!cachedVersions && !builtinVersions) return [];
+  if (!builtinVersions) return [{ versions: cachedVersions!, source: 'cloud' }];
+  if (!cachedVersions)
+    return [{ versions: builtinVersions, source: 'builtin' }];
+
+  const useBuiltinOverCache =
+    parseTimestamp(builtinVersions.timestamp) >
+    parseTimestamp(cachedVersions.timestamp);
+  const first: { versions: SupportedVersions; source: 'cloud' | 'builtin' } =
+    useBuiltinOverCache
+      ? { versions: builtinVersions, source: 'builtin' }
+      : { versions: cachedVersions, source: 'cloud' };
+  const second: { versions: SupportedVersions; source: 'cloud' | 'builtin' } =
+    useBuiltinOverCache
+      ? { versions: cachedVersions, source: 'cloud' }
+      : { versions: builtinVersions, source: 'builtin' };
+  return [first, second];
+};
+
 const loadFromCache = (serverUrl: string): SupportedVersions | undefined => {
   try {
     const cached = supportedVersionsStore.get(getCacheKey(serverUrl));
@@ -555,38 +586,65 @@ const withExceptionScopeUniqueId = async (
     : serverView;
 };
 
-// Validates the fallback (cache/builtin) payload and dispatches the verdict.
-// isServerVersionSupported can throw on a malformed cached/builtin payload
-// (e.g. `versions` not an array). Left unguarded, that throw would reject
-// updateSupportedVersionsData before WEBVIEW_SERVER_SUPPORTED_VERSIONS_ERROR
-// is dispatched, leaving supportedVersionsFetchState stuck at 'loading' —
-// which suppresses the UnsupportedServer block gate (fail-open). On failure,
-// only the error state is dispatched; the prior verdict is left untouched.
+// Validates the fallback (cache/builtin) candidates, in order, and dispatches
+// the verdict. isServerVersionSupported can throw on a malformed
+// cached/builtin payload (e.g. `versions` not an array). Left unguarded, that
+// throw would reject updateSupportedVersionsData before
+// WEBVIEW_SERVER_SUPPORTED_VERSIONS_ERROR is dispatched, leaving
+// supportedVersionsFetchState stuck at 'loading' — which suppresses the
+// UnsupportedServer block gate (fail-open). On failure, only the error state
+// is dispatched; the prior verdict is left untouched.
+//
+// Blocking on the fallback path is only correct when NO available source
+// supports the server: the builtin payload can rescue a server that a stale
+// cache wrongly blocks, but the cache is the only fallback source that can
+// carry this tenant's own exceptions (the builtin payload never does). So
+// candidates are tried in freshness order and the first one that supports
+// the server wins; only if every candidate fails to support it do we accept
+// the last-checked (freshest) verdict as the block reason.
 const validateFallbackAndDispatch = async (
   server: Server,
   serverUrl: string,
-  fallbackVersions: SupportedVersions,
-  fallbackSource: 'cloud' | 'builtin',
+  candidates: { versions: SupportedVersions; source: 'cloud' | 'builtin' }[],
   freshCommitHash: string | undefined,
   isStale: () => boolean
 ): Promise<void> => {
   try {
-    const fallbackSupported = await isServerVersionSupported(
+    // At most two candidates (cache + builtin) are ever passed. Check the
+    // freshness-preferred one first; only consult the second if the first
+    // fails to support the server, and prefer the second's verdict only
+    // when it succeeds where the first didn't.
+    let chosen = candidates[0];
+    let verdict = await isServerVersionSupported(
       server,
-      fallbackVersions,
+      chosen.versions,
       freshCommitHash,
-      fallbackSource
+      chosen.source
     );
+    const other = candidates[1];
+    if (!verdict.supported && other) {
+      const otherVerdict = await isServerVersionSupported(
+        server,
+        other.versions,
+        freshCommitHash,
+        other.source
+      );
+      if (otherVerdict.supported) {
+        chosen = other;
+        verdict = otherVerdict;
+      }
+    }
     if (isStale()) return;
+    saveToCache(serverUrl, chosen.versions);
     dispatch({
       type: WEBVIEW_SERVER_IS_SUPPORTED_VERSION,
       payload: {
         url: server.url,
-        isSupportedVersion: fallbackSupported.supported,
+        isSupportedVersion: verdict.supported,
       },
     });
-    dispatchSupportedVersionsUpdated(server.url, fallbackVersions, {
-      source: fallbackSource,
+    dispatchSupportedVersionsUpdated(server.url, chosen.versions, {
+      source: chosen.source,
     });
   } catch (error) {
     console.error('Error validating fallback supported versions:', error);
@@ -633,16 +691,16 @@ export const updateSupportedVersionsData = async (
     2000
   );
 
-  // Build a server view that reflects the freshly-fetched version and
-  // uniqueId when available, so every downstream support check
-  // (server/cloud/cache/builtin) is evaluated against the same authoritative
-  // identity. Current servers do NOT include `uniqueId` in /api/info, so the
-  // fallback to persisted server.uniqueID is the common path.
+  // Build a server view that reflects the freshly-fetched version, so every
+  // downstream support check (server/cloud/cache/builtin) is evaluated
+  // against the same authoritative identity. /api/info carries no workspace
+  // uniqueId, so the persisted server.uniqueID is used as-is here, and
+  // withExceptionScopeUniqueId resolves it on demand when it's missing.
   const serverWithFreshVersion: Server = serverInfoResult
     ? {
         ...server,
         version: serverInfoResult.version,
-        uniqueID: serverInfoResult.uniqueId ?? server.uniqueID,
+        uniqueID: server.uniqueID,
       }
     : server;
   const freshCommitHash = serverInfoResult?.commit?.hash;
@@ -759,34 +817,24 @@ export const updateSupportedVersionsData = async (
     }
   }
 
-  // Neither the server nor the cloud could be reached. Pick the freshest of
-  // the two remaining sources by `timestamp` instead of always trusting the
-  // cache: a persisted cache entry can predate the app's own bundled builtin
-  // data (e.g. right after an app update ships a refreshed builtin list), in
-  // which case trusting the stale cache indefinitely blocks servers the new
-  // builtin already recognizes as supported.
+  // Neither the server nor the cloud could be reached. Order the two
+  // remaining sources by `timestamp` instead of always trusting the cache
+  // (see buildFallbackCandidates): both are still tried (see
+  // validateFallbackAndDispatch) so the cache's tenant exceptions — which
+  // the builtin payload never carries — aren't lost to a fresher builtin
+  // that simply doesn't know about them.
   const cachedVersions = loadFromCache(serverUrl);
-  const useBuiltinOverCache =
-    !!builtinSupportedVersions &&
-    (!cachedVersions ||
-      parseTimestamp(builtinSupportedVersions.timestamp) >
-        parseTimestamp(cachedVersions.timestamp));
-  const fallbackVersions = useBuiltinOverCache
-    ? builtinSupportedVersions
-    : cachedVersions;
-  const fallbackSource: 'cloud' | 'builtin' = useBuiltinOverCache
-    ? 'builtin'
-    : 'cloud';
+  const fallbackCandidates = buildFallbackCandidates(
+    cachedVersions,
+    builtinSupportedVersions
+  );
 
-  if (fallbackVersions) {
-    if (isStale()) return;
-    saveToCache(serverUrl, fallbackVersions);
+  if (fallbackCandidates.length > 0) {
     if (isStale()) return;
     await validateFallbackAndDispatch(
       serverWithFreshIdentity,
       serverUrl,
-      fallbackVersions,
-      fallbackSource,
+      fallbackCandidates,
       freshCommitHash,
       isStale
     );

--- a/src/servers/supportedVersions/types.ts
+++ b/src/servers/supportedVersions/types.ts
@@ -54,8 +54,14 @@ export type SupportedVersions = {
 
 export type ServerInfo = {
   version: string;
-  uniqueId: string;
-  build: {
+  /**
+   * `build`, `marketplaceApiVersion`, and `commit` are only present when the
+   * caller is authenticated with the view-statistics permission. The
+   * desktop app always requests /api/info unauthenticated, so these fields
+   * never arrive on the wire in practice. The sha-exception path relies on
+   * the persisted `server.gitCommitHash` pushed by the web client instead.
+   */
+  build?: {
     date: string;
     nodeVersion: string;
     arch: string;
@@ -65,8 +71,8 @@ export type ServerInfo = {
     freeMemory: number;
     cpus: number;
   };
-  marketplaceApiVersion: string;
-  commit: {
+  marketplaceApiVersion?: string;
+  commit?: {
     hash: string;
     date: Date;
     author: string;
@@ -82,6 +88,9 @@ export type ServerInfo = {
     desktop: string;
     mobile: string;
   };
+  cloudWorkspaceId?: string;
+  workspaceUrl?: string;
+  hashedWorkspaceUrl?: string;
 };
 
 export type CloudInfo = {

--- a/src/ui/components/ServersView/ServerPane.tsx
+++ b/src/ui/components/ServersView/ServerPane.tsx
@@ -223,6 +223,7 @@ export const ServerPane = ({
         isSupported={isSupported}
         fetchState={supportedVersionsFetchState}
         instanceDomain={new URL(serverUrl).hostname}
+        serverUrl={serverUrl}
       />
       <ErrorView isFailed={isFailed} onReload={handleReload} />
     </Wrapper>

--- a/src/ui/components/ServersView/UnsupportedServer.spec.tsx
+++ b/src/ui/components/ServersView/UnsupportedServer.spec.tsx
@@ -1,0 +1,96 @@
+import { ipcRenderer } from 'electron';
+
+import { render, screen, userEvent } from '../../test-utils';
+import UnsupportedServer from './UnsupportedServer';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) =>
+      options ? `${key} ${JSON.stringify(options)}` : key,
+    i18n: { language: 'en', changeLanguage: jest.fn() },
+  }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}));
+
+jest.mock('electron', () => ({
+  ipcRenderer: {
+    invoke: jest.fn(),
+  },
+}));
+
+const invokeMock = ipcRenderer.invoke as jest.MockedFunction<
+  typeof ipcRenderer.invoke
+>;
+
+const SERVER_URL = 'https://chat.example.com/';
+
+describe('UnsupportedServer', () => {
+  beforeEach(() => {
+    invokeMock.mockClear();
+  });
+
+  it('renders the check again button when isSupported is false', () => {
+    render(
+      <UnsupportedServer
+        isSupported={false}
+        fetchState='error'
+        instanceDomain='chat.example.com'
+        serverUrl={SERVER_URL}
+      />
+    );
+
+    expect(
+      screen.getByText('unsupportedServer.checkAgain')
+    ).toBeInTheDocument();
+  });
+
+  it('invokes refresh-supported-versions with the server url on click', async () => {
+    const user = userEvent.setup();
+    render(
+      <UnsupportedServer
+        isSupported={false}
+        fetchState='error'
+        instanceDomain='chat.example.com'
+        serverUrl={SERVER_URL}
+      />
+    );
+
+    await user.click(screen.getByText('unsupportedServer.checkAgain'));
+
+    expect(invokeMock).toHaveBeenCalledWith(
+      'refresh-supported-versions',
+      SERVER_URL
+    );
+  });
+
+  it('does not render the blocking gate when isSupported is true', () => {
+    render(
+      <UnsupportedServer
+        isSupported
+        fetchState='success'
+        instanceDomain='chat.example.com'
+        serverUrl={SERVER_URL}
+      />
+    );
+
+    expect(
+      screen.queryByText('unsupportedServer.checkAgain')
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render the blocking gate while a fresh validation is loading', () => {
+    render(
+      <UnsupportedServer
+        isSupported={false}
+        fetchState='loading'
+        instanceDomain='chat.example.com'
+        serverUrl={SERVER_URL}
+      />
+    );
+
+    expect(
+      screen.queryByText('unsupportedServer.checkAgain')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/ui/components/ServersView/UnsupportedServer.tsx
+++ b/src/ui/components/ServersView/UnsupportedServer.tsx
@@ -16,12 +16,14 @@ type UnsupportedServerProps = {
   isSupported: boolean | undefined;
   fetchState?: 'idle' | 'loading' | 'success' | 'error';
   instanceDomain: string;
+  serverUrl: string;
 };
 
 const UnsupportedServer = ({
   isSupported,
   fetchState,
   instanceDomain,
+  serverUrl,
 }: UnsupportedServerProps) => {
   const { t } = useTranslation();
 
@@ -30,6 +32,10 @@ const UnsupportedServer = ({
       'server-view/open-url-on-browser',
       urls.docs.supportedVersions
     );
+  };
+
+  const handleCheckAgainButtonClick = (): void => {
+    ipcRenderer.invoke('refresh-supported-versions', serverUrl);
   };
 
   // Block whenever a definitive `false` verdict exists, except while a fresh
@@ -66,6 +72,9 @@ const UnsupportedServer = ({
             <StatesActions>
               <Button secondary onClick={handleMoreInfoButtonClick}>
                 {t('unsupportedServer.moreInformation')}
+              </Button>
+              <Button onClick={handleCheckAgainButtonClick}>
+                {t('unsupportedServer.checkAgain')}
               </Button>
             </StatesActions>
           </States>

--- a/src/ui/components/SupportedVersionDialog/index.spec.tsx
+++ b/src/ui/components/SupportedVersionDialog/index.spec.tsx
@@ -1,8 +1,12 @@
+import { act } from '@testing-library/react';
 import { ipcRenderer } from 'electron';
 
 import { SupportedVersionDialog } from '.';
 import * as urls from '../../../urls';
-import { SUPPORTED_VERSION_DIALOG_DISMISS } from '../../actions';
+import {
+  SIDE_BAR_SERVER_SELECTED,
+  SUPPORTED_VERSION_DIALOG_DISMISS,
+} from '../../actions';
 import { renderWithStore, screen, userEvent, waitFor } from '../../test-utils';
 
 jest.mock('react-i18next', () => ({
@@ -163,5 +167,38 @@ describe('SupportedVersionDialog', () => {
 
     await waitFor(() => expect(isServerVersionSupported).toHaveBeenCalled());
     expect(screen.queryByText('Workspace expiring')).not.toBeInTheDocument();
+  });
+
+  it('re-runs the version check when the selected currentView changes', async () => {
+    const OTHER_SERVER_URL = 'https://chat.other.com/';
+    const { store } = renderWithStore(<SupportedVersionDialog />, {
+      preloadedState: {
+        ...preloadedState,
+        servers: [
+          ...preloadedState.servers,
+          {
+            url: OTHER_SERVER_URL,
+            title: 'Other',
+            version: '6.0.0',
+            supportedVersions: { versions: [], messages: [] },
+          },
+        ],
+      },
+    });
+
+    await waitFor(() =>
+      expect(isServerVersionSupported).toHaveBeenCalledTimes(1)
+    );
+
+    act(() => {
+      store.dispatch({
+        type: SIDE_BAR_SERVER_SELECTED,
+        payload: OTHER_SERVER_URL,
+      });
+    });
+
+    await waitFor(() =>
+      expect(isServerVersionSupported).toHaveBeenCalledTimes(2)
+    );
   });
 });

--- a/src/ui/components/SupportedVersionDialog/index.tsx
+++ b/src/ui/components/SupportedVersionDialog/index.tsx
@@ -15,7 +15,7 @@ import { ipcRenderer } from 'electron';
 import moment from 'moment';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { getLanguage } from '../../../i18n/main';
@@ -25,9 +25,9 @@ import {
 } from '../../../servers/supportedVersions/main';
 import type { MessageTranslated } from '../../../servers/supportedVersions/types';
 import type { RootAction } from '../../../store/actions';
+import type { RootState } from '../../../store/rootReducer';
 import * as urls from '../../../urls';
 import { SUPPORTED_VERSION_DIALOG_DISMISS } from '../../actions';
-import { currentView } from '../../reducers/currentView';
 import ModalBackdrop from '../Modal/ModalBackdrop';
 import { useServers } from '../hooks/useServers';
 import { Wrapper } from './styles';
@@ -35,6 +35,7 @@ import { Wrapper } from './styles';
 export const SupportedVersionDialog = () => {
   const [isVisible, setIsVisible] = useState(false);
   const dispatch = useDispatch<Dispatch<RootAction>>();
+  const currentView = useSelector(({ currentView }: RootState) => currentView);
 
   const servers = useServers();
   const server = servers.find((server) => server.selected === true);
@@ -140,8 +141,7 @@ export const SupportedVersionDialog = () => {
 
   useEffect(() => {
     checkServerVersion();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [server?.supportedVersions, server?.lastPath, currentView]);
+  }, [checkServerVersion, currentView]);
 
   const handleMoreInfoButtonClick = (): void => {
     if (expirationMessage?.link && expirationMessage?.link !== '') {


### PR DESCRIPTION
Lands the 4.15.3 hotfix content on master:
- supported-versions hardening series (equivalent to #3404/#3407/#3406 — #3404 already on master)
- Wayland screen-picker startup fix (already on master via #3400)
- version bump to 4.15.3

Supersedes #3407 and #3406, which will be closed.
Jira: [CORE-2409](https://rocketchat.atlassian.net/browse/CORE-2409)

[CORE-2409]: https://rocketchat.atlassian.net/browse/CORE-2409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ