### PR TITLE
fix: workspace tabs QA feedback (CORE-2312)

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -123,9 +123,15 @@ const electronRunner = (() => {
 
       // Extra Chromium/Electron switches for dev tooling, e.g.
       // ELECTRON_EXTRA_LAUNCH_ARGS='--remote-debugging-port=9222' yarn start
-      const extraArgs = (process.env.ELECTRON_EXTRA_LAUNCH_ARGS ?? '')
-        .split(' ')
-        .filter(Boolean);
+      // Shell-style tokenization: quoted segments (including embedded quotes,
+      // e.g. --js-flags="--a --b") stay single args, quotes stripped.
+      const extraArgs = (
+        (process.env.ELECTRON_EXTRA_LAUNCH_ARGS ?? '').match(
+          /(?:[^\s"']+|"[^"]*"|'[^']*')+/g
+        ) ?? []
+      ).map((token) =>
+        token.replace(/"([^"]*)"|'([^']*)'/g, (_, dq, sq) => dq ?? sq)
+      );
       electronArgs.unshift(...extraArgs);
 
       // Linux-specific flags for development

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -121,6 +121,13 @@ const electronRunner = (() => {
 
       const electronArgs = [`--inspect=${DEV_INSPECT_PORT}`, '.'];
 
+      // Extra Chromium/Electron switches for dev tooling, e.g.
+      // ELECTRON_EXTRA_LAUNCH_ARGS='--remote-debugging-port=9222' yarn start
+      const extraArgs = (process.env.ELECTRON_EXTRA_LAUNCH_ARGS ?? '')
+        .split(' ')
+        .filter(Boolean);
+      electronArgs.unshift(...extraArgs);
+
       // Linux-specific flags for development
       if (process.platform === 'linux') {
         electronArgs.push('--no-sandbox');

--- a/src/i18n/en.i18n.json
+++ b/src/i18n/en.i18n.json
@@ -308,9 +308,9 @@
       "navigation": {
         "title": "Workspace switcher",
         "description": "Choose how to switch between workspaces",
-        "workspaceTabs": "Workspace Tabs",
-        "workspaceBar": "Workspace Bar",
-        "disabledHint": "Enable the menu bar first to use Workspace Tabs."
+        "workspaceTabs": "Workspace tabs",
+        "workspaceBar": "Workspace bar",
+        "disabledHint": "Enable the menu bar first to use Workspace tabs."
       },
       "trayIcon": {
         "title": "Tray icon",
@@ -449,8 +449,8 @@
     "showServerList": "Server list",
     "showTrayIcon": "Tray icon",
     "toggleDevTools": "Toggle &DevTools",
-    "workspaceTabs": "Workspace Tabs",
-    "workspaceBar": "Workspace Bar",
+    "workspaceTabs": "Workspace tabs",
+    "workspaceBar": "Workspace bar",
     "nextWorkspace": "Next Workspace",
     "previousWorkspace": "Previous Workspace",
     "openConfigFolder": "Open &Configuration Folder",

--- a/src/i18n/en.i18n.json
+++ b/src/i18n/en.i18n.json
@@ -503,6 +503,7 @@
     "settings": "App settings",
     "menuTitle": "Customize and control app",
     "item": {
+      "workspace": "Workspace",
       "reload": "Reload",
       "remove": "Remove",
       "openDevTools": "Open DevTools",

--- a/src/i18n/en.i18n.json
+++ b/src/i18n/en.i18n.json
@@ -503,15 +503,14 @@
     "settings": "App settings",
     "menuTitle": "Customize and control app",
     "item": {
-      "workspace": "Workspace",
       "reload": "Reload",
       "remove": "Remove",
       "openDevTools": "Open DevTools",
       "clearCache": "Clear Cache",
       "clearStorageData": "Clear Storage Data",
-      "copyCurrentUrl": "Copy current URL",
+      "copyCurrentUrl": "Copy URL",
       "reloadClearingCache": "Force reload",
-      "serverInfo": "Server Info",
+      "serverInfo": "Server info",
       "supportedVersionsInfo": "Supported Versions Info",
       "addWorkspace": "Add workspace"
     },

--- a/src/ui/actions.ts
+++ b/src/ui/actions.ts
@@ -41,8 +41,6 @@ export const VIDEO_CALL_WINDOW_STATE_CHANGED =
   'video-call-window/state-changed';
 export const SIDE_BAR_ADD_NEW_SERVER_CLICKED =
   'side-bar/add-new-server-clicked';
-export const SIDE_BAR_CONTEXT_MENU_TRIGGERED =
-  'side-bar/context-menu-triggered';
 export const SIDE_BAR_DOWNLOADS_BUTTON_CLICKED =
   'side-bar/downloads-button-clicked';
 export const SIDE_BAR_SETTINGS_BUTTON_CLICKED =
@@ -203,7 +201,6 @@ export type UiActionTypeToPayloadMap = {
   [ROOT_WINDOW_STATE_CHANGED]: WindowState;
   [VIDEO_CALL_WINDOW_STATE_CHANGED]: WindowState;
   [SIDE_BAR_ADD_NEW_SERVER_CLICKED]: void;
-  [SIDE_BAR_CONTEXT_MENU_TRIGGERED]: Server['url'];
   [SIDE_BAR_DOWNLOADS_BUTTON_CLICKED]: void;
   [SIDE_BAR_SETTINGS_BUTTON_CLICKED]: void;
   [SIDE_BAR_REMOVE_SERVER_CLICKED]: Server['url'];

--- a/src/ui/components/AddServerView/styles.tsx
+++ b/src/ui/components/AddServerView/styles.tsx
@@ -6,7 +6,7 @@ export const Wrapper = styled.section`
   top: 0;
   right: 0;
   bottom: 0;
-  background-color: #2f343d;
+  background-color: var(--rcx-color-surface-sidebar, #2f343d);
 
   overflow-y: auto;
   align-items: center;

--- a/src/ui/components/SettingsView/GeneralTab.tsx
+++ b/src/ui/components/SettingsView/GeneralTab.tsx
@@ -10,7 +10,6 @@ import { NTLMCredentials } from './features/NTLMCredentials';
 import { NavigationLayout } from './features/NavigationLayout';
 import { OutlookCalendarSyncInterval } from './features/OutlookCalendarSyncInterval';
 import { ReportErrors } from './features/ReportErrors';
-import { ThemeAppearance } from './features/ThemeAppearance';
 import { TransparentWindow } from './features/TransparentWindow';
 import { TrayIcon } from './features/TrayIcon';
 
@@ -23,7 +22,6 @@ export const GeneralTab = () => {
       <Box is='form' width='x600' maxWidth='full'>
         <FieldGroup>
           <NavigationLayout />
-          <ThemeAppearance />
         </FieldGroup>
 
         <FieldGroup mbs='x24'>

--- a/src/ui/components/Shell/index.spec.tsx
+++ b/src/ui/components/Shell/index.spec.tsx
@@ -208,10 +208,10 @@ describe('Shell', () => {
     ).toBeInTheDocument();
   });
 
-  it('applies the machine theme when the user preference is auto', () => {
+  it('forces the dark theme regardless of the machine theme', () => {
     renderWithStore(<Shell />, {
       preloadedState: buildState({
-        machineTheme: 'dark',
+        machineTheme: 'light',
         userThemePreference: 'auto',
       }),
     });
@@ -222,17 +222,17 @@ describe('Shell', () => {
     );
   });
 
-  it('applies the explicit user theme preference when it is not auto', () => {
+  it('forces the dark theme regardless of the user theme preference', () => {
     renderWithStore(<Shell />, {
       preloadedState: buildState({
-        machineTheme: 'dark',
+        machineTheme: 'light',
         userThemePreference: 'light',
       }),
     });
 
     expect(screen.getByTestId('palette-style-tag')).toHaveAttribute(
       'data-theme',
-      'light'
+      'dark'
     );
   });
 

--- a/src/ui/components/Shell/index.tsx
+++ b/src/ui/components/Shell/index.tsx
@@ -63,7 +63,7 @@ export const Shell = () => {
         <WindowDragBar />
       )}
       <Box
-        bg='room'
+        bg='sidebar'
         display='flex'
         flexWrap='wrap'
         height='100vh'

--- a/src/ui/components/Shell/index.tsx
+++ b/src/ui/components/Shell/index.tsx
@@ -1,6 +1,5 @@
 import { Box, PaletteStyleTag } from '@rocket.chat/fuselage';
-import type { Themes } from '@rocket.chat/fuselage/dist/components/PaletteStyleTag/types/themes';
-import { useEffect, useLayoutEffect, useState } from 'react';
+import { useLayoutEffect } from 'react';
 import { useSelector } from 'react-redux';
 
 import type { RootState } from '../../../store/rootReducer';
@@ -30,30 +29,12 @@ import { GlobalStyles, WindowDragBar } from './styles';
 
 export const Shell = () => {
   const appPath = useSelector(({ appPath }: RootState) => appPath);
-  const machineTheme = useSelector(
-    ({ machineTheme }: RootState) => machineTheme
-  );
-  const userThemePreference = useSelector(
-    ({ userThemePreference }: RootState) => userThemePreference
-  );
   const isTransparentWindowEnabled = useSelector(
     ({ isTransparentWindowEnabled }: RootState) => isTransparentWindowEnabled
   );
   const navigationLayout = useSelector(
     ({ navigationLayout }: RootState) => navigationLayout
   );
-
-  const [currentTheme, setCurrentTheme] = useState<Themes | undefined>(
-    machineTheme as Themes
-  );
-
-  useEffect(() => {
-    if (userThemePreference === 'auto') {
-      setCurrentTheme(machineTheme as Themes);
-    } else {
-      setCurrentTheme(userThemePreference as Themes);
-    }
-  }, [machineTheme, userThemePreference]);
 
   useLayoutEffect(() => {
     if (!appPath) {
@@ -73,7 +54,7 @@ export const Shell = () => {
   return (
     <TooltipProvider>
       <PaletteStyleTag
-        theme={currentTheme}
+        theme='dark'
         selector=':root'
         // tagId='sidebar-palette'
       />

--- a/src/ui/components/Shell/styles.tsx
+++ b/src/ui/components/Shell/styles.tsx
@@ -13,7 +13,7 @@ export const GlobalStyles = ({
   const backgroundColor =
     isDarwin && isTransparentWindowEnabled
       ? 'transparent'
-      : 'var(--rcx-color-surface-room, #2f343d)';
+      : 'var(--rcx-color-surface-sidebar, #2f343d)';
 
   return (
     <Global
@@ -75,7 +75,7 @@ export const Wrapper = styled.div<WrapperProps>`
   background-color: ${({ isTransparentWindowEnabled }) =>
     isDarwin && isTransparentWindowEnabled
       ? 'transparent'
-      : 'var(--rcx-color-surface-room, #2f343d)'};
+      : 'var(--rcx-color-surface-sidebar, #2f343d)'};
   display: flex;
   flex-flow: row nowrap;
 `;

--- a/src/ui/components/SideBar/ServerButton.tsx
+++ b/src/ui/components/SideBar/ServerButton.tsx
@@ -1,32 +1,14 @@
 import { css } from '@rocket.chat/css-in-js';
-import {
-  Avatar,
-  IconButton,
-  Badge,
-  Box,
-  Dropdown,
-  Option,
-  OptionIcon,
-  OptionContent,
-  OptionDivider,
-} from '@rocket.chat/fuselage';
+import { Avatar, IconButton, Badge, Box } from '@rocket.chat/fuselage';
 import type { DragEvent, MouseEvent } from 'react';
 import { useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { SupportedVersions } from '../../../servers/supportedVersions/types';
 import { dispatch } from '../../../store';
-import {
-  SIDE_BAR_SERVER_SELECTED,
-  SIDE_BAR_SERVER_RELOAD,
-  SIDE_BAR_SERVER_COPY_URL,
-  SIDE_BAR_SERVER_OPEN_DEV_TOOLS,
-  SIDE_BAR_SERVER_FORCE_RELOAD,
-  SIDE_BAR_SERVER_REMOVE,
-  OPEN_SERVER_INFO_MODAL,
-} from '../../actions';
+import { SIDE_BAR_SERVER_SELECTED } from '../../actions';
+import WorkspaceContextMenu from '../WorkspaceContextMenu';
 import { getServerInitials } from '../utils/getServerInitials';
-import ServerInfoDropdown from './ServerInfoDropdown';
 import { Initials, ServerButtonWrapper } from './styles';
 import { useDropdownVisibility } from './useDropdownVisibility';
 
@@ -53,14 +35,6 @@ type ServerButtonProps = {
   onDrop: (event: DragEvent) => void;
   exchangeUrl?: string;
 };
-
-type ServerActionType =
-  | typeof SIDE_BAR_SERVER_SELECTED
-  | typeof SIDE_BAR_SERVER_RELOAD
-  | typeof SIDE_BAR_SERVER_COPY_URL
-  | typeof SIDE_BAR_SERVER_OPEN_DEV_TOOLS
-  | typeof SIDE_BAR_SERVER_FORCE_RELOAD
-  | typeof SIDE_BAR_SERVER_REMOVE;
 
 const ServerButton = ({
   url,
@@ -90,44 +64,12 @@ const ServerButton = ({
 
   const reference = useRef(null);
   const target = useRef(null);
-  const serverInfoReference = useRef(null);
-  const serverInfoTarget = useRef(null);
 
   const { t } = useTranslation();
 
   const { isVisible, toggle } = useDropdownVisibility({ reference, target });
-  const { isVisible: isServerInfoVisible, toggle: toggleServerInfo } =
-    useDropdownVisibility({
-      reference: serverInfoReference,
-      target: serverInfoTarget,
-    });
 
   const initials = useMemo(() => getServerInitials(title, url), [title, url]);
-
-  const handleActionDropdownClick = (
-    action: ServerActionType,
-    serverUrl: string
-  ): void => {
-    if (action) dispatch({ type: action, payload: serverUrl });
-    toggle();
-  };
-
-  const handleOpenServerInfoModal = (): void => {
-    dispatch({
-      type: OPEN_SERVER_INFO_MODAL,
-      payload: {
-        url,
-        version,
-        exchangeUrl,
-        isSupportedVersion,
-        supportedVersionsSource,
-        supportedVersionsFetchState,
-        supportedVersions,
-      },
-    });
-    toggle();
-    toggleServerInfo(false);
-  };
 
   const handleServerContextMenu = (event: MouseEvent): void => {
     event.preventDefault();
@@ -204,77 +146,18 @@ const ServerButton = ({
         </IconButton>
       </ServerButtonWrapper>
       {isVisible && (
-        <Dropdown reference={reference} ref={target} placement='right-start'>
-          <Box display='flex' className='rcx-option__title'>
-            Workspace
-          </Box>
-          <Option
-            onClick={() =>
-              handleActionDropdownClick(SIDE_BAR_SERVER_RELOAD, url)
-            }
-          >
-            <OptionIcon name='refresh' />
-            <OptionContent>{t('sidebar.item.reload')}</OptionContent>
-          </Option>
-          <Option
-            onClick={() =>
-              handleActionDropdownClick(SIDE_BAR_SERVER_COPY_URL, url)
-            }
-          >
-            <OptionIcon name='copy' />
-            <OptionContent>{t('sidebar.item.copyCurrentUrl')}</OptionContent>
-          </Option>
-          <Option
-            onClick={() =>
-              handleActionDropdownClick(SIDE_BAR_SERVER_OPEN_DEV_TOOLS, url)
-            }
-          >
-            <OptionIcon name='code-block' />
-            <OptionContent>{t('sidebar.item.openDevTools')}</OptionContent>
-          </Option>
-          <Option
-            ref={serverInfoReference}
-            onMouseEnter={() => toggleServerInfo(true)}
-            onMouseLeave={() => toggleServerInfo(false)}
-            onClick={handleOpenServerInfoModal}
-          >
-            <OptionIcon name='info' />
-            <OptionContent>{t('sidebar.item.serverInfo')}</OptionContent>
-          </Option>
-          <Option
-            onClick={() =>
-              handleActionDropdownClick(SIDE_BAR_SERVER_FORCE_RELOAD, url)
-            }
-          >
-            <OptionIcon name='refresh' />
-            <OptionContent>
-              {t('sidebar.item.reloadClearingCache')}
-            </OptionContent>
-          </Option>
-          <OptionDivider />
-          <Option
-            onClick={(event) => {
-              event?.stopPropagation();
-              handleActionDropdownClick(SIDE_BAR_SERVER_REMOVE, url);
-            }}
-            variant='danger'
-          >
-            <OptionIcon name='trash' />
-            <OptionContent>{t('sidebar.item.remove')}</OptionContent>
-          </Option>
-        </Dropdown>
-      )}
-      {isServerInfoVisible && (
-        <ServerInfoDropdown
-          reference={serverInfoReference}
-          target={serverInfoTarget}
+        <WorkspaceContextMenu
+          reference={reference}
+          target={target}
           url={url}
           version={version}
           exchangeUrl={exchangeUrl}
-          supportedVersions={supportedVersions}
           isSupportedVersion={isSupportedVersion}
           supportedVersionsSource={supportedVersionsSource}
           supportedVersionsFetchState={supportedVersionsFetchState}
+          supportedVersions={supportedVersions}
+          onClose={() => toggle(false)}
+          placement='right-start'
         />
       )}
     </>

--- a/src/ui/components/TabBar/MeatballMenuButton.spec.tsx
+++ b/src/ui/components/TabBar/MeatballMenuButton.spec.tsx
@@ -48,6 +48,13 @@ describe('MeatballMenuButton', () => {
     });
   });
 
+  it('renders with white text color', () => {
+    renderWithStore(<MeatballMenuButton />);
+
+    const button = screen.getByRole('button', { name: 'tabBar.meatballMenu' });
+    expect(button).toHaveStyle({ color: '#ffffff' });
+  });
+
   it('exposes menu affordance attributes for accessibility', () => {
     renderWithStore(<MeatballMenuButton />);
 

--- a/src/ui/components/TabBar/WindowControls.spec.tsx
+++ b/src/ui/components/TabBar/WindowControls.spec.tsx
@@ -75,6 +75,16 @@ describe('WindowControls', () => {
     });
   });
 
+  it('renders window control buttons with white text color', () => {
+    renderWithStore(<WindowControls />, { preloadedState: buildState() });
+
+    const minimizeButton = screen.getByRole('button', {
+      name: 'tabBar.windowControls.minimize',
+    });
+
+    expect(minimizeButton).toHaveStyle({ color: '#ffffff' });
+  });
+
   it('shows the maximize label and glyph when the window is not maximized', () => {
     renderWithStore(<WindowControls />, {
       preloadedState: buildState({

--- a/src/ui/components/TabBar/WorkspaceTab.tsx
+++ b/src/ui/components/TabBar/WorkspaceTab.tsx
@@ -1,4 +1,3 @@
-import { Badge } from '@rocket.chat/fuselage';
 import type { DragEvent, FocusEvent, KeyboardEvent, MouseEvent } from 'react';
 import { useContext, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -12,7 +11,14 @@ import { isDarwin } from '../../utils/platform';
 import { TooltipContext } from '../utils/TooltipContext';
 import { getServerPanelId, getServerTabId } from '../utils/getServerDomId';
 import { getServerInitials } from '../utils/getServerInitials';
-import { Favicon, Initials, Label, ShortcutChip, Tab } from './styles';
+import {
+  Favicon,
+  Initials,
+  Label,
+  ShortcutChip,
+  Tab,
+  TabBadge,
+} from './styles';
 
 const formatMentionCount = (count: number | undefined): string | undefined => {
   if (count === undefined) {
@@ -136,8 +142,8 @@ const WorkspaceTab = ({
       {isShortcutVisible && shortcutNumber && (
         <ShortcutChip>{shortcutNumber}</ShortcutChip>
       )}
-      {displayCount && <Badge variant='secondary'>{displayCount}</Badge>}
-      {!userLoggedIn && <Badge variant='warning'>!</Badge>}
+      {displayCount && <TabBadge variant='secondary'>{displayCount}</TabBadge>}
+      {!userLoggedIn && <TabBadge variant='warning'>!</TabBadge>}
     </Tab>
   );
 };

--- a/src/ui/components/TabBar/WorkspaceTab.tsx
+++ b/src/ui/components/TabBar/WorkspaceTab.tsx
@@ -2,12 +2,12 @@ import type { DragEvent, FocusEvent, KeyboardEvent, MouseEvent } from 'react';
 import { useContext, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import type { SupportedVersions } from '../../../servers/supportedVersions/types';
 import { dispatch } from '../../../store';
-import {
-  SIDE_BAR_CONTEXT_MENU_TRIGGERED,
-  SIDE_BAR_SERVER_SELECTED,
-} from '../../actions';
+import { SIDE_BAR_SERVER_SELECTED } from '../../actions';
 import { isDarwin } from '../../utils/platform';
+import { useDropdownVisibility } from '../SideBar/useDropdownVisibility';
+import WorkspaceContextMenu from '../WorkspaceContextMenu';
 import { TooltipContext } from '../utils/TooltipContext';
 import { getServerPanelId, getServerTabId } from '../utils/getServerDomId';
 import { getServerInitials } from '../utils/getServerInitials';
@@ -39,6 +39,13 @@ type WorkspaceTabProps = {
   shortcutNumber: string | null;
   isShortcutVisible: boolean;
   tabIndex: 0 | -1;
+  version?: string;
+  isSupportedVersion?: boolean;
+  supportedVersionsSource?: 'server' | 'cloud' | 'builtin';
+  supportedVersionsFetchState?: 'idle' | 'loading' | 'success' | 'error';
+  supportedVersions?: SupportedVersions;
+  exchangeUrl?: string;
+  showAddWorkspace?: boolean;
   onDragStart: (event: DragEvent) => void;
   onDragEnd: (event: DragEvent) => void;
   onDragEnter: (event: DragEvent) => void;
@@ -56,6 +63,13 @@ const WorkspaceTab = ({
   shortcutNumber,
   isShortcutVisible,
   tabIndex,
+  version,
+  isSupportedVersion,
+  supportedVersionsSource,
+  supportedVersionsFetchState,
+  supportedVersions,
+  exchangeUrl,
+  showAddWorkspace,
   onDragStart,
   onDragEnd,
   onDragEnter,
@@ -64,6 +78,12 @@ const WorkspaceTab = ({
   const { t } = useTranslation();
   const tooltip = useContext(TooltipContext);
   const ref = useRef<HTMLButtonElement>(null);
+  const target = useRef(null);
+
+  const { isVisible, toggle } = useDropdownVisibility({
+    reference: ref,
+    target,
+  });
 
   const initials = useMemo(() => getServerInitials(title, url), [title, url]);
 
@@ -98,7 +118,7 @@ const WorkspaceTab = ({
 
   const handleContextMenu = (event: MouseEvent): void => {
     event.preventDefault();
-    dispatch({ type: SIDE_BAR_CONTEXT_MENU_TRIGGERED, payload: url });
+    toggle();
   };
 
   const handleKeyDown = (event: KeyboardEvent): void => {
@@ -117,37 +137,57 @@ const WorkspaceTab = ({
   };
 
   return (
-    <Tab
-      ref={ref}
-      id={getServerTabId(url)}
-      role='tab'
-      aria-selected={isSelected}
-      aria-controls={getServerPanelId(url)}
-      tabIndex={tabIndex}
-      isSelected={isSelected}
-      isCompact={compact}
-      title={tooltipText}
-      draggable='true'
-      onClick={handleClick}
-      onContextMenu={handleContextMenu}
-      onKeyDown={handleKeyDown}
-      onFocus={handleFocus}
-      onBlur={handleBlur}
-      onDragOver={(event: DragEvent) => event.preventDefault()}
-      onDragStart={onDragStart}
-      onDragEnd={onDragEnd}
-      onDragEnter={onDragEnter}
-      onDrop={onDrop}
-    >
-      <Initials visible={!favicon}>{initials}</Initials>
-      <Favicon visible={!!favicon} src={favicon ?? ''} draggable='false' />
-      {!compact && <Label>{title}</Label>}
-      {!compact && isShortcutVisible && shortcutNumber && (
-        <ShortcutChip>{shortcutNumber}</ShortcutChip>
+    <>
+      <Tab
+        ref={ref}
+        id={getServerTabId(url)}
+        role='tab'
+        aria-selected={isSelected}
+        aria-controls={getServerPanelId(url)}
+        tabIndex={tabIndex}
+        isSelected={isSelected}
+        isCompact={compact}
+        title={tooltipText}
+        draggable='true'
+        onClick={handleClick}
+        onContextMenu={handleContextMenu}
+        onKeyDown={handleKeyDown}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        onDragOver={(event: DragEvent) => event.preventDefault()}
+        onDragStart={onDragStart}
+        onDragEnd={onDragEnd}
+        onDragEnter={onDragEnter}
+        onDrop={onDrop}
+      >
+        <Initials visible={!favicon}>{initials}</Initials>
+        <Favicon visible={!!favicon} src={favicon ?? ''} draggable='false' />
+        {!compact && <Label>{title}</Label>}
+        {!compact && isShortcutVisible && shortcutNumber && (
+          <ShortcutChip>{shortcutNumber}</ShortcutChip>
+        )}
+        {displayCount && (
+          <TabBadge variant='secondary'>{displayCount}</TabBadge>
+        )}
+        {!userLoggedIn && <TabBadge variant='warning'>!</TabBadge>}
+      </Tab>
+      {isVisible && (
+        <WorkspaceContextMenu
+          reference={ref}
+          target={target}
+          url={url}
+          version={version}
+          exchangeUrl={exchangeUrl}
+          isSupportedVersion={isSupportedVersion}
+          supportedVersionsSource={supportedVersionsSource}
+          supportedVersionsFetchState={supportedVersionsFetchState}
+          supportedVersions={supportedVersions}
+          onClose={() => toggle(false)}
+          showAddWorkspace={showAddWorkspace}
+          placement='bottom-start'
+        />
       )}
-      {displayCount && <TabBadge variant='secondary'>{displayCount}</TabBadge>}
-      {!userLoggedIn && <TabBadge variant='warning'>!</TabBadge>}
-    </Tab>
+    </>
   );
 };
 

--- a/src/ui/components/TabBar/WorkspaceTab.tsx
+++ b/src/ui/components/TabBar/WorkspaceTab.tsx
@@ -148,6 +148,7 @@ const WorkspaceTab = ({
         isSelected={isSelected}
         isCompact={compact}
         title={tooltipText}
+        aria-label={tooltipText}
         draggable='true'
         onClick={handleClick}
         onContextMenu={handleContextMenu}

--- a/src/ui/components/TabBar/WorkspaceTab.tsx
+++ b/src/ui/components/TabBar/WorkspaceTab.tsx
@@ -35,6 +35,7 @@ type WorkspaceTabProps = {
   isSelected: boolean;
   badge?: '•' | number;
   userLoggedIn?: boolean;
+  compact: boolean;
   shortcutNumber: string | null;
   isShortcutVisible: boolean;
   tabIndex: 0 | -1;
@@ -51,6 +52,7 @@ const WorkspaceTab = ({
   isSelected,
   badge,
   userLoggedIn,
+  compact,
   shortcutNumber,
   isShortcutVisible,
   tabIndex,
@@ -123,6 +125,7 @@ const WorkspaceTab = ({
       aria-controls={getServerPanelId(url)}
       tabIndex={tabIndex}
       isSelected={isSelected}
+      isCompact={compact}
       title={tooltipText}
       draggable='true'
       onClick={handleClick}
@@ -138,8 +141,8 @@ const WorkspaceTab = ({
     >
       <Initials visible={!favicon}>{initials}</Initials>
       <Favicon visible={!!favicon} src={favicon ?? ''} draggable='false' />
-      <Label>{title}</Label>
-      {isShortcutVisible && shortcutNumber && (
+      {!compact && <Label>{title}</Label>}
+      {!compact && isShortcutVisible && shortcutNumber && (
         <ShortcutChip>{shortcutNumber}</ShortcutChip>
       )}
       {displayCount && <TabBadge variant='secondary'>{displayCount}</TabBadge>}

--- a/src/ui/components/TabBar/index.spec.tsx
+++ b/src/ui/components/TabBar/index.spec.tsx
@@ -304,14 +304,14 @@ describe('TabBar', () => {
     expect(screen.queryByText('Server C')).not.toBeInTheDocument();
   });
 
-  it('aligns the add button with the 34px tab row instead of stretching over the 44px strip', async () => {
+  it('aligns the add button with the 28px tab row instead of stretching over the 32px strip', async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     renderTabBar(<TabBar />, { preloadedState: buildState() });
 
     const addButton = screen.getByTitle('tabBar.addWorkspace');
     const wrapper = addButton.closest('div');
 
-    expect(wrapper).toHaveStyle({ alignSelf: 'flex-end', height: '34px' });
+    expect(wrapper).toHaveStyle({ alignSelf: 'flex-end', height: '28px' });
     // sanity check the button is still reachable/clickable after the alignment change
     await user.click(addButton);
     expect(mockDispatch).toHaveBeenCalled();

--- a/src/ui/components/TabBar/index.spec.tsx
+++ b/src/ui/components/TabBar/index.spec.tsx
@@ -322,14 +322,18 @@ describe('TabBar', () => {
     expect(screen.queryByText('Server C')).not.toBeInTheDocument();
   });
 
-  it('aligns the add button with the 28px tab row instead of stretching over the 32px strip', async () => {
+  it('aligns the add button with the 32px tab row instead of stretching over the 36px strip', async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     renderTabBar(<TabBar />, { preloadedState: buildState() });
 
     const addButton = screen.getByTitle('tabBar.addWorkspace');
     const wrapper = addButton.closest('div');
 
-    expect(wrapper).toHaveStyle({ alignSelf: 'flex-end', height: '28px' });
+    expect(wrapper).toHaveStyle({
+      alignSelf: 'flex-end',
+      alignItems: 'flex-start',
+      height: '32px',
+    });
     // sanity check the button is still reachable/clickable after the alignment change
     await user.click(addButton);
     expect(mockDispatch).toHaveBeenCalled();

--- a/src/ui/components/TabBar/index.spec.tsx
+++ b/src/ui/components/TabBar/index.spec.tsx
@@ -3,7 +3,6 @@ import { act } from '@testing-library/react';
 import { TabBar } from '.';
 import {
   SIDE_BAR_ADD_NEW_SERVER_CLICKED,
-  SIDE_BAR_CONTEXT_MENU_TRIGGERED,
   SIDE_BAR_SERVER_SELECTED,
 } from '../../actions';
 import { renderWithStore, screen, userEvent } from '../../test-utils';
@@ -36,6 +35,26 @@ const mockDispatch = jest.fn();
 jest.mock('../../../store', () => ({
   dispatch: (action: unknown) => mockDispatch(action),
 }));
+
+jest.mock('../SideBar/ServerInfoDropdown', () => ({
+  __esModule: true,
+  default: () => <div data-testid='server-info-dropdown' />,
+}));
+
+// Fuselage's <Dropdown> resolves to its mobile variant under jsdom (matchMedia
+// has no real layout) and renders its children into an unreachable portal/tile.
+// Replace only that component with an inline passthrough so the menu Options
+// render in the tree; every other Fuselage component stays real.
+jest.mock('@rocket.chat/fuselage', () => {
+  const actual = jest.requireActual('@rocket.chat/fuselage');
+  return {
+    __esModule: true,
+    ...actual,
+    Dropdown: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid='dropdown'>{children}</div>
+    ),
+  };
+});
 
 let mockTabListWidth = 1000;
 
@@ -169,22 +188,22 @@ describe('TabBar', () => {
     expect(screen.getByText('SA')).toBeInTheDocument();
   });
 
-  it('dispatches SIDE_BAR_CONTEXT_MENU_TRIGGERED on context menu', () => {
+  it('opens the custom workspace context menu instead of the native menu on context menu', async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     renderTabBar(<TabBar />, { preloadedState: buildState() });
 
-    const tab = screen.getByText('Server A').closest('[role="tab"]');
+    const tab = screen
+      .getByText('Server A')
+      .closest('[role="tab"]') as HTMLElement;
     expect(tab).not.toBeNull();
 
-    const event = new MouseEvent('contextmenu', {
-      bubbles: true,
-      cancelable: true,
-    });
-    tab?.dispatchEvent(event);
+    await user.pointer({ keys: '[MouseRight]', target: tab });
 
-    expect(mockDispatch).toHaveBeenCalledWith({
-      type: SIDE_BAR_CONTEXT_MENU_TRIGGERED,
-      payload: 'https://a.rocket.chat/',
-    });
+    expect(screen.getByText('Workspace')).toBeInTheDocument();
+    expect(screen.getByText('sidebar.item.serverInfo')).toBeInTheDocument();
+    expect(mockDispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'side-bar/context-menu-triggered' })
+    );
   });
 
   it('renders with zero servers without crashing', () => {

--- a/src/ui/components/TabBar/index.spec.tsx
+++ b/src/ui/components/TabBar/index.spec.tsx
@@ -199,7 +199,7 @@ describe('TabBar', () => {
 
     await user.pointer({ keys: '[MouseRight]', target: tab });
 
-    expect(screen.getByText('Workspace')).toBeInTheDocument();
+    expect(screen.getByText('sidebar.item.workspace')).toBeInTheDocument();
     expect(screen.getByText('sidebar.item.serverInfo')).toBeInTheDocument();
     expect(mockDispatch).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: 'side-bar/context-menu-triggered' })

--- a/src/ui/components/TabBar/index.spec.tsx
+++ b/src/ui/components/TabBar/index.spec.tsx
@@ -256,4 +256,66 @@ describe('TabBar', () => {
 
     expect(screen.getAllByRole('tab')).toHaveLength(2);
   });
+
+  it('hugs tab content instead of stretching to fill the strip', () => {
+    renderTabBar(<TabBar />, {
+      preloadedState: buildState({
+        servers: [{ url: 'https://a.rocket.chat/', title: 'Server A' }],
+      }),
+    });
+
+    const tab = screen.getByText('Server A').closest('[role="tab"]');
+    expect(tab).toHaveStyle({
+      flex: '0 1 auto',
+      minWidth: '52px',
+      maxWidth: '180px',
+    });
+  });
+
+  it('drops the label only at the 52px minimum tab width, not at 75px', () => {
+    renderTabBar(<TabBar />, {
+      preloadedState: buildState({
+        servers: [{ url: 'https://a.rocket.chat/', title: 'Server A' }],
+      }),
+    });
+
+    const styleTags = Array.from(document.querySelectorAll('style'))
+      .map((style) =>
+        style.sheet
+          ? Array.from(style.sheet.cssRules)
+              .map((rule) => rule.cssText)
+              .join('\n')
+          : style.textContent ?? ''
+      )
+      .join('\n');
+
+    expect(styleTags).toMatch(/@container[^{]*max-width:\s*56px/);
+    expect(styleTags).not.toMatch(/@container[^{]*max-width:\s*75px/);
+  });
+
+  it('aligns the add button with the 34px tab row instead of stretching over the 44px strip', async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    renderTabBar(<TabBar />, { preloadedState: buildState() });
+
+    const addButton = screen.getByTitle('tabBar.addWorkspace');
+    const wrapper = addButton.closest('div');
+
+    expect(wrapper).toHaveStyle({ alignSelf: 'flex-end', height: '34px' });
+    // sanity check the button is still reachable/clickable after the alignment change
+    await user.click(addButton);
+    expect(mockDispatch).toHaveBeenCalled();
+  });
+
+  it('renders a non-shrinking, pill-shaped badge for two-digit mention counts', () => {
+    renderTabBar(<TabBar />, {
+      preloadedState: buildState({
+        servers: [
+          { url: 'https://a.rocket.chat/', title: 'Server A', badge: 97 },
+        ],
+      }),
+    });
+
+    const badge = screen.getByText('97');
+    expect(badge).toHaveStyle({ flexShrink: '0' });
+  });
 });

--- a/src/ui/components/TabBar/index.spec.tsx
+++ b/src/ui/components/TabBar/index.spec.tsx
@@ -272,25 +272,36 @@ describe('TabBar', () => {
     });
   });
 
-  it('drops the label only at the 52px minimum tab width, not at 75px', () => {
+  it('shows the workspace name label when the strip has room', () => {
     renderTabBar(<TabBar />, {
       preloadedState: buildState({
         servers: [{ url: 'https://a.rocket.chat/', title: 'Server A' }],
       }),
     });
 
-    const styleTags = Array.from(document.querySelectorAll('style'))
-      .map((style) =>
-        style.sheet
-          ? Array.from(style.sheet.cssRules)
-              .map((rule) => rule.cssText)
-              .join('\n')
-          : style.textContent ?? ''
-      )
-      .join('\n');
+    expect(screen.getByText('Server A')).toBeInTheDocument();
+  });
 
-    expect(styleTags).toMatch(/@container[^{]*max-width:\s*56px/);
-    expect(styleTags).not.toMatch(/@container[^{]*max-width:\s*75px/);
+  it('hides the label and shortcut chip when the strip is crowded (compact mode)', () => {
+    // 190px fits all 3 tabs at their 52px minimum (no slicing by
+    // computeVisibleServers) but sits below the 3 * (64 + gap) compact threshold.
+    mockTabListWidth = 190;
+
+    renderTabBar(<TabBar />, {
+      preloadedState: buildState({
+        servers: [
+          { url: 'https://a.rocket.chat/', title: 'Server A' },
+          { url: 'https://b.rocket.chat/', title: 'Server B' },
+          { url: 'https://c.rocket.chat/', title: 'Server C' },
+        ],
+        isAddNewServersEnabled: false,
+      }),
+    });
+
+    expect(screen.getAllByRole('tab')).toHaveLength(3);
+    expect(screen.queryByText('Server A')).not.toBeInTheDocument();
+    expect(screen.queryByText('Server B')).not.toBeInTheDocument();
+    expect(screen.queryByText('Server C')).not.toBeInTheDocument();
   });
 
   it('aligns the add button with the 34px tab row instead of stretching over the 44px strip', async () => {

--- a/src/ui/components/TabBar/index.spec.tsx
+++ b/src/ui/components/TabBar/index.spec.tsx
@@ -199,7 +199,6 @@ describe('TabBar', () => {
 
     await user.pointer({ keys: '[MouseRight]', target: tab });
 
-    expect(screen.getByText('sidebar.item.workspace')).toBeInTheDocument();
     expect(screen.getByText('sidebar.item.serverInfo')).toBeInTheDocument();
     expect(mockDispatch).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: 'side-bar/context-menu-triggered' })

--- a/src/ui/components/TabBar/index.tsx
+++ b/src/ui/components/TabBar/index.tsx
@@ -53,7 +53,7 @@ export const TabBar = ({ leadingSlot, trailingSlot }: TabBarProps) => {
 
   const activeServer = sortedServers.find((server) => server.selected);
 
-  const { visibleServers, tabListRef } = useTabBarLayout(
+  const { visibleServers, compact, tabListRef } = useTabBarLayout(
     sortedServers,
     activeServer?.url,
     isAddNewServersEnabled
@@ -126,6 +126,7 @@ export const TabBar = ({ leadingSlot, trailingSlot }: TabBarProps) => {
               isSelected={server.selected}
               badge={server.badge}
               userLoggedIn={server.userLoggedIn}
+              compact={compact}
               shortcutNumber={shortcutNumber}
               isShortcutVisible={isEachShortcutVisible}
               tabIndex={

--- a/src/ui/components/TabBar/index.tsx
+++ b/src/ui/components/TabBar/index.tsx
@@ -132,6 +132,13 @@ export const TabBar = ({ leadingSlot, trailingSlot }: TabBarProps) => {
               tabIndex={
                 server.selected || (!hasSelectedServer && index === 0) ? 0 : -1
               }
+              version={server.version}
+              isSupportedVersion={server.isSupportedVersion}
+              supportedVersionsSource={server.supportedVersionsSource}
+              supportedVersionsFetchState={server.supportedVersionsFetchState}
+              supportedVersions={server.supportedVersions}
+              exchangeUrl={server.outlookCredentials?.serverUrl}
+              showAddWorkspace={isAddNewServersEnabled}
               onDragStart={handleDragStart(server.url)}
               onDragEnd={handleDragEnd}
               onDragEnter={handleDragEnter(server.url)}

--- a/src/ui/components/TabBar/index.tsx
+++ b/src/ui/components/TabBar/index.tsx
@@ -150,7 +150,7 @@ export const TabBar = ({ leadingSlot, trailingSlot }: TabBarProps) => {
           <AddButtonWrapper>
             <IconButton
               small
-              icon='plus'
+              icon='plus-small'
               title={t('tabBar.addWorkspace')}
               onClick={handleAddServerButtonClicked}
             />

--- a/src/ui/components/TabBar/styles.tsx
+++ b/src/ui/components/TabBar/styles.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import { Badge } from '@rocket.chat/fuselage';
 
 type StripProps = {
   isTransparentWindowEnabled: boolean;
@@ -51,7 +52,8 @@ export const DragSpacer = styled.div`
 export const AddButtonWrapper = styled.div`
   display: flex;
   align-items: center;
-  align-self: stretch;
+  align-self: flex-end;
+  height: 34px;
   flex: 0 0 auto;
   -webkit-app-region: no-drag;
 `;
@@ -69,7 +71,7 @@ export const Tab = styled.button<TabProps>`
   flex-direction: row;
   align-items: center;
   gap: 6px;
-  flex: 1 1 180px;
+  flex: 0 1 auto;
   min-width: 52px;
   max-width: 180px;
   height: 34px;
@@ -163,10 +165,11 @@ export const Label = styled.span`
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 13px;
-  font-weight: 500;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 12px;
 
-  @container (max-width: 75px) {
+  @container (max-width: 56px) {
     display: none;
   }
 `;
@@ -176,9 +179,13 @@ export const ShortcutChip = styled.span`
   font-size: 11px;
   opacity: 0.7;
 
-  @container (max-width: 75px) {
+  @container (max-width: 56px) {
     display: none;
   }
+`;
+
+export const TabBadge = styled(Badge)`
+  flex-shrink: 0;
 `;
 
 export const MeatballButton = styled.button`

--- a/src/ui/components/TabBar/styles.tsx
+++ b/src/ui/components/TabBar/styles.tsx
@@ -12,7 +12,7 @@ export const Strip = styled.div<StripProps>`
   align-items: stretch;
   flex: 0 0 auto;
   width: 100%;
-  height: 32px;
+  height: 36px;
   -webkit-app-region: drag;
   user-select: none;
   background-color: ${({ isTransparentWindowEnabled }) =>
@@ -38,8 +38,8 @@ export const TabList = styled.div`
   align-items: flex-end;
   flex: 1 1 auto;
   min-width: 0;
-  gap: 8px;
-  padding-left: 8px;
+  gap: 4px;
+  padding-left: 4px;
   overflow: hidden;
   -webkit-app-region: drag;
 `;
@@ -51,9 +51,9 @@ export const DragSpacer = styled.div`
 
 export const AddButtonWrapper = styled.div`
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   align-self: flex-end;
-  height: 28px;
+  height: 32px;
   flex: 0 0 auto;
   -webkit-app-region: no-drag;
 `;
@@ -76,7 +76,7 @@ export const Tab = styled.button<TabProps>`
   flex: 0 1 auto;
   min-width: 52px;
   max-width: 180px;
-  height: 28px;
+  height: 32px;
   align-self: flex-end;
   position: relative;
   padding: ${({ isCompact }) => (isCompact ? '0 6px' : '0 10px')};
@@ -194,10 +194,10 @@ export const MeatballButton = styled.button`
   height: 100%;
   cursor: pointer;
   -webkit-app-region: no-drag;
-  color: var(--rcx-color-font-default, #1f2329);
+  color: #ffffff;
 
   &:hover {
-    background-color: var(--rcx-color-surface-neutral, #e4e7ea);
+    background-color: rgba(255, 255, 255, 0.12);
   }
 
   &:focus-visible {
@@ -231,12 +231,12 @@ export const WindowControlButton = styled.button<WindowControlButtonProps>`
   height: 100%;
   cursor: pointer;
   -webkit-app-region: no-drag;
-  color: var(--rcx-color-font-default, #1f2329);
+  color: #ffffff;
 
   &:hover {
     background-color: ${({ isCloseButton }) =>
-      isCloseButton ? '#c42b1c' : 'var(--rcx-color-surface-neutral, #e4e7ea)'};
-    color: ${({ isCloseButton }) => (isCloseButton ? '#ffffff' : 'inherit')};
+      isCloseButton ? '#c42b1c' : 'rgba(255, 255, 255, 0.12)'};
+    color: #ffffff;
   }
 
   &:focus-visible {

--- a/src/ui/components/TabBar/styles.tsx
+++ b/src/ui/components/TabBar/styles.tsx
@@ -60,6 +60,7 @@ export const AddButtonWrapper = styled.div`
 
 type TabProps = {
   isSelected: boolean;
+  isCompact: boolean;
 };
 
 export const Tab = styled.button<TabProps>`
@@ -77,8 +78,7 @@ export const Tab = styled.button<TabProps>`
   height: 34px;
   align-self: flex-end;
   position: relative;
-  container-type: inline-size;
-  padding: 0 10px;
+  padding: ${({ isCompact }) => (isCompact ? '0 6px' : '0 10px')};
   cursor: pointer;
   -webkit-app-region: no-drag;
   color: var(--rcx-color-font-default, #1f2329);
@@ -168,20 +168,12 @@ export const Label = styled.span`
   font-size: 10px;
   font-weight: 700;
   line-height: 12px;
-
-  @container (max-width: 56px) {
-    display: none;
-  }
 `;
 
 export const ShortcutChip = styled.span`
   flex: 0 0 auto;
   font-size: 11px;
   opacity: 0.7;
-
-  @container (max-width: 56px) {
-    display: none;
-  }
 `;
 
 export const TabBadge = styled(Badge)`

--- a/src/ui/components/TabBar/styles.tsx
+++ b/src/ui/components/TabBar/styles.tsx
@@ -12,7 +12,7 @@ export const Strip = styled.div<StripProps>`
   align-items: stretch;
   flex: 0 0 auto;
   width: 100%;
-  height: 44px;
+  height: 32px;
   -webkit-app-region: drag;
   user-select: none;
   background-color: ${({ isTransparentWindowEnabled }) =>
@@ -39,7 +39,7 @@ export const TabList = styled.div`
   flex: 1 1 auto;
   min-width: 0;
   gap: 8px;
-  padding-left: 10px;
+  padding-left: 8px;
   overflow: hidden;
   -webkit-app-region: drag;
 `;
@@ -53,7 +53,7 @@ export const AddButtonWrapper = styled.div`
   display: flex;
   align-items: center;
   align-self: flex-end;
-  height: 34px;
+  height: 28px;
   flex: 0 0 auto;
   -webkit-app-region: no-drag;
 `;
@@ -68,6 +68,7 @@ export const Tab = styled.button<TabProps>`
   border: none;
   outline: none;
   background: transparent;
+  font-family: inherit;
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -75,7 +76,7 @@ export const Tab = styled.button<TabProps>`
   flex: 0 1 auto;
   min-width: 52px;
   max-width: 180px;
-  height: 34px;
+  height: 28px;
   align-self: flex-end;
   position: relative;
   padding: ${({ isCompact }) => (isCompact ? '0 6px' : '0 10px')};

--- a/src/ui/components/TabBar/useTabBarLayout.spec.ts
+++ b/src/ui/components/TabBar/useTabBarLayout.spec.ts
@@ -1,5 +1,5 @@
 import type { Server } from '../../../servers/common';
-import { computeVisibleServers } from './useTabBarLayout';
+import { computeIsCompact, computeVisibleServers } from './useTabBarLayout';
 
 const buildServer = (url: string): Server => ({ url, title: url });
 
@@ -76,5 +76,25 @@ describe('computeVisibleServers', () => {
       buildServer('b'),
       buildServer('c'),
     ]);
+  });
+});
+
+describe('computeIsCompact', () => {
+  it('returns false for a wide strip with few tabs', () => {
+    expect(computeIsCompact(1000, 2)).toBe(false);
+  });
+
+  it('returns true when the average width per tab is at or below the compact threshold', () => {
+    // 200 / 3 tabs = 66.67px avg, below the (64 + gap) per-tab threshold.
+    expect(computeIsCompact(200, 3)).toBe(true);
+  });
+
+  it('returns false when width is not yet measured (zero or negative)', () => {
+    expect(computeIsCompact(0, 3)).toBe(false);
+    expect(computeIsCompact(-50, 3)).toBe(false);
+  });
+
+  it('returns false when there are no visible servers', () => {
+    expect(computeIsCompact(500, 0)).toBe(false);
   });
 });

--- a/src/ui/components/TabBar/useTabBarLayout.ts
+++ b/src/ui/components/TabBar/useTabBarLayout.ts
@@ -5,6 +5,7 @@ import type { Server } from '../../../servers/common';
 const TAB_MIN_WIDTH = 52;
 const TAB_GAP = 8;
 const ADD_BUTTON_WIDTH = 36;
+const COMPACT_AVG_WIDTH_THRESHOLD = 64;
 
 export const computeVisibleServers = <S extends Server>(
   availableWidth: number,
@@ -41,12 +42,27 @@ export const computeVisibleServers = <S extends Server>(
   return visible;
 };
 
+export const computeIsCompact = (
+  availableWidth: number,
+  visibleServerCount: number
+): boolean => {
+  if (availableWidth <= 0 || visibleServerCount <= 0) {
+    return false;
+  }
+
+  return (
+    availableWidth <
+    visibleServerCount * (COMPACT_AVG_WIDTH_THRESHOLD + TAB_GAP)
+  );
+};
+
 export const useTabBarLayout = <S extends Server>(
   servers: S[],
   activeUrl: string | undefined,
   hasAddButton: boolean
 ): {
   visibleServers: S[];
+  compact: boolean;
   tabListRef: (node: HTMLElement | null) => void;
 } => {
   const [availableWidth, setAvailableWidth] = useState(0);
@@ -109,5 +125,7 @@ export const useTabBarLayout = <S extends Server>(
     activeUrl
   );
 
-  return { visibleServers, tabListRef };
+  const compact = computeIsCompact(availableWidth, visibleServers.length);
+
+  return { visibleServers, compact, tabListRef };
 };

--- a/src/ui/components/WorkspaceContextMenu/index.spec.tsx
+++ b/src/ui/components/WorkspaceContextMenu/index.spec.tsx
@@ -1,0 +1,187 @@
+import { useRef } from 'react';
+
+import WorkspaceContextMenu from '.';
+import {
+  SIDE_BAR_ADD_NEW_SERVER_CLICKED,
+  SIDE_BAR_SERVER_RELOAD,
+  SIDE_BAR_SERVER_COPY_URL,
+  SIDE_BAR_SERVER_OPEN_DEV_TOOLS,
+  SIDE_BAR_SERVER_FORCE_RELOAD,
+  SIDE_BAR_SERVER_REMOVE,
+  OPEN_SERVER_INFO_MODAL,
+} from '../../actions';
+import { render, screen, userEvent } from '../../test-utils';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en', changeLanguage: jest.fn() },
+  }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}));
+
+const mockDispatch = jest.fn();
+
+jest.mock('../../../store', () => ({
+  dispatch: (action: unknown) => mockDispatch(action),
+}));
+
+jest.mock('../SideBar/ServerInfoDropdown', () => ({
+  __esModule: true,
+  default: () => <div data-testid='server-info-dropdown' />,
+}));
+
+// Fuselage's <Dropdown> resolves to its mobile variant under jsdom (matchMedia
+// has no real layout) and renders its children into an unreachable portal/tile.
+// Replace only that component with an inline passthrough so the menu Options
+// render in the tree; every other Fuselage component stays real.
+jest.mock('@rocket.chat/fuselage', () => {
+  const actual = jest.requireActual('@rocket.chat/fuselage');
+  return {
+    __esModule: true,
+    ...actual,
+    Dropdown: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid='dropdown'>{children}</div>
+    ),
+  };
+});
+
+const Wrapper = (
+  overrides: Partial<React.ComponentProps<typeof WorkspaceContextMenu>> = {}
+) => {
+  const reference = useRef(null);
+  const target = useRef(null);
+
+  return (
+    <WorkspaceContextMenu
+      reference={reference}
+      target={target}
+      url='https://open.rocket.chat'
+      onClose={jest.fn()}
+      {...overrides}
+    />
+  );
+};
+
+describe('WorkspaceContextMenu', () => {
+  beforeEach(() => {
+    mockDispatch.mockClear();
+  });
+
+  it('renders the workspace title and the standard action items', () => {
+    render(<Wrapper />);
+
+    expect(screen.getByText('Workspace')).toBeInTheDocument();
+    expect(screen.getByText('sidebar.item.reload')).toBeInTheDocument();
+    expect(screen.getByText('sidebar.item.copyCurrentUrl')).toBeInTheDocument();
+    expect(screen.getByText('sidebar.item.openDevTools')).toBeInTheDocument();
+    expect(screen.getByText('sidebar.item.serverInfo')).toBeInTheDocument();
+    expect(
+      screen.getByText('sidebar.item.reloadClearingCache')
+    ).toBeInTheDocument();
+    expect(screen.getByText('sidebar.item.remove')).toBeInTheDocument();
+  });
+
+  it('does not render the Add workspace option by default', () => {
+    render(<Wrapper />);
+
+    expect(
+      screen.queryByText('sidebar.item.addWorkspace')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the Add workspace option when showAddWorkspace is true', () => {
+    render(<Wrapper showAddWorkspace />);
+
+    expect(screen.getByText('sidebar.item.addWorkspace')).toBeInTheDocument();
+  });
+
+  it('dispatches SIDE_BAR_ADD_NEW_SERVER_CLICKED when Add workspace is clicked', async () => {
+    const user = userEvent.setup();
+    render(<Wrapper showAddWorkspace />);
+
+    await user.click(screen.getByText('sidebar.item.addWorkspace'));
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: SIDE_BAR_ADD_NEW_SERVER_CLICKED,
+    });
+  });
+
+  it('renders the Remove option with the danger variant', () => {
+    render(<Wrapper />);
+
+    const removeOption = screen.getByText('sidebar.item.remove').closest('li');
+    expect(removeOption).toHaveClass('rcx-option--danger');
+  });
+
+  it('dispatches reload with the url when Reload is clicked', async () => {
+    const user = userEvent.setup();
+    render(<Wrapper url='https://open.rocket.chat' />);
+
+    await user.click(screen.getByText('sidebar.item.reload'));
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: SIDE_BAR_SERVER_RELOAD,
+      payload: 'https://open.rocket.chat',
+    });
+  });
+
+  it('dispatches copy-url, dev-tools, force-reload and remove actions', async () => {
+    const user = userEvent.setup();
+    render(<Wrapper url='https://open.rocket.chat' />);
+
+    await user.click(screen.getByText('sidebar.item.copyCurrentUrl'));
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: SIDE_BAR_SERVER_COPY_URL,
+      payload: 'https://open.rocket.chat',
+    });
+
+    await user.click(screen.getByText('sidebar.item.openDevTools'));
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: SIDE_BAR_SERVER_OPEN_DEV_TOOLS,
+      payload: 'https://open.rocket.chat',
+    });
+
+    await user.click(screen.getByText('sidebar.item.reloadClearingCache'));
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: SIDE_BAR_SERVER_FORCE_RELOAD,
+      payload: 'https://open.rocket.chat',
+    });
+
+    await user.click(screen.getByText('sidebar.item.remove'));
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: SIDE_BAR_SERVER_REMOVE,
+      payload: 'https://open.rocket.chat',
+    });
+  });
+
+  it('dispatches the open-server-info-modal action with the server details', async () => {
+    const user = userEvent.setup();
+    render(
+      <Wrapper
+        url='https://open.rocket.chat'
+        version='6.5.0'
+        exchangeUrl='https://exchange.example.com'
+        isSupportedVersion
+        supportedVersionsSource='cloud'
+        supportedVersionsFetchState='success'
+      />
+    );
+
+    await user.click(screen.getByText('sidebar.item.serverInfo'));
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: OPEN_SERVER_INFO_MODAL,
+      payload: {
+        url: 'https://open.rocket.chat',
+        version: '6.5.0',
+        exchangeUrl: 'https://exchange.example.com',
+        isSupportedVersion: true,
+        supportedVersionsSource: 'cloud',
+        supportedVersionsFetchState: 'success',
+        supportedVersions: undefined,
+      },
+    });
+  });
+});

