### PR TITLE
fix: externalize dependency subpath imports in rollup bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "patch-package": "patch-package",
     "start": "run-s build:watch",
     "clean": "rimraf app dist",
-    "build": "rollup -c",
+    "build": "rollup -c && node scripts/check-bundle-externals.mjs",
     "build:watch": "rollup -c -w",
     "build-mac": "yarn build && yarn electron-builder --publish never --mac --universal",
     "build-mas": "yarn build && yarn electron-builder --publish never --mac mas --universal",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -198,13 +198,25 @@ const downloadSupportedVersions = () => {
 
 const extensions = ['.js', '.ts', '.tsx'];
 
+// Match dependency subpaths (e.g. `react-dom/client`) as external too. An
+// exact-name list leaves subpath entrypoints to be bundled at build-time
+// NODE_ENV while the base package resolves from the asar at runtime, which
+// can mix development and production React internals and crash the renderer.
+const makeExternal = (bundledModules = []) => {
+  const externalModules = [
+    ...builtinModules,
+    ...Object.keys(appManifest.dependencies),
+    ...Object.keys(appManifest.devDependencies),
+  ].filter((moduleName) => !bundledModules.includes(moduleName));
+  return (id) =>
+    externalModules.some(
+      (moduleName) => id === moduleName || id.startsWith(`${moduleName}/`)
+    );
+};
+
 export default [
   {
-    external: [
-      ...builtinModules,
-      ...Object.keys(appManifest.dependencies),
-      ...Object.keys(appManifest.devDependencies),
-    ].filter((moduleName) => moduleName !== '@bugsnag/js'),
+    external: makeExternal(['@bugsnag/js']),
     input: 'src/videoCallWindow/video-call-window.ts',
     preserveEntrySignatures: 'strict',
     plugins: [
@@ -234,11 +246,7 @@ export default [
     ],
   },
   {
-    external: [
-      ...builtinModules,
-      ...Object.keys(appManifest.dependencies),
-      ...Object.keys(appManifest.devDependencies),
-    ].filter((moduleName) => moduleName !== '@bugsnag/js'),
+    external: makeExternal(['@bugsnag/js']),
     input: 'src/logViewerWindow/log-viewer-window.tsx',
     preserveEntrySignatures: 'strict',
     plugins: [
@@ -268,11 +276,7 @@ export default [
     ],
   },
   {
-    external: [
-      ...builtinModules,
-      ...Object.keys(appManifest.dependencies),
-      ...Object.keys(appManifest.devDependencies),
-    ].filter((moduleName) => moduleName !== '@bugsnag/js'),
+    external: makeExternal(['@bugsnag/js']),
     input: 'src/screenSharing/screen-picker-window.tsx',
     preserveEntrySignatures: 'strict',
     plugins: [
@@ -302,11 +306,7 @@ export default [
     ],
   },
   {
-    external: [
-      ...builtinModules,
-      ...Object.keys(appManifest.dependencies),
-      ...Object.keys(appManifest.devDependencies),
-    ].filter((moduleName) => moduleName !== '@bugsnag/js'),
+    external: makeExternal(['@bugsnag/js']),
     input: 'src/videoCallWindow/preload/index.ts',
     preserveEntrySignatures: 'strict',
     plugins: [
@@ -337,20 +337,13 @@ export default [
     ],
   },
   {
-    external: [
-      ...builtinModules,
-      ...Object.keys(appManifest.dependencies),
-      ...Object.keys(appManifest.devDependencies),
-    ].filter(
-      (moduleName) =>
-        ![
-          '@bugsnag/js',
-          'marked',
-          'marked-highlight',
-          'highlight.js',
-          'dompurify',
-        ].includes(moduleName)
-    ),
+    external: makeExternal([
+      '@bugsnag/js',
+      'marked',
+      'marked-highlight',
+      'highlight.js',
+      'dompurify',
+    ]),
     input: 'src/rootWindow.ts',
     preserveEntrySignatures: 'strict',
     plugins: [
@@ -381,11 +374,7 @@ export default [
     },
   },
   {
-    external: [
-      ...builtinModules,
-      ...Object.keys(appManifest.dependencies),
-      ...Object.keys(appManifest.devDependencies),
-    ].filter((moduleName) => moduleName !== '@bugsnag/js'),
+    external: makeExternal(['@bugsnag/js']),
     input: 'src/preload.ts',
     plugins: [
       json(),
@@ -444,11 +433,7 @@ export default [
     ],
   },
   {
-    external: [
-      ...builtinModules,
-      ...Object.keys(appManifest.dependencies),
-      ...Object.keys(appManifest.devDependencies),
-    ],
+    external: makeExternal(),
     input: 'src/main.ts',
     plugins: [
       copy({

--- a/scripts/check-bundle-externals.mjs
+++ b/scripts/check-bundle-externals.mjs
@@ -136,7 +136,11 @@ const assertContains = (entry, needle) => {
 assertContains('rootWindow.js', "require('react')");
 assertContains('rootWindow.js', "require('react-dom/client')");
 assertContains('screen-picker-window.js', "require('react')");
+assertContains('screen-picker-window.js', "require('react-dom/client')");
 assertContains('log-viewer-window.js', "require('react')");
+assertContains('log-viewer-window.js', "require('react-dom/client')");
+assertContains('video-call-window.js', "require('react')");
+assertContains('video-call-window.js', "require('react-dom/client')");
 
 console.log(
   `bundle externals check passed (${allReachable.size} chunks scanned)`

--- a/scripts/check-bundle-externals.mjs
+++ b/scripts/check-bundle-externals.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * Regression guard for the 4.16.0-alpha.0 mixed-React-internals bug.
+ *
+ * rollup externals used to match module ids by exact name, so
+ * `react-dom/client` (React 19's subpath entrypoint) did not match the
+ * `react-dom` external and got bundled as production ReactDOM, while
+ * `react` stayed external and resolved to development React from the
+ * asar at runtime. Mixing dev/prod React internals crashes at startup.
+ *
+ * This script walks each entry bundle's reachable local-chunk graph and
+ * fails the build if any chunk contains bundled React internals, and
+ * fails if the expected `require('react')` / `require('react-dom/client')`
+ * external calls are missing (which would mean this check itself has
+ * gone stale and needs a conscious update).
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const appDir = join(rootDir, 'app');
+
+// injected.js is deliberately excluded: it's a self-contained IIFE with no
+// externals, so dev/prod React mixing is impossible there.
+const ENTRIES = [
+  'main.js',
+  'rootWindow.js',
+  'preload.js',
+  'video-call-window.js',
+  'log-viewer-window.js',
+  'screen-picker-window.js',
+  'preload/preload.js',
+];
+
+const REACT_INTERNAL_MARKERS = [
+  '__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE',
+  '__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED',
+];
+
+const LOCAL_CHUNK_PATTERN =
+  /require\(['"](\.\/[^'"]+\.js)['"]\)|from ['"](\.\/[^'"]+\.js)['"]/g;
+
+const fail = (message) => {
+  console.error(message);
+  process.exit(1);
+};
+
+for (const entry of ENTRIES) {
+  const entryPath = join(appDir, entry);
+  if (!existsSync(entryPath)) {
+    fail(
+      `bundle externals check: expected entry bundle not found: app/${entry}\n` +
+        'An entry may have been renamed or removed. Update ENTRIES in ' +
+        'scripts/check-bundle-externals.mjs to match the current rollup ' +
+        'output filenames.'
+    );
+  }
+}
+
+const collectReachableChunks = (entryPath) => {
+  const reachable = new Map();
+  const queue = [entryPath];
+
+  while (queue.length > 0) {
+    const filePath = queue.pop();
+    if (reachable.has(filePath)) continue;
+
+    const content = readFileSync(filePath, 'utf8');
+    reachable.set(filePath, content);
+
+    const dir = dirname(filePath);
+    for (const match of content.matchAll(LOCAL_CHUNK_PATTERN)) {
+      const relativePath = match[1] ?? match[2];
+      const resolvedPath = resolve(dir, relativePath);
+      if (!reachable.has(resolvedPath) && existsSync(resolvedPath)) {
+        queue.push(resolvedPath);
+      }
+    }
+  }
+
+  return reachable;
+};
+
+const allReachable = new Map();
+const entryReachable = new Map();
+
+for (const entry of ENTRIES) {
+  const entryPath = join(appDir, entry);
+  const reachable = collectReachableChunks(entryPath);
+  entryReachable.set(entry, reachable);
+  for (const [filePath, content] of reachable) {
+    allReachable.set(filePath, content);
+  }
+}
+
+for (const [filePath, content] of allReachable) {
+  for (const marker of REACT_INTERNAL_MARKERS) {
+    if (content.includes(marker)) {
+      fail(
+        `bundle externals check FAILED\n` +
+          `File: ${filePath}\n` +
+          `Marker: ${marker}\n` +
+          'React/ReactDOM internals were found bundled into this chunk ' +
+          'instead of being externalized. This happens when a rollup ' +
+          '`external` matcher fails to match a module id (e.g. exact-name ' +
+          'matching missing a subpath entrypoint like `react-dom/client`), ' +
+          'causing that module to be bundled as production code while a ' +
+          'related module (e.g. `react`) stays external and resolves to a ' +
+          'different (dev) copy at runtime, mixing incompatible React ' +
+          'internals and crashing at startup. Check the `makeExternal` ' +
+          'matcher in rollup.config.mjs.'
+      );
+    }
+  }
+}
+
+const assertContains = (entry, needle) => {
+  const reachable = entryReachable.get(entry);
+  const found = [...reachable.values()].some((content) =>
+    content.includes(needle)
+  );
+  if (!found) {
+    fail(
+      `bundle externals check FAILED\n` +
+        `Entry: app/${entry}\n` +
+        `Expected to find: ${needle}\n` +
+        'The external-require pattern for this entry has changed. This ' +
+        'script needs a conscious update to match the new pattern before ' +
+        'the build can be trusted.'
+    );
+  }
+};
+
+assertContains('rootWindow.js', "require('react')");
+assertContains('rootWindow.js', "require('react-dom/client')");
+assertContains('screen-picker-window.js', "require('react')");
+assertContains('log-viewer-window.js', "require('react')");
+
+console.log(
+  `bundle externals check passed (${allReachable.size} chunks scanned)`
+);


### PR DESCRIPTION
## What

4.16.0-alpha.0 on macOS rendered a gray window on launch. The root window crashed before first paint with:

```
TypeError: dispatcher.getOwner is not a function
    at getOwner (.../app.asar/node_modules/react/cjs/react.development.js:163:54)
```

## Root cause

The rollup `external` lists matched dependency names exactly. React 18's `react-dom/client.js` was a thin shim that required `react-dom` (external, resolved from the asar at runtime), so everything stayed consistent. React 19 (#3384) changed `react-dom/client.js` to require `./cjs/react-dom-client.production.js` directly — the subpath `react-dom/client` no longer matched the exact-name external list, so the whole ReactDOM reconciler (and `react/jsx-runtime`) was bundled with the CI build's `NODE_ENV=production`. Meanwhile `require('react')` stayed external and resolved from the asar at runtime, where `NODE_ENV` is undefined, loading the development build.

Development React 19's `createElement` calls `dispatcher.getOwner()` on the shared internals dispatcher; the production ReactDOM dispatcher doesn't provide it. Mixed dev/prod React internals crashed every render. The mismatch was production-only: dev builds bundle the development ReactDOM, which matches the development React, so `yarn start` never reproduced it.

## Changes

- **rollup.config.mjs** — `makeExternal()` helper matches dependency subpaths (`id === name || id.startsWith(name + '/')`) as external. Now `react-dom/client`, `react/jsx-runtime`, `semver/functions/gte`, and `electron-log/renderer` resolve from the asar at runtime like their base packages. Per-bundle intentionally-bundled modules (`@bugsnag/js`, `marked`, `marked-highlight`, `highlight.js`, `dompurify`) are preserved.
- **scripts/check-bundle-externals.mjs** — post-build regression guard. Walks the chunk graph from each entry bundle (immune to stale hashed chunks in `app/`), fails the build if any reachable chunk contains bundled React internals markers (React 19 `__CLIENT_INTERNALS…` / React 18 `__SECRET_INTERNALS…`), and asserts `require('react')` / `require('react-dom/client')` remain external requires in the React window bundles. `injected.js` is exempt: it is a self-contained IIFE with no externals, so dev/prod mixing cannot occur there.
- **package.json** — `yarn build` runs the guard after rollup, so every platform build and CI release build is gated. `yarn start` / watch mode unchanged.

## Verification

- `NODE_ENV=production yarn build`: rootWindow bundle contains no ReactDOM internals; `react-dom/client` and `react/jsx-runtime` appear as external requires. Guard passes (29 chunks scanned).
- Runtime smoke test of the production build (`env -u NODE_ENV npx electron .`, same module resolution as the packaged app): boots and renders with no `getOwner` error and no uncaught React errors.
- Guard mutation-tested: injecting the React internals marker into a chunk fails the build; removing the `require('react-dom/client')` literal from all four reachable chunks that contain it fails the positive assertion; restoring returns it to pass.
- ESLint and Prettier clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated build validation to ensure React and related dependencies stay external and aren’t accidentally bundled into application output.
  * The checks verify expected bundle references and scan built chunks to catch unintended inclusion early.

* **Chores**
  * Updated the build process to run the new bundle validation automatically after the bundling step.
  * Improved bundling configuration to treat external vs bundled packages more consistently across targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->