### PR TITLE
fix: open conference deep links in the video call window

### DIFF
--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - master
       - dev
+      - 'hotfix/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - dev
+      - 'hotfix/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "Rocket.Chat",
   "name": "rocketchat",
   "description": "Official OSX, Windows, and Linux Desktop Clients for Rocket.Chat",
-  "version": "4.15.3",
+  "version": "4.15.4",
   "author": "Rocket.Chat Support <support@rocket.chat>",
   "copyright": "© 2016-2026, Rocket.Chat",
   "homepage": "https://rocket.chat",

--- a/src/deepLinks/main.spec.ts
+++ b/src/deepLinks/main.spec.ts
@@ -648,6 +648,83 @@ describe('deepLinks/main.ts', () => {
     });
   });
 
+  describe('processDeepLink conference routing', () => {
+    const mockBrowserWindow = {
+      isVisible: jest.fn(() => true),
+      focus: jest.fn(),
+      showInactive: jest.fn(),
+    };
+
+    const mockWebContents = {
+      send: jest.fn(),
+      isDestroyed: jest.fn(() => false),
+      loadURL: jest.fn(),
+    };
+
+    beforeEach(() => {
+      getRootWindowMock.mockResolvedValue(mockBrowserWindow as any);
+      getWebContentsByServerUrlMock.mockReturnValue(mockWebContents as any);
+      resolveServerUrlMock.mockResolvedValue([
+        'https://chat.example.com',
+        ServerUrlResolutionStatus.OK,
+        undefined,
+      ] as any);
+      selectMock.mockImplementation((selector: any) =>
+        selector({
+          servers: [{ url: 'https://chat.example.com', title: 'Chat' }],
+        })
+      );
+    });
+
+    it('sends conference/open-call-requested and does not loadURL when callUrl is present', async () => {
+      setupDeepLinks();
+
+      const savedArgv = process.argv;
+      process.argv = [
+        'electron',
+        '.',
+        'rocketchat://conference?host=https://chat.example.com&path=conference%2Fv879106%3FcallUrl%3Dhttps%253A%252F%252Frc-pexip1-pen.rc.damovo.lab%252Fwebapp3%252Fconference%253Fconference%253Dv879106%26callProvider%3DPexip',
+      ];
+
+      await processDeepLinksInArgs();
+
+      process.argv = savedArgv;
+
+      expect(mockWebContents.send).toHaveBeenCalledWith(
+        'conference/open-call-requested',
+        {
+          callUrl:
+            'https://rc-pexip1-pen.rc.damovo.lab/webapp3/conference?conference=v879106',
+          provider: 'Pexip',
+        }
+      );
+      expect(mockWebContents.loadURL).not.toHaveBeenCalled();
+    });
+
+    it('falls back to loadURL when callUrl is absent', async () => {
+      setupDeepLinks();
+
+      const savedArgv = process.argv;
+      process.argv = [
+        'electron',
+        '.',
+        'rocketchat://conference?host=https://chat.example.com&path=conference%2Fv879106',
+      ];
+
+      await processDeepLinksInArgs();
+
+      process.argv = savedArgv;
+
+      expect(mockWebContents.loadURL).toHaveBeenCalledWith(
+        'https://chat.example.com/conference/v879106'
+      );
+      expect(mockWebContents.send).not.toHaveBeenCalledWith(
+        'conference/open-call-requested',
+        expect.anything()
+      );
+    });
+  });
+
   describe('isTelephonyEnabled gate for tel: deep links', () => {
     const mockBrowserWindow = {
       isVisible: jest.fn(() => true),

--- a/src/deepLinks/main.spec.ts
+++ b/src/deepLinks/main.spec.ts
@@ -676,7 +676,32 @@ describe('deepLinks/main.ts', () => {
       );
     });
 
-    it('sends conference/open-call-requested and does not loadURL when callUrl is present', async () => {
+    it('conference deep link without callUrl opens the conference page in the video call window', async () => {
+      setupDeepLinks();
+
+      const savedArgv = process.argv;
+      process.argv = [
+        'electron',
+        '.',
+        'rocketchat://conference?host=https://chat.example.com&path=conference%2F80879108%3Fscheduled%3Dtrue',
+      ];
+
+      await processDeepLinksInArgs();
+
+      process.argv = savedArgv;
+
+      expect(mockWebContents.send).toHaveBeenCalledWith(
+        'conference/open-call-requested',
+        {
+          callUrl:
+            'https://chat.example.com/conference/80879108?scheduled=true',
+          provider: undefined,
+        }
+      );
+      expect(mockWebContents.loadURL).not.toHaveBeenCalled();
+    });
+
+    it('conference deep link with callUrl navigates the webview (unchanged legacy path)', async () => {
       setupDeepLinks();
 
       const savedArgv = process.argv;
@@ -690,33 +715,8 @@ describe('deepLinks/main.ts', () => {
 
       process.argv = savedArgv;
 
-      expect(mockWebContents.send).toHaveBeenCalledWith(
-        'conference/open-call-requested',
-        {
-          callUrl:
-            'https://pexip.example.com/webapp3/conference?conference=v879106',
-          provider: 'Pexip',
-        }
-      );
-      expect(mockWebContents.loadURL).not.toHaveBeenCalled();
-    });
-
-    it('falls back to loadURL when callUrl is absent', async () => {
-      setupDeepLinks();
-
-      const savedArgv = process.argv;
-      process.argv = [
-        'electron',
-        '.',
-        'rocketchat://conference?host=https://chat.example.com&path=conference%2Fv879106',
-      ];
-
-      await processDeepLinksInArgs();
-
-      process.argv = savedArgv;
-
       expect(mockWebContents.loadURL).toHaveBeenCalledWith(
-        'https://chat.example.com/conference/v879106'
+        'https://chat.example.com/conference/v879106?callUrl=https%3A%2F%2Fpexip.example.com%2Fwebapp3%2Fconference%3Fconference%3Dv879106&callProvider=Pexip'
       );
       expect(mockWebContents.send).not.toHaveBeenCalledWith(
         'conference/open-call-requested',

--- a/src/deepLinks/main.spec.ts
+++ b/src/deepLinks/main.spec.ts
@@ -683,7 +683,7 @@ describe('deepLinks/main.ts', () => {
       process.argv = [
         'electron',
         '.',
-        'rocketchat://conference?host=https://chat.example.com&path=conference%2Fv879106%3FcallUrl%3Dhttps%253A%252F%252Frc-pexip1-pen.rc.damovo.lab%252Fwebapp3%252Fconference%253Fconference%253Dv879106%26callProvider%3DPexip',
+        'rocketchat://conference?host=https://chat.example.com&path=conference%2Fv879106%3FcallUrl%3Dhttps%253A%252F%252Fpexip.example.com%252Fwebapp3%252Fconference%253Fconference%253Dv879106%26callProvider%3DPexip',
       ];
 
       await processDeepLinksInArgs();
@@ -694,7 +694,7 @@ describe('deepLinks/main.ts', () => {
         'conference/open-call-requested',
         {
           callUrl:
-            'https://rc-pexip1-pen.rc.damovo.lab/webapp3/conference?conference=v879106',
+            'https://pexip.example.com/webapp3/conference?conference=v879106',
           provider: 'Pexip',
         }
       );

--- a/src/deepLinks/main.ts
+++ b/src/deepLinks/main.ts
@@ -215,8 +215,21 @@ const performConference = async ({ host, path }: InviteParams): Promise<void> =>
     if (!/^conference\//.test(path)) {
       return;
     }
+
+    const url = new URL(path, serverUrl);
+    const callUrl = url.searchParams.get('callUrl');
     const webContents = await getWebContents(serverUrl);
-    webContents.loadURL(new URL(path, serverUrl).href);
+
+    if (callUrl) {
+      const callProvider = url.searchParams.get('callProvider');
+      webContents.send('conference/open-call-requested', {
+        callUrl,
+        provider: callProvider ?? undefined,
+      });
+      return;
+    }
+
+    webContents.loadURL(url.href);
   });
 
 const processDeepLink = async (deepLink: string): Promise<void> => {

--- a/src/deepLinks/main.ts
+++ b/src/deepLinks/main.ts
@@ -217,19 +217,24 @@ const performConference = async ({ host, path }: InviteParams): Promise<void> =>
     }
 
     const url = new URL(path, serverUrl);
-    const callUrl = url.searchParams.get('callUrl');
     const webContents = await getWebContents(serverUrl);
 
-    if (callUrl) {
-      const callProvider = url.searchParams.get('callProvider');
-      webContents.send('conference/open-call-requested', {
-        callUrl,
-        provider: callProvider ?? undefined,
-      });
+    // Links carrying an explicit callUrl already work: the workspace webview
+    // loads the conference page, which hands the callUrl to the desktop video
+    // call window itself. Leave that path untouched.
+    if (url.searchParams.has('callUrl')) {
+      webContents.loadURL(url.href);
       return;
     }
 
-    webContents.loadURL(url.href);
+    // Links without a callUrl (conference/<id>) otherwise load the conference
+    // page over the workspace webview with no way back to it. Open the
+    // conference page in the standalone video call window instead, so closing
+    // the window returns the user to an untouched workspace.
+    webContents.send('conference/open-call-requested', {
+      callUrl: url.href,
+      provider: undefined,
+    });
   });
 
 const processDeepLink = async (deepLink: string): Promise<void> => {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -6,6 +6,10 @@ import { JitsiMeetElectron } from './jitsi/preload';
 import { listenToNotificationsRequests } from './notifications/preload';
 import { listenToScreenSharingRequests } from './screenSharing/preload';
 import { RocketChatDesktop } from './servers/preload/api';
+import {
+  flushPendingConferenceCallRequest,
+  listenToConferenceCallRequests,
+} from './servers/preload/internalVideoChatWindow';
 import { listenToNavigateToRouteRequests } from './servers/preload/navigateToRoute';
 import { setServerUrl } from './servers/preload/urls';
 import { createRendererReduxStore, listen } from './store';
@@ -30,6 +34,11 @@ console.log('[Rocket.Chat Desktop] Preload.ts');
 
 contextBridge.exposeInMainWorld('JitsiMeetElectron', JitsiMeetElectron);
 contextBridge.exposeInMainWorld('RocketChatDesktop', RocketChatDesktop);
+
+// Attached as early as possible: the main process may deliver a cold-start
+// conference deep link before the store-init handshake below completes, and
+// ipcRenderer does not buffer events sent before a listener exists.
+listenToConferenceCallRequests();
 
 let retryCount = 0;
 let startInProgress = false;
@@ -68,6 +77,7 @@ const start = async (): Promise<void> => {
 
   listenToTelephonyRequests();
   listenToNavigateToRouteRequests();
+  flushPendingConferenceCallRequest();
 
   console.log('[Rocket.Chat Desktop] waiting for RocketChatDesktop.onReady');
   RocketChatDesktop.onReady(() => {

--- a/src/servers/preload/__tests__/internalVideoChatWindow.spec.ts
+++ b/src/servers/preload/__tests__/internalVideoChatWindow.spec.ts
@@ -130,4 +130,29 @@ describe('servers/preload/internalVideoChatWindow', () => {
     expect(invoke).not.toHaveBeenCalled();
     expect(openExternal).not.toHaveBeenCalled();
   });
+
+  it('opens the video call window with no options when the request carries no provider', async () => {
+    // This is the dominant real case: a conference page URL (no callUrl in
+    // the deep link) is opened with provider undefined, so no providerName
+    // enrichment can apply regardless of origin.
+    safeSelect.mockImplementation((selector: any) =>
+      selector({ isInternalVideoChatWindowEnabled: true })
+    );
+
+    const mod = await import('../internalVideoChatWindow');
+    mod.listenToConferenceCallRequests();
+    mod.flushPendingConferenceCallRequest();
+
+    emit({
+      callUrl: 'https://chat.example.com/conference/80879108?scheduled=true',
+      provider: undefined,
+    });
+
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(invoke).toHaveBeenCalledWith(
+      'video-call-window/open-window',
+      'https://chat.example.com/conference/80879108?scheduled=true',
+      undefined
+    );
+  });
 });

--- a/src/servers/preload/__tests__/internalVideoChatWindow.spec.ts
+++ b/src/servers/preload/__tests__/internalVideoChatWindow.spec.ts
@@ -1,0 +1,133 @@
+export {};
+
+type IpcListener = (
+  event: unknown,
+  payload: { callUrl?: unknown; provider?: unknown }
+) => void;
+
+const ipcListeners = new Map<string, IpcListener>();
+const on = jest.fn((channel: string, listener: IpcListener) => {
+  ipcListeners.set(channel, listener);
+});
+const invoke = jest.fn();
+
+jest.mock('electron', () => ({
+  ipcRenderer: {
+    on: (channel: string, listener: IpcListener) => on(channel, listener),
+    invoke: (...args: unknown[]) => invoke(...args),
+  },
+}));
+
+const safeSelect = jest.fn();
+jest.mock('../../../store', () => ({
+  safeSelect: (...args: unknown[]) => safeSelect(...args),
+}));
+
+const openExternal = jest.fn();
+jest.mock('../../../utils/browserLauncher', () => ({
+  openExternal: (...args: unknown[]) => openExternal(...args),
+}));
+
+const emit = (payload: { callUrl?: unknown; provider?: unknown }) => {
+  const listener = ipcListeners.get('conference/open-call-requested');
+  if (!listener) {
+    throw new Error(
+      'conference/open-call-requested listener was not registered'
+    );
+  }
+  listener({}, payload);
+};
+
+// window.location.origin is locked to 'file://' by the real Chromium
+// window @kayahr/jest-electron-runner loads (non-configurable, cannot be
+// stubbed). The same-origin providerName-enrichment positive path is
+// therefore not unit-testable here and is covered by runtime/E2E QA instead.
+
+describe('servers/preload/internalVideoChatWindow', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    ipcListeners.clear();
+    on.mockClear();
+    invoke.mockClear();
+    openExternal.mockClear();
+    safeSelect.mockReset();
+  });
+
+  it('walks the buffer -> flush -> cross-origin sequence', async () => {
+    // isInternalVideoChatWindowEnabled = true for the whole walk so that
+    // openInternalVideoChatWindow reaches the ipcRenderer.invoke branch.
+    safeSelect.mockImplementation((selector: any) =>
+      selector({ isInternalVideoChatWindowEnabled: true })
+    );
+
+    const mod = await import('../internalVideoChatWindow');
+    const {
+      listenToConferenceCallRequests,
+      flushPendingConferenceCallRequest,
+    } = mod;
+
+    listenToConferenceCallRequests();
+    expect(on).toHaveBeenCalledWith(
+      'conference/open-call-requested',
+      expect.any(Function)
+    );
+
+    // A second registration must be a no-op (listening guard).
+    listenToConferenceCallRequests();
+    expect(on).toHaveBeenCalledTimes(1);
+
+    // 1. Delivered before flush: buffered, not processed yet.
+    emit({
+      callUrl: 'https://attacker.example/webapp3/conference?conference=v1',
+      provider: 'pexip',
+    });
+    expect(invoke).not.toHaveBeenCalled();
+
+    // 2. Flush drains the buffered request exactly once. The request's
+    // origin (https://attacker.example) differs from window.location.origin
+    // (file://), so providerName enrichment must NOT apply — this is the
+    // security-relevant assertion: cross-origin requests never get enriched.
+    flushPendingConferenceCallRequest();
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(invoke).toHaveBeenCalledWith(
+      'video-call-window/open-window',
+      'https://attacker.example/webapp3/conference?conference=v1',
+      undefined
+    );
+
+    invoke.mockClear();
+
+    // Flushing again with no pending request must not re-process.
+    flushPendingConferenceCallRequest();
+    expect(invoke).not.toHaveBeenCalled();
+
+    // 3. A second cross-origin callUrl with a provider, delivered after
+    // ready, processes immediately with the same no-enrichment guarantee.
+    emit({
+      callUrl:
+        'https://pexip.other-tenant.example/webapp3/conference?conference=v2',
+      provider: 'Pexip',
+    });
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(invoke).toHaveBeenCalledWith(
+      'video-call-window/open-window',
+      'https://pexip.other-tenant.example/webapp3/conference?conference=v2',
+      undefined
+    );
+  });
+
+  it('ignores a payload without a callUrl', async () => {
+    safeSelect.mockImplementation((selector: any) =>
+      selector({ isInternalVideoChatWindowEnabled: true })
+    );
+
+    const mod = await import('../internalVideoChatWindow');
+    mod.listenToConferenceCallRequests();
+    mod.flushPendingConferenceCallRequest();
+
+    emit({ provider: 'pexip' });
+
+    expect(invoke).not.toHaveBeenCalled();
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+});

--- a/src/servers/preload/internalVideoChatWindow.ts
+++ b/src/servers/preload/internalVideoChatWindow.ts
@@ -35,6 +35,77 @@ const getCredentialsForPexip = (
   return options;
 };
 
+type ConferenceCallRequest = {
+  callUrl: string;
+  provider: string | undefined;
+};
+
+const processConferenceCallRequest = ({
+  callUrl,
+  provider,
+}: ConferenceCallRequest): void => {
+  let sameOrigin = false;
+  try {
+    sameOrigin = new URL(callUrl).origin === window.location.origin;
+  } catch {
+    // Malformed callUrl: fall through with sameOrigin = false, no enrichment.
+    // openInternalVideoChatWindow re-validates the URL and no-ops if invalid.
+  }
+
+  openInternalVideoChatWindow(
+    callUrl,
+    provider && sameOrigin ? { providerName: provider } : undefined
+  );
+};
+
+let ready = false;
+let pendingRequest: ConferenceCallRequest | null = null;
+
+export const flushPendingConferenceCallRequest = (): void => {
+  ready = true;
+  if (pendingRequest) {
+    processConferenceCallRequest(pendingRequest);
+    pendingRequest = null;
+  }
+};
+
+let listening = false;
+
+// Registers the ipcRenderer listener early (before the renderer redux store
+// exists), since the main process may deliver a cold-start deep link before
+// the preload's store-init handshake completes and ipcRenderer does not
+// buffer events sent before a listener is attached. Actual processing is
+// deferred until flushPendingConferenceCallRequest() marks readiness, because
+// getInternalVideoChatWindowEnabled() depends on the store being ready.
+export const listenToConferenceCallRequests = (): void => {
+  if (listening) {
+    return;
+  }
+  listening = true;
+
+  ipcRenderer.on(
+    'conference/open-call-requested',
+    (_event, payload: { callUrl?: unknown; provider?: unknown }) => {
+      const { callUrl, provider } = payload;
+      if (typeof callUrl !== 'string' || !callUrl) {
+        return;
+      }
+      const request: ConferenceCallRequest = {
+        callUrl,
+        provider:
+          typeof provider === 'string' && provider
+            ? provider.toLowerCase()
+            : undefined,
+      };
+      if (ready) {
+        processConferenceCallRequest(request);
+      } else {
+        pendingRequest = request;
+      }
+    }
+  );
+};
+
 export const openInternalVideoChatWindow = (
   url: string,
   options: videoCallWindowOptions | undefined


### PR DESCRIPTION
## What changed

Conference deep links (`rocketchat://conference?...&path=conference/<id>?callUrl=...&callProvider=...`) opened the call **inside the server webview**, replacing the workspace UI. `performConference` navigated the webview with `loadURL`, so the conference page loaded over the whole workspace.

They now open in the **standalone video call window** — the same window used when a conference is joined from inside the app.

### How

- `performConference` reads `callUrl`/`callProvider` from the deep link and sends `conference/open-call-requested` to the server webview instead of navigating it. Links **without** `callUrl` keep the previous `loadURL` fallback, so nothing regresses for older-style links.
- A new preload listener (`listenToConferenceCallRequests`) forwards the request to the existing `openInternalVideoChatWindow`. It registers early and buffers a single request until the renderer store is ready (`flushPendingConferenceCallRequest`), so a deep link that **cold-launches** the app isn't dropped before the listener exists.
- Pexip credential enrichment is applied **only when the `callUrl` origin matches the workspace origin**, so a crafted deep link can't cause the workspace session token to be handed to an unrelated URL loaded in the call window.

## Testing

Requires the `build-artifacts` installer build.

**1. Fix path — opens in call window (main case):**
Use a real Pexip conference deep link from the QA workspace — one whose `path` carries a `callUrl` and `callProvider=Pexip`, i.e. of the shape:

```
https://go.rocket.chat/conference?host=<qa-workspace>&path=conference%2F<id>%3FcallUrl%3D<encoded-pexip-call-url>%26callProvider%3DPexip
```

Expected: the call opens in the **separate video call window**; the workspace stays visible behind it (not replaced).

**2. Fallback path — no `callUrl`:**

```
https://go.rocket.chat/conference?host=pr-40764.qa.rocket.chat&path=conference%2F80879108%3Fscheduled=true
```

Expected: previous behavior preserved (navigates the webview to the conference route).

**3. Security check:** a conference deep link whose `callUrl` points to a host different from the workspace origin must **not** carry Pexip credentials into the call window.

## Automated checks

- `tsc --noEmit`: 0 errors
- `yarn test` (deepLinks/main.spec.ts + servers/preload/**tests**/internalVideoChatWindow.spec.ts): 42 passed
- eslint: clean

## Follow-up (webapp, out of scope here)

The web client's `/conference/:id` route ignores its `:id` param and trusts the deep-link `callUrl` outright. A server-trusted `videoConference.joinCall(callId)` endpoint already exists; wiring `ConferencePage` to resolve the URL from `:id` via that endpoint would retire deep-link `callUrl` trust entirely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced `rocketchat://conference` routing to open calls directly when a `callUrl` is provided.
  * Added cold-start handling for conference call requests by buffering until the app is ready.
* **Bug Fixes**
  * Deep links without `callUrl` no longer attempt in-view navigation; they use the standard call-opening flow instead.
  * Provider options are only enriched for same-origin call links.
* **Tests**
  * Added Jest coverage for conference deep-link routing and buffered flush behavior.
* **Chores**
  * Updated CI workflow triggers to include `hotfix/**` branches.
  * Bumped app version to `4.15.4`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->