### PR TITLE
chore: bump version to 4.16.0-alpha.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "Rocket.Chat",
   "name": "rocketchat",
   "description": "Official OSX, Windows, and Linux Desktop Clients for Rocket.Chat",
-  "version": "4.15.3",
+  "version": "4.16.0-alpha.0",
   "author": "Rocket.Chat Support <support@rocket.chat>",
   "copyright": "© 2016-2026, Rocket.Chat",
   "homepage": "https://rocket.chat",


### PR DESCRIPTION
First alpha of the 4.16.0 line. Ships everything on master since 4.15.3:

## ✨ Improvements
- Workspace tabs as a display option — new default layout (#3394)
- Screen picker opens on originating popout window; concurrent capture requests queued (#3399)
- Cmd+, shortcut opens Preferences on macOS (#3340)

## 🐛 Fixes
- Sidebar tooltip crash in shortcut formatting (#3326)
- Supported-versions hardening: exception scoping, malformed enforcementStartDate, /api/info contract alignment (#3404, #3407, #3406 — also shipped in 4.15.3)
- Startup screen-capture enumeration no longer opens Wayland picker on launch (#3400 — also in 4.15.3)

## 🔒 Security
- Permission requests bound to known server origin (CORE-1121, #3395)
- Non-http(s) main-frame navigation blocked in server webview (CORE-1123, #3397)
- Session data cleared on logout (CORE-1130, #3398)
- Tightened CSP on local renderer windows (CORE-1126, #3316)

## 🔧 Internal
- React 18.3 → 19 (#3384), Fuselage 0.78 → 0.80 (#3383)
- Coverage specs (#3393), i18n update (#3392), silent-install docs (#3178), post-mortems (#3402), dev automations (#3192)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package to version **4.16.0-alpha.0**.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->