--- a/src/ui/components/WorkspaceContextMenu/index.spec.tsx
+++ b/src/ui/components/WorkspaceContextMenu/index.spec.tsx
@@ -72,7 +72,7 @@ describe('WorkspaceContextMenu', () => {
   it('renders the workspace title and the standard action items', () => {
     render(<Wrapper />);
 
-    expect(screen.getByText('Workspace')).toBeInTheDocument();
+    expect(screen.getByText('sidebar.item.workspace')).toBeInTheDocument();
     expect(screen.getByText('sidebar.item.reload')).toBeInTheDocument();
     expect(screen.getByText('sidebar.item.copyCurrentUrl')).toBeInTheDocument();
     expect(screen.getByText('sidebar.item.openDevTools')).toBeInTheDocument();

--- a/src/ui/components/WorkspaceContextMenu/index.spec.tsx
+++ b/src/ui/components/WorkspaceContextMenu/index.spec.tsx
@@ -10,7 +10,7 @@ import {
   SIDE_BAR_SERVER_REMOVE,
   OPEN_SERVER_INFO_MODAL,
 } from '../../actions';
-import { render, screen, userEvent } from '../../test-utils';
+import { fireEvent, render, screen, userEvent } from '../../test-utils';
 
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -69,18 +69,49 @@ describe('WorkspaceContextMenu', () => {
     mockDispatch.mockClear();
   });
 
-  it('renders the workspace title and the standard action items', () => {
+  it('does not render the workspace title', () => {
     render(<Wrapper />);
 
-    expect(screen.getByText('sidebar.item.workspace')).toBeInTheDocument();
+    expect(
+      screen.queryByText('sidebar.item.workspace')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the standard action items in the redesigned order', () => {
+    render(<Wrapper />);
+
     expect(screen.getByText('sidebar.item.reload')).toBeInTheDocument();
-    expect(screen.getByText('sidebar.item.copyCurrentUrl')).toBeInTheDocument();
-    expect(screen.getByText('sidebar.item.openDevTools')).toBeInTheDocument();
-    expect(screen.getByText('sidebar.item.serverInfo')).toBeInTheDocument();
     expect(
       screen.getByText('sidebar.item.reloadClearingCache')
     ).toBeInTheDocument();
+    expect(screen.getByText('sidebar.item.copyCurrentUrl')).toBeInTheDocument();
+    expect(screen.getByText('sidebar.item.openDevTools')).toBeInTheDocument();
+    expect(screen.getByText('sidebar.item.serverInfo')).toBeInTheDocument();
     expect(screen.getByText('sidebar.item.remove')).toBeInTheDocument();
+
+    const labels = [
+      'sidebar.item.reload',
+      'sidebar.item.reloadClearingCache',
+      'sidebar.item.copyCurrentUrl',
+      'sidebar.item.openDevTools',
+      'sidebar.item.serverInfo',
+      'sidebar.item.remove',
+    ];
+    for (let i = 0; i < labels.length - 1; i += 1) {
+      const current = screen.getByText(labels[i]);
+      const next = screen.getByText(labels[i + 1]);
+      expect(
+        current.compareDocumentPosition(next) & Node.DOCUMENT_POSITION_FOLLOWING
+      ).toBeTruthy();
+    }
+  });
+
+  it('does not render option icons', () => {
+    const { container } = render(<Wrapper showAddWorkspace />);
+
+    expect(
+      container.querySelector('.rcx-option__icon')
+    ).not.toBeInTheDocument();
   });
 
   it('does not render the Add workspace option by default', () => {
@@ -113,6 +144,50 @@ describe('WorkspaceContextMenu', () => {
 
     const removeOption = screen.getByText('sidebar.item.remove').closest('li');
     expect(removeOption).toHaveClass('rcx-option--danger');
+  });
+
+  it('does not render a divider immediately before Remove', () => {
+    const { container } = render(<Wrapper />);
+
+    const removeOption = screen.getByText('sidebar.item.remove').closest('li');
+    expect(removeOption?.previousElementSibling?.tagName).not.toBe('HR');
+    expect(container.querySelectorAll('hr')).toHaveLength(0);
+  });
+
+  it('renders a divider before Add workspace when shown', () => {
+    const { container } = render(<Wrapper showAddWorkspace />);
+
+    expect(container.querySelectorAll('hr')).toHaveLength(1);
+  });
+
+  it('calls onClose when clicking the backdrop', () => {
+    const onClose = jest.fn();
+    const { container } = render(<Wrapper onClose={onClose} />);
+
+    const backdrop = container.querySelector('[role="presentation"]');
+    expect(backdrop).not.toBeNull();
+
+    fireEvent.mouseDown(backdrop as Element);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when pressing Escape', () => {
+    const onClose = jest.fn();
+    render(<Wrapper onClose={onClose} />);
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose on window blur', () => {
+    const onClose = jest.fn();
+    render(<Wrapper onClose={onClose} />);
+
+    fireEvent(window, new Event('blur'));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it('dispatches reload with the url when Reload is clicked', async () => {

--- a/src/ui/components/WorkspaceContextMenu/index.tsx
+++ b/src/ui/components/WorkspaceContextMenu/index.tsx
@@ -105,7 +105,7 @@ const WorkspaceContextMenu = ({
     <>
       <Dropdown reference={reference} ref={target} placement={placement}>
         <Box display='flex' className='rcx-option__title'>
-          Workspace
+          {t('sidebar.item.workspace')}
         </Box>
         <Option
           onClick={() => handleActionDropdownClick(SIDE_BAR_SERVER_RELOAD, url)}

--- a/src/ui/components/WorkspaceContextMenu/index.tsx
+++ b/src/ui/components/WorkspaceContextMenu/index.tsx
@@ -1,13 +1,11 @@
 import {
-  Box,
   Dropdown,
   Option,
-  OptionIcon,
   OptionContent,
   OptionDivider,
 } from '@rocket.chat/fuselage';
 import type { RefObject } from 'react';
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { SupportedVersions } from '../../../servers/supportedVersions/types';
@@ -23,6 +21,7 @@ import {
 } from '../../actions';
 import ServerInfoDropdown from '../SideBar/ServerInfoDropdown';
 import { useDropdownVisibility } from '../SideBar/useDropdownVisibility';
+import { Backdrop } from './styles';
 
 type ServerActionType =
   | typeof SIDE_BAR_SERVER_RELOAD
@@ -101,24 +100,42 @@ const WorkspaceContextMenu = ({
     onClose();
   };
 
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') onClose();
+    };
+    const handleBlur = (): void => onClose();
+
+    document.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('blur', handleBlur);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('blur', handleBlur);
+    };
+  }, [onClose]);
+
   return (
     <>
+      <Backdrop role='presentation' onMouseDown={onClose} />
       <Dropdown reference={reference} ref={target} placement={placement}>
-        <Box display='flex' className='rcx-option__title'>
-          {t('sidebar.item.workspace')}
-        </Box>
         <Option
           onClick={() => handleActionDropdownClick(SIDE_BAR_SERVER_RELOAD, url)}
         >
-          <OptionIcon name='refresh' />
           <OptionContent>{t('sidebar.item.reload')}</OptionContent>
+        </Option>
+        <Option
+          onClick={() =>
+            handleActionDropdownClick(SIDE_BAR_SERVER_FORCE_RELOAD, url)
+          }
+        >
+          <OptionContent>{t('sidebar.item.reloadClearingCache')}</OptionContent>
         </Option>
         <Option
           onClick={() =>
             handleActionDropdownClick(SIDE_BAR_SERVER_COPY_URL, url)
           }
         >
-          <OptionIcon name='copy' />
           <OptionContent>{t('sidebar.item.copyCurrentUrl')}</OptionContent>
         </Option>
         <Option
@@ -126,7 +143,6 @@ const WorkspaceContextMenu = ({
             handleActionDropdownClick(SIDE_BAR_SERVER_OPEN_DEV_TOOLS, url)
           }
         >
-          <OptionIcon name='code-block' />
           <OptionContent>{t('sidebar.item.openDevTools')}</OptionContent>
         </Option>
         <Option
@@ -135,18 +151,8 @@ const WorkspaceContextMenu = ({
           onMouseLeave={() => toggleServerInfo(false)}
           onClick={handleOpenServerInfoModal}
         >
-          <OptionIcon name='info' />
           <OptionContent>{t('sidebar.item.serverInfo')}</OptionContent>
         </Option>
-        <Option
-          onClick={() =>
-            handleActionDropdownClick(SIDE_BAR_SERVER_FORCE_RELOAD, url)
-          }
-        >
-          <OptionIcon name='refresh' />
-          <OptionContent>{t('sidebar.item.reloadClearingCache')}</OptionContent>
-        </Option>
-        <OptionDivider />
         <Option
           onClick={(event) => {
             event?.stopPropagation();
@@ -154,14 +160,12 @@ const WorkspaceContextMenu = ({
           }}
           variant='danger'
         >
-          <OptionIcon name='trash' />
           <OptionContent>{t('sidebar.item.remove')}</OptionContent>
         </Option>
         {showAddWorkspace && (
           <>
             <OptionDivider />
             <Option onClick={handleAddWorkspaceClick}>
-              <OptionIcon name='plus' />
               <OptionContent>{t('sidebar.item.addWorkspace')}</OptionContent>
             </Option>
           </>

--- a/src/ui/components/WorkspaceContextMenu/index.tsx
+++ b/src/ui/components/WorkspaceContextMenu/index.tsx
@@ -1,0 +1,187 @@
+import {
+  Box,
+  Dropdown,
+  Option,
+  OptionIcon,
+  OptionContent,
+  OptionDivider,
+} from '@rocket.chat/fuselage';
+import type { RefObject } from 'react';
+import { useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { SupportedVersions } from '../../../servers/supportedVersions/types';
+import { dispatch } from '../../../store';
+import {
+  SIDE_BAR_SERVER_RELOAD,
+  SIDE_BAR_SERVER_COPY_URL,
+  SIDE_BAR_SERVER_OPEN_DEV_TOOLS,
+  SIDE_BAR_SERVER_FORCE_RELOAD,
+  SIDE_BAR_SERVER_REMOVE,
+  SIDE_BAR_ADD_NEW_SERVER_CLICKED,
+  OPEN_SERVER_INFO_MODAL,
+} from '../../actions';
+import ServerInfoDropdown from '../SideBar/ServerInfoDropdown';
+import { useDropdownVisibility } from '../SideBar/useDropdownVisibility';
+
+type ServerActionType =
+  | typeof SIDE_BAR_SERVER_RELOAD
+  | typeof SIDE_BAR_SERVER_COPY_URL
+  | typeof SIDE_BAR_SERVER_OPEN_DEV_TOOLS
+  | typeof SIDE_BAR_SERVER_FORCE_RELOAD
+  | typeof SIDE_BAR_SERVER_REMOVE;
+
+type WorkspaceContextMenuProps = {
+  reference: RefObject<HTMLElement | null>;
+  target: RefObject<HTMLElement | null>;
+  url: string;
+  version?: string;
+  exchangeUrl?: string;
+  isSupportedVersion?: boolean;
+  supportedVersionsSource?: 'server' | 'cloud' | 'builtin';
+  supportedVersionsFetchState?: 'idle' | 'loading' | 'success' | 'error';
+  supportedVersions?: SupportedVersions;
+  onClose: () => void;
+  showAddWorkspace?: boolean;
+  placement?: 'right-start' | 'bottom-start';
+};
+
+const WorkspaceContextMenu = ({
+  reference,
+  target,
+  url,
+  version,
+  exchangeUrl,
+  isSupportedVersion,
+  supportedVersionsSource,
+  supportedVersionsFetchState,
+  supportedVersions,
+  onClose,
+  showAddWorkspace,
+  placement = 'right-start',
+}: WorkspaceContextMenuProps) => {
+  const { t } = useTranslation();
+
+  const serverInfoReference = useRef(null);
+  const serverInfoTarget = useRef(null);
+
+  const { isVisible: isServerInfoVisible, toggle: toggleServerInfo } =
+    useDropdownVisibility({
+      reference: serverInfoReference,
+      target: serverInfoTarget,
+    });
+
+  const handleActionDropdownClick = (
+    action: ServerActionType,
+    serverUrl: string
+  ): void => {
+    if (action) dispatch({ type: action, payload: serverUrl });
+    onClose();
+  };
+
+  const handleOpenServerInfoModal = (): void => {
+    dispatch({
+      type: OPEN_SERVER_INFO_MODAL,
+      payload: {
+        url,
+        version,
+        exchangeUrl,
+        isSupportedVersion,
+        supportedVersionsSource,
+        supportedVersionsFetchState,
+        supportedVersions,
+      },
+    });
+    onClose();
+    toggleServerInfo(false);
+  };
+
+  const handleAddWorkspaceClick = (): void => {
+    dispatch({ type: SIDE_BAR_ADD_NEW_SERVER_CLICKED });
+    onClose();
+  };
+
+  return (
+    <>
+      <Dropdown reference={reference} ref={target} placement={placement}>
+        <Box display='flex' className='rcx-option__title'>
+          Workspace
+        </Box>
+        <Option
+          onClick={() => handleActionDropdownClick(SIDE_BAR_SERVER_RELOAD, url)}
+        >
+          <OptionIcon name='refresh' />
+          <OptionContent>{t('sidebar.item.reload')}</OptionContent>
+        </Option>
+        <Option
+          onClick={() =>
+            handleActionDropdownClick(SIDE_BAR_SERVER_COPY_URL, url)
+          }
+        >
+          <OptionIcon name='copy' />
+          <OptionContent>{t('sidebar.item.copyCurrentUrl')}</OptionContent>
+        </Option>
+        <Option
+          onClick={() =>
+            handleActionDropdownClick(SIDE_BAR_SERVER_OPEN_DEV_TOOLS, url)
+          }
+        >
+          <OptionIcon name='code-block' />
+          <OptionContent>{t('sidebar.item.openDevTools')}</OptionContent>
+        </Option>
+        <Option
+          ref={serverInfoReference}
+          onMouseEnter={() => toggleServerInfo(true)}
+          onMouseLeave={() => toggleServerInfo(false)}
+          onClick={handleOpenServerInfoModal}
+        >
+          <OptionIcon name='info' />
+          <OptionContent>{t('sidebar.item.serverInfo')}</OptionContent>
+        </Option>
+        <Option
+          onClick={() =>
+            handleActionDropdownClick(SIDE_BAR_SERVER_FORCE_RELOAD, url)
+          }
+        >
+          <OptionIcon name='refresh' />
+          <OptionContent>{t('sidebar.item.reloadClearingCache')}</OptionContent>
+        </Option>
+        <OptionDivider />
+        <Option
+          onClick={(event) => {
+            event?.stopPropagation();
+            handleActionDropdownClick(SIDE_BAR_SERVER_REMOVE, url);
+          }}
+          variant='danger'
+        >
+          <OptionIcon name='trash' />
+          <OptionContent>{t('sidebar.item.remove')}</OptionContent>
+        </Option>
+        {showAddWorkspace && (
+          <>
+            <OptionDivider />
+            <Option onClick={handleAddWorkspaceClick}>
+              <OptionIcon name='plus' />
+              <OptionContent>{t('sidebar.item.addWorkspace')}</OptionContent>
+            </Option>
+          </>
+        )}
+      </Dropdown>
+      {isServerInfoVisible && (
+        <ServerInfoDropdown
+          reference={serverInfoReference}
+          target={serverInfoTarget}
+          url={url}
+          version={version}
+          exchangeUrl={exchangeUrl}
+          supportedVersions={supportedVersions}
+          isSupportedVersion={isSupportedVersion}
+          supportedVersionsSource={supportedVersionsSource}
+          supportedVersionsFetchState={supportedVersionsFetchState}
+        />
+      )}
+    </>
+  );
+};
+
+export default WorkspaceContextMenu;

--- a/src/ui/components/WorkspaceContextMenu/styles.tsx
+++ b/src/ui/components/WorkspaceContextMenu/styles.tsx
@@ -1,0 +1,8 @@
+import styled from '@emotion/styled';
+
+export const Backdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 9998;
+  -webkit-app-region: no-drag;
+`;

--- a/src/ui/main/menuBar.spec.ts
+++ b/src/ui/main/menuBar.spec.ts
@@ -1,0 +1,195 @@
+import type { MenuItemConstructorOptions } from 'electron';
+
+import type { Server } from '../../servers/common';
+import type { RootState } from '../../store/rootReducer';
+import { selectMenuBarTemplate, selectMenuBarTemplateAsJson } from './menuBar';
+
+jest.mock('electron', () => ({
+  app: {
+    name: 'Rocket.Chat',
+    commandLine: { hasSwitch: jest.fn(() => false) },
+    getPath: jest.fn(() => ''),
+  },
+  shell: {
+    showItemInFolder: jest.fn(),
+  },
+  BrowserWindow: {
+    getAllWindows: jest.fn(() => []),
+    getFocusedWindow: jest.fn(() => null),
+  },
+  Menu: {
+    buildFromTemplate: jest.fn(),
+    setApplicationMenu: jest.fn(),
+  },
+}));
+
+jest.mock('i18next', () => ({
+  t: (key: string) => key,
+}));
+
+jest.mock('../../app/main/app', () => ({
+  relaunchApp: jest.fn(),
+}));
+
+jest.mock('../../utils/browserLauncher', () => ({
+  openExternal: jest.fn(),
+}));
+
+jest.mock('../../videoCallWindow/ipc', () => ({
+  openVideoCallWebviewDevTools: jest.fn(),
+}));
+
+jest.mock('./dialogs', () => ({
+  askForAppDataReset: jest.fn(),
+}));
+
+jest.mock('./rootWindow', () => ({
+  getRootWindow: jest.fn(),
+}));
+
+jest.mock('./serverView', () => ({
+  getWebContentsByServerUrl: jest.fn(),
+}));
+
+jest.mock('../../store', () => ({
+  dispatch: jest.fn(),
+  select: jest.fn(),
+  Service: class Service {
+    protected initialize(): void {}
+
+    setUp(): void {
+      this.initialize();
+    }
+  },
+}));
+
+const createServer = (url: string, title: string): Server => ({
+  url,
+  title,
+});
+
+const createState = (overrides: Partial<RootState> = {}): RootState =>
+  ({
+    servers: [],
+    currentView: 'downloads',
+    isTrayIconEnabled: true,
+    isMenuBarEnabled: true,
+    isAddNewServersEnabled: true,
+    isShowWindowOnUnreadChangedEnabled: false,
+    isDeveloperModeEnabled: false,
+    isVideoCallDevtoolsAutoOpenEnabled: false,
+    navigationLayout: 'tabs',
+    rootWindowState: {
+      focused: true,
+      visible: true,
+      maximized: false,
+      minimized: false,
+      fullscreen: false,
+      normal: true,
+      bounds: { x: undefined, y: undefined, width: 1000, height: 600 },
+    },
+    ...overrides,
+  }) as RootState;
+
+const findMenu = (
+  template: MenuItemConstructorOptions[],
+  id: string
+): MenuItemConstructorOptions => {
+  const menu = template.find((item) => item.id === id);
+  if (!menu) {
+    throw new Error(`Menu with id "${id}" not found`);
+  }
+  return menu;
+};
+
+describe('ui/main/menuBar', () => {
+  describe('selectMenuBarTemplateAsJson', () => {
+    it('differs between a 1-server state and a 2-server state', () => {
+      const oneServerState = createState({
+        servers: [createServer('https://one.example', 'One')],
+      });
+      const twoServerState = createState({
+        servers: [
+          createServer('https://one.example', 'One'),
+          createServer('https://two.example', 'Two'),
+        ],
+      });
+
+      const oneServerJson = selectMenuBarTemplateAsJson(oneServerState);
+      const twoServerJson = selectMenuBarTemplateAsJson(twoServerState);
+
+      expect(oneServerJson).toBeDefined();
+      expect(twoServerJson).toBeDefined();
+      expect(oneServerJson).not.toEqual(twoServerJson);
+    });
+  });
+
+  describe('Window menu', () => {
+    it('lists per-server items with accelerators matching server order', () => {
+      const state = createState({
+        servers: [
+          createServer('https://one.example', 'One'),
+          createServer('https://two.example', 'Two'),
+          createServer('https://three.example', 'Three'),
+        ],
+      });
+
+      const template = selectMenuBarTemplate(state);
+      const windowMenu = findMenu(
+        template as MenuItemConstructorOptions[],
+        'windowMenu'
+      );
+      const submenu = windowMenu.submenu as MenuItemConstructorOptions[];
+
+      const serverItems = state.servers.map((server) =>
+        submenu.find((item) => item.id === server.url)
+      );
+
+      serverItems.forEach((item, index) => {
+        expect(item).toBeDefined();
+        expect(item?.accelerator).toBe(`CommandOrControl+${index + 1}`);
+      });
+    });
+  });
+
+  describe('View menu', () => {
+    it('contains workspaceTabs and workspaceBar items with checked state following navigationLayout', () => {
+      const tabsState = createState({ navigationLayout: 'tabs' });
+      const sidebarState = createState({ navigationLayout: 'sidebar' });
+
+      const tabsTemplate = selectMenuBarTemplate(tabsState);
+      const sidebarTemplate = selectMenuBarTemplate(sidebarState);
+
+      const tabsViewMenu = findMenu(
+        tabsTemplate as MenuItemConstructorOptions[],
+        'viewMenu'
+      );
+      const sidebarViewMenu = findMenu(
+        sidebarTemplate as MenuItemConstructorOptions[],
+        'viewMenu'
+      );
+
+      const tabsSubmenu = tabsViewMenu.submenu as MenuItemConstructorOptions[];
+      const sidebarSubmenu =
+        sidebarViewMenu.submenu as MenuItemConstructorOptions[];
+
+      const workspaceTabsInTabsState = tabsSubmenu.find(
+        (item) => item.id === 'workspaceTabs'
+      );
+      const workspaceBarInTabsState = tabsSubmenu.find(
+        (item) => item.id === 'workspaceBar'
+      );
+      expect(workspaceTabsInTabsState?.checked).toBe(true);
+      expect(workspaceBarInTabsState?.checked).toBe(false);
+
+      const workspaceTabsInSidebarState = sidebarSubmenu.find(
+        (item) => item.id === 'workspaceTabs'
+      );
+      const workspaceBarInSidebarState = sidebarSubmenu.find(
+        (item) => item.id === 'workspaceBar'
+      );
+      expect(workspaceTabsInSidebarState?.checked).toBe(false);
+      expect(workspaceBarInSidebarState?.checked).toBe(true);
+    });
+  });
+});

--- a/src/ui/main/menuBar.ts
+++ b/src/ui/main/menuBar.ts
@@ -866,7 +866,7 @@ export const createHelpMenu = createSelector(
   })
 );
 
-const selectMenuBarTemplate = createSelector(
+export const selectMenuBarTemplate = createSelector(
   [
     createAppMenu,
     createEditMenu,
@@ -877,9 +877,9 @@ const selectMenuBarTemplate = createSelector(
   (...menus) => menus
 );
 
-const selectMenuBarTemplateAsJson = createSelector(
-  (_state: any) => selectMenuBarTemplate,
-  (template: unknown) => JSON.stringify(template)
+export const selectMenuBarTemplateAsJson = createSelector(
+  selectMenuBarTemplate,
+  (template) => JSON.stringify(template)
 );
 
 const createRocketChatMenu = createSelector(

--- a/src/ui/main/rootWindow.ts
+++ b/src/ui/main/rootWindow.ts
@@ -99,7 +99,7 @@ const getEnableVibrancy = (): boolean => {
 
 const getInitialBackgroundColor = (enableVibrancy: boolean): string => {
   if (enableVibrancy) return '#00000000';
-  return nativeTheme.shouldUseDarkColors ? '#2f343d' : '#ffffff';
+  return '#2f343d';
 };
 
 export const createRootWindow = (): void => {

--- a/src/ui/main/rootWindow.ts
+++ b/src/ui/main/rootWindow.ts
@@ -110,7 +110,7 @@ export const createRootWindow = (): void => {
     minWidth: 400,
     minHeight: 400,
     titleBarStyle: platformTitleBarStyle,
-    ...(isMac ? { trafficLightPosition: { x: 16, y: 9 } } : {}),
+    ...(isMac ? { trafficLightPosition: { x: 16, y: 11 } } : {}),
     backgroundColor: getInitialBackgroundColor(enableVibrancy),
     show: false,
     webPreferences,
@@ -355,7 +355,7 @@ export const setupRootWindow = (): void => {
             async (navigationLayout) => {
               await safeWindowOperation((browserWindow) => {
                 browserWindow.setWindowButtonPosition(
-                  navigationLayout === 'tabs' ? { x: 16, y: 9 } : null
+                  navigationLayout === 'tabs' ? { x: 16, y: 11 } : null
                 );
               }, 'Window button position update');
             }

--- a/src/ui/main/rootWindow.ts
+++ b/src/ui/main/rootWindow.ts
@@ -110,6 +110,7 @@ export const createRootWindow = (): void => {
     minWidth: 400,
     minHeight: 400,
     titleBarStyle: platformTitleBarStyle,
+    ...(isMac ? { trafficLightPosition: { x: 16, y: 9 } } : {}),
     backgroundColor: getInitialBackgroundColor(enableVibrancy),
     show: false,
     webPreferences,
@@ -354,7 +355,7 @@ export const setupRootWindow = (): void => {
             async (navigationLayout) => {
               await safeWindowOperation((browserWindow) => {
                 browserWindow.setWindowButtonPosition(
-                  navigationLayout === 'tabs' ? { x: 16, y: 16 } : null
+                  navigationLayout === 'tabs' ? { x: 16, y: 9 } : null
                 );
               }, 'Window button position update');
             }

--- a/src/ui/main/serverView/index.ts
+++ b/src/ui/main/serverView/index.ts
@@ -7,15 +7,13 @@ import type {
   Event,
   Input,
   MediaAccessPermissionRequest,
-  MenuItemConstructorOptions,
   OpenExternalPermissionRequest,
   UploadFile,
   UploadRawData,
   WebContents,
   WebPreferences,
 } from 'electron';
-import { app, clipboard, Menu, webContents } from 'electron';
-import i18next from 'i18next';
+import { app, clipboard, webContents } from 'electron';
 
 import { setupPreloadReload } from '../../../app/main/dev';
 import { handle } from '../../../ipc/main';
@@ -28,8 +26,6 @@ import { dispatch, listen, select } from '../../../store';
 import { openExternal } from '../../../utils/browserLauncher';
 import {
   LOADING_ERROR_VIEW_RELOAD_SERVER_CLICKED,
-  SIDE_BAR_ADD_NEW_SERVER_CLICKED,
-  SIDE_BAR_CONTEXT_MENU_TRIGGERED,
   SIDE_BAR_REMOVE_SERVER_CLICKED,
   WEBVIEW_READY,
   WEBVIEW_DID_FAIL_LOAD,
@@ -50,8 +46,6 @@ import { handleMediaPermissionRequest } from '../mediaPermissions';
 import { getRootWindow } from '../rootWindow';
 import { isMarkdownViewerDownloadUrl } from './isMarkdownViewerDownloadUrl';
 import { createPopupMenuForServerView } from './popupMenu';
-
-const t = i18next.t.bind(i18next);
 
 const webContentsByServerUrl = new Map<Server['url'], WebContents>();
 
@@ -594,87 +588,6 @@ export const attachGuestWebContentsEvents = async (): Promise<void> => {
     dispatch({
       type: SIDE_BAR_REMOVE_SERVER_CLICKED,
       payload: action.payload,
-    });
-  });
-
-  listen(SIDE_BAR_CONTEXT_MENU_TRIGGERED, (action) => {
-    const { payload: serverUrl } = action;
-    const isAddNewServersEnabled = select(
-      ({ isAddNewServersEnabled }) => isAddNewServersEnabled
-    );
-
-    const menuTemplate: MenuItemConstructorOptions[] = [
-      {
-        label: t('sidebar.item.reload'),
-        click: () => {
-          const guestWebContents = getWebContentsByServerUrl(serverUrl);
-          if (!guestWebContents) {
-            return;
-          }
-          guestWebContents.loadURL(serverUrl).catch((error) => {
-            console.error('Failed to load URL for guestWebContents:', error);
-          });
-          if (serverUrl) {
-            dispatch({
-              type: WEBVIEW_SERVER_RELOADED,
-              payload: { url: serverUrl },
-            });
-          }
-        },
-      },
-      {
-        label: t('sidebar.item.remove'),
-        click: () => {
-          dispatch({
-            type: SIDE_BAR_REMOVE_SERVER_CLICKED,
-            payload: serverUrl,
-          });
-        },
-      },
-      { type: 'separator' },
-      {
-        label: t('sidebar.item.openDevTools'),
-        click: () => {
-          const guestWebContents = getWebContentsByServerUrl(serverUrl);
-          guestWebContents?.openDevTools();
-        },
-      },
-      {
-        label: t('sidebar.item.copyCurrentUrl'),
-        click: async () => {
-          const guestWebContents = getWebContentsByServerUrl(serverUrl);
-          const currentUrl = guestWebContents?.getURL();
-          clipboard.writeText(currentUrl || '');
-        },
-      },
-      {
-        label: t('sidebar.item.reloadClearingCache'),
-        click: async () => {
-          const guestWebContents = getWebContentsByServerUrl(serverUrl);
-          if (!guestWebContents) {
-            return;
-          }
-          dispatch({
-            type: CLEAR_CACHE_TRIGGERED,
-            payload: guestWebContents.id,
-          });
-        },
-      },
-      ...(isAddNewServersEnabled
-        ? [
-            { type: 'separator' as const },
-            {
-              label: t('sidebar.item.addWorkspace'),
-              click: () => {
-                dispatch({ type: SIDE_BAR_ADD_NEW_SERVER_CLICKED });
-              },
-            },
-          ]
-        : []),
-    ];
-    const menu = Menu.buildFromTemplate(menuTemplate);
-    menu.popup({
-      window: rootWindow,
     });
   });
 


### PR DESCRIPTION
## Summary

Addresses design review feedback on the workspace tabs feature (CORE-2312), covering keyboard shortcuts, tab visuals, labels, and theming.

## Changes

- **Rebuild application menu on state change** — a selector regression caused the application menu to be built only once at startup: the reselect input returned the selector function itself, so the serialized template was always `undefined` and the store watcher never fired again. Workspaces added at runtime never received their `Cmd/Ctrl+1..9` accelerators and View-menu checkmarks went stale. Fixed the selector and added a spec that locks the regression (it fails against the previous selector form).
- **Chrome-style tab sizing** — tabs hug their content instead of stretching, and the workspace name truncates with ellipsis before being dropped near the minimum width. Compact mode (name/shortcut hidden) is derived from the measured strip width via the existing ResizeObserver layout hook instead of CSS container queries, whose size containment conflicts with content-based flex sizing.
- **Design-spec metrics** — titlebar strip 32px, tabs 28px, 8px gap/leading padding, per the Figma titlebar spec. macOS traffic lights re-centered on the 32px bar (the previous position was tuned for the taller strip).
- **Typography fix** — workspace names rendered in Chromium's UA form-control font (Arial) because tabs are `button` elements that don't inherit the body font; `font-family: inherit` restores Inter. Name label uses micro typography (10px / 700 / 12px line-height).
- **Tab strip visual polish** — add-workspace button aligned with the tab row; unread badge no longer clips 2+ digit counts.
- **Tab context menu parity** — right-clicking a workspace tab opened a native OS menu while the sidebar shows a custom Fuselage dropdown; the sidebar menu is extracted into a shared `WorkspaceContextMenu` used by both surfaces (tab variant appends Add workspace). The unused native-menu path is removed.
- **Sentence-case labels** — "Workspace tabs" / "Workspace bar" in settings and menu strings (English source; other locales sync via translation pipeline).
- **Dark theme only for app chrome** — the shell always renders the dark palette and the root window background is pinned to the dark constant (vibrancy branch unchanged). The theme appearance section is removed from Settings; the reducer and persisted preference remain so the setting can be restored without migration.
- **Dev tooling** — the rollup dev watcher forwards `ELECTRON_EXTRA_LAUNCH_ARGS` to the spawned Electron, enabling DevTools-protocol-driven visual verification of the running app.

## Testing

- `yarn lint`, `npx tsc --noEmit`, `yarn test`: 155 suites / 1643+ tests passing
- New spec `src/ui/main/menuBar.spec.ts` covers menu rebuild, per-workspace accelerators, and View-menu toggle state
- Updated TabBar and Shell specs cover tab sizing, compact mode, add-button alignment, badge behavior, and forced dark theme
- Visual verification on macOS against the Figma spec via DevTools protocol: measured strip 32px, tab 28px, label Inter 10px/700, traffic-light center 15.75px vs 16px bar center
- Windows runtime not exercised (menu structure covered by unit spec)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Workspace switcher labels are now consistently sentence-cased (e.g., “Workspace tabs/bar”).
  * Right-clicking a workspace opens a dedicated Workspace menu with reload, copy URL, dev tools, server info, force reload, and remove; “add workspace” appears when available.
  * Tab bar now automatically enters a compact mode on smaller widths, refining spacing and badges and hiding labels/shortcuts when compact.
  * Theme visuals are standardized: palette is forced to dark, and when vibrancy is disabled a fixed background color is used.
* **Settings**
  * Removed the “Theme appearance” option from General settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
