### PR TITLE
chore: apply least privilege pattern to github actions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,5 +1,4 @@
-permissions:
-  contents: read
+permissions: {}
 name: Build release
 
 on:
@@ -15,6 +14,8 @@ concurrency:
 
 jobs:
   build:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/powershell-lint.yml
+++ b/.github/workflows/powershell-lint.yml
@@ -1,7 +1,6 @@
 name: PowerShell Lint
 
-permissions:
-  contents: read
+permissions: {}
 
 on:
   pull_request:
@@ -22,6 +21,8 @@ on:
 
 jobs:
   lint:
+    permissions:
+      contents: read
     runs-on: windows-latest
     
     steps:

--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -1,8 +1,6 @@
 name: Build pull request artifacts
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 
 on:
   pull_request:
@@ -16,6 +14,9 @@ concurrency:
 
 jobs:
   build:
+    permissions:
+      contents: read
+      pull-requests: write
     if: contains(github.event.pull_request.labels.*.name, 'build-artifacts')
     strategy:
       fail-fast: false

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -10,10 +10,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: {}
 jobs:
   check:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
# Proposed changes (including videos or screenshots)
This PR applies the principle of least privilege to `GITHUB_TOKEN` permissions across all GitHub Actions workflows by setting `permissions: {}` globally and explicitly re-granting only the minimum permissions required per job, as part of a supply chain security hardening effort.

Workflows relied on GitHub’s default token scopes, which may grant more access than most jobs actually need. Scoping permissions at the job level reduces the attack surface in the event that a GitHub Action, third-party dependency, or CI component is compromised, helping mitigate the impact of potential supply chain attacks and limiting unnecessary repository access.

This change only affects the permissions granted to the workflow `GITHUB_TOKEN`. Operations authenticated using explicitly configured Personal Access Tokens (PATs) continue to have the scopes assigned to those tokens and are not affected by workflow permissions settings.

# Issue(s)
[SB-975](https://rocketchat.atlassian.net/browse/SB-975)


[SB-975]: https://rocketchat.atlassian.net/browse/SB-975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Tightened automated workflow permissions by default.
  * Limited repository access to only the specific jobs that require it.
  * Preserved necessary build, validation, linting, and pull request capabilities while reducing broader access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->