### PR TITLE
fix: keep screen picker sources stable under Electron 42 macOS capture stack

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,6 +1,30 @@
 # Known Issues
 
+## Electron 42 macOS `desktopCapturer.getSources()` — 3s cap, empty results under repeated calls
+
+- Status: Confirmed (Electron 42.5.0, macOS, hardware measurement 2026-07-14).
+- Symptom: Screen picker intermittently shows "No windows found" / "No screens found"
+  seconds after listing sources; screen share denied with "selected source no longer
+  available" right after the user picks a valid source.
+- Root cause: Electron's macOS ScreenCaptureKit rewrite made `getSources()` unbounded-slow
+  (~24s observed under Electron 41.9), then upstream bounded it at ~3s returning whatever
+  arrived (hang fix, electron/electron#51128 lineage; DCHECK crash fix electron/electron#50960
+  shipped in 42.0.1). Under Electron 42.5.0, back-to-back calls return `[]` ~75% of the time
+  and mostly-empty thumbnails otherwise. Combined `types: ['window','screen']` calls always
+  hit the 3s cap; `['screen']`-only completes in ~700ms and never flakes; paced (≥4s gap)
+  alternating per-type calls never return empty.
+- Workaround (implemented in src/screenSharing/desktopCapturerCache.ts): per-type cache
+  buckets, ≥4s cooldown between enumerations, empty result never overwrites a non-empty
+  bucket, per-id thumbnail merge; post-selection validation reads the cache instead of
+  re-enumerating (src/screenSharing/ScreenSharingRequestTracker.ts).
+- Follow-up: adopt `setDisplayMediaRequestHandler(..., { useSystemPicker: true })` (native
+  SCContentSharingPicker) on macOS 15+ — eliminates `getSources` from the flow entirely.
+  Experimental; gate on `isDisplayMediaSystemPickerAvailable()`; audio caveat electron#44685.
+- Affected files: src/screenSharing/desktopCapturerCache.ts,
+  src/screenSharing/ScreenSharingRequestTracker.ts, src/screenSharing/screenSharePicker.tsx.
+
 ## Fuselage modern `Select` portals focus to body — breaks `:hover`/`:focus-within` on parent rows
+
 - Status: Confirmed (fuselage 0.78, react-aria 3.48).
 - Symptom: A CSS row highlight on a Fuselage `Field` using `:hover` or `:focus-within`
   disappears while a child `<Select>` dropdown is open, even with the pointer over the row.
@@ -20,6 +44,7 @@
   Fuselage `Select`.
 
 ## RTL auto-cleanup vs manual `document.body.innerHTML = ''` in `afterEach` orphans portal anchors
+
 - Status: Confirmed (RTL 14.3.1, @kayahr/jest-electron-runner, single shared `src/.jest/setup.ts`).
 - Symptom: A renderer spec that renders a portal/anchor component (e.g. TooltipProvider ->
   TooltipPortal -> createAnchor's `#tooltip-root`) crashes the ENTIRE `yarn test:coverage` run with
@@ -41,6 +66,7 @@
   src/ui/components/utils/TooltipPortal.tsx, src/.jest/setup.ts.
 
 ## No certificate pinning for the auto-updater (CORE-1128) — accepted risk, not a gap
+
 - Status: Resolved as risk acceptance (2022 pentest finding CORE-1128; no code change).
 - Symptom: N/A — this documents a deliberate decision, not an observed bug.
 - Context: CORE-1128 flagged "Missing Certificate Pinning for Connections and autoUpdater

--- a/src/screenSharing/ScreenSharingRequestTracker.ts
+++ b/src/screenSharing/ScreenSharingRequestTracker.ts
@@ -1,6 +1,7 @@
 import type { Event } from 'electron';
 import { desktopCapturer, ipcMain } from 'electron';
 
+import { getCachedSources } from './desktopCapturerCache';
 import type { DisplayMediaCallback } from './screenPicker/types';
 
 const DEFAULT_TIMEOUT = 60000;
@@ -157,6 +158,27 @@ export class ScreenSharingRequestTracker {
       }
 
       try {
+        const cachedSources = getCachedSources();
+
+        if (cachedSources.length > 0) {
+          const selectedSource = cachedSources.find((s) => s.id === sourceId);
+
+          if (!selectedSource) {
+            console.warn(
+              `${this.label}: selected source no longer available:`,
+              sourceId
+            );
+            entry.cb(null);
+            this.finishActive(entry);
+            return;
+          }
+
+          entry.cb({ video: selectedSource });
+          this.finishActive(entry);
+          return;
+        }
+
+        // Cache is empty: fall back to a single direct enumeration attempt.
         const sources = await desktopCapturer.getSources({
           types: ['window', 'screen'],
         });

--- a/src/screenSharing/desktopCapturerCache.ts
+++ b/src/screenSharing/desktopCapturerCache.ts
@@ -2,116 +2,192 @@ import { desktopCapturer } from 'electron';
 
 import { handle } from '../ipc/main';
 
-const DESKTOP_CAPTURER_STALE_THRESHOLD = 3000;
-const SOURCE_VALIDATION_CACHE_TTL = 30000;
+const STALE_THRESHOLD = 5000;
+const ENUMERATION_COOLDOWN = 4000;
 
-let desktopCapturerCache: {
+type Bucket = {
   sources: Electron.DesktopCapturerSource[];
   timestamp: number;
-} | null = null;
+} | null;
 
-let desktopCapturerPromise: Promise<Electron.DesktopCapturerSource[]> | null =
-  null;
+type BucketType = 'screens' | 'windows';
 
-const sourceValidationCache: Set<string> = new Set();
-let sourceValidationCacheTimestamp = 0;
+const buckets: Record<BucketType, Bucket> = {
+  screens: null,
+  windows: null,
+};
+
+let enumerationPromise: Promise<void> | null = null;
+let lastEnumerationCompletedAt = 0;
+let warnedEmptyOnce: Record<BucketType, boolean> = {
+  screens: false,
+  windows: false,
+};
+
+const typeForBucket = (bucket: BucketType): Electron.SourcesOptions['types'] =>
+  bucket === 'screens' ? ['screen'] : ['window'];
+
+const isStale = (bucket: Bucket): boolean =>
+  !bucket || Date.now() - bucket.timestamp > STALE_THRESHOLD;
+
+const cooldownElapsed = (): boolean =>
+  Date.now() - lastEnumerationCompletedAt >= ENUMERATION_COOLDOWN;
+
+const mergeWithPrevious = (
+  bucketType: BucketType,
+  incoming: Electron.DesktopCapturerSource[]
+): Electron.DesktopCapturerSource[] => {
+  const previous = buckets[bucketType];
+  const previousById = new Map(
+    (previous?.sources ?? []).map((source) => [source.id, source])
+  );
+
+  const merged: Electron.DesktopCapturerSource[] = [];
+  incoming.forEach((source) => {
+    if (!source.name || source.name.trim() === '') {
+      return;
+    }
+
+    if (source.thumbnail.isEmpty()) {
+      const previousSource = previousById.get(source.id);
+      if (previousSource && !previousSource.thumbnail.isEmpty()) {
+        merged.push({ ...source, thumbnail: previousSource.thumbnail });
+        return;
+      }
+      // No cached fallback for a blank thumbnail: drop it.
+      return;
+    }
+
+    merged.push(source);
+  });
+
+  return merged;
+};
+
+const enumerateBucket = async (bucketType: BucketType): Promise<void> => {
+  try {
+    const sources = await desktopCapturer.getSources({
+      types: typeForBucket(bucketType),
+    });
+
+    if (sources.length === 0) {
+      if (buckets[bucketType] && buckets[bucketType]!.sources.length > 0) {
+        if (!warnedEmptyOnce[bucketType]) {
+          console.warn(
+            `Desktop capturer returned no ${bucketType}; keeping previous cache`
+          );
+          warnedEmptyOnce[bucketType] = true;
+        }
+        return;
+      }
+      buckets[bucketType] = { sources: [], timestamp: Date.now() };
+      return;
+    }
+
+    warnedEmptyOnce[bucketType] = false;
+    const merged = mergeWithPrevious(bucketType, sources);
+    buckets[bucketType] = { sources: merged, timestamp: Date.now() };
+  } catch (error) {
+    console.error(`Background cache refresh failed for ${bucketType}:`, error);
+    // Preserve the existing bucket unchanged on error.
+  } finally {
+    lastEnumerationCompletedAt = Date.now();
+  }
+};
+
+const scheduleRefresh = (
+  bucketType: BucketType,
+  bypassCooldown = false
+): Promise<void> => {
+  if (enumerationPromise) return enumerationPromise;
+  if (!bypassCooldown && !cooldownElapsed()) return Promise.resolve();
+
+  enumerationPromise = enumerateBucket(bucketType).finally(() => {
+    enumerationPromise = null;
+  });
+  return enumerationPromise;
+};
+
+const stalestBucket = (): BucketType => {
+  const screensTs = buckets.screens?.timestamp ?? 0;
+  const windowsTs = buckets.windows?.timestamp ?? 0;
+  return screensTs <= windowsTs ? 'screens' : 'windows';
+};
+
+const bucketFromOptions = (
+  options?: Electron.SourcesOptions
+): BucketType | null => {
+  if (!options?.types || options.types.length !== 1) return null;
+  if (options.types[0] === 'screen') return 'screens';
+  if (options.types[0] === 'window') return 'windows';
+  return null;
+};
 
 export const refreshDesktopCapturerCache = (
-  options: Electron.SourcesOptions
+  options?: Electron.SourcesOptions
 ): void => {
-  if (desktopCapturerPromise) return;
-
-  desktopCapturerPromise = (async () => {
-    try {
-      const sources = await desktopCapturer.getSources(options);
-
-      const validSources = sources.filter((source) => {
-        if (!source.name || source.name.trim() === '') {
-          return false;
-        }
-
-        const now = Date.now();
-        const cacheExpired =
-          now - sourceValidationCacheTimestamp > SOURCE_VALIDATION_CACHE_TTL;
-
-        if (!cacheExpired && sourceValidationCache.has(source.id)) {
-          return true;
-        }
-
-        if (source.thumbnail.isEmpty()) {
-          return false;
-        }
-
-        if (cacheExpired) {
-          sourceValidationCache.clear();
-          sourceValidationCacheTimestamp = now;
-        }
-        sourceValidationCache.add(source.id);
-
-        return true;
-      });
-
-      desktopCapturerCache = {
-        sources: validSources,
-        timestamp: Date.now(),
-      };
-
-      return validSources;
-    } catch (error) {
-      console.error('Background cache refresh failed:', error);
-      return desktopCapturerCache?.sources || [];
-    } finally {
-      desktopCapturerPromise = null;
-    }
-  })();
+  void scheduleRefresh(bucketFromOptions(options) ?? stalestBucket());
 };
 
 export const prewarmDesktopCapturerCache = (): void => {
-  refreshDesktopCapturerCache({ types: ['window', 'screen'] });
+  if (!buckets.screens && !buckets.windows) {
+    // Bootstrap: populating both buckets for the first time is not the
+    // back-to-back hammering the cooldown guards against, so the windows
+    // kick bypasses it.
+    void scheduleRefresh('screens').then(() => {
+      void scheduleRefresh('windows', true);
+    });
+    return;
+  }
+  void scheduleRefresh(stalestBucket());
 };
 
 export const clearDesktopCapturerCache = (): void => {
-  desktopCapturerCache = null;
-  desktopCapturerPromise = null;
-  sourceValidationCache.clear();
-  sourceValidationCacheTimestamp = 0;
+  buckets.screens = null;
+  buckets.windows = null;
+  enumerationPromise = null;
+  lastEnumerationCompletedAt = 0;
+  warnedEmptyOnce = { screens: false, windows: false };
 };
 
 export const getDesktopCapturerCacheStatus = (): {
   cached: boolean;
   pending: boolean;
 } => ({
-  cached: desktopCapturerCache !== null,
-  pending: desktopCapturerPromise !== null,
+  cached: buckets.screens !== null || buckets.windows !== null,
+  pending: enumerationPromise !== null,
 });
 
+export const getCachedSources = (): Electron.DesktopCapturerSource[] => [
+  ...(buckets.screens?.sources ?? []),
+  ...(buckets.windows?.sources ?? []),
+];
+
 export const handleDesktopCapturerGetSources = (): void => {
-  handle('desktop-capturer-get-sources', async (_webContents, opts) => {
+  handle('desktop-capturer-get-sources', async (_webContents, _opts) => {
     try {
-      const options = Array.isArray(opts) ? opts[0] : opts;
-
-      if (desktopCapturerCache) {
-        const isStale =
-          Date.now() - desktopCapturerCache.timestamp >
-          DESKTOP_CAPTURER_STALE_THRESHOLD;
-        if (isStale && !desktopCapturerPromise) {
-          refreshDesktopCapturerCache(options);
-        }
-        return desktopCapturerCache.sources;
+      if (!buckets.screens && !buckets.windows) {
+        // First-ever call: await screens (fast + reliable) so the picker gets
+        // content immediately, then kick windows in the background. This is
+        // the initial population, not repeated hammering, so the windows
+        // kick bypasses the cooldown gate.
+        await scheduleRefresh('screens');
+        void scheduleRefresh('windows', true);
+        return getCachedSources();
       }
 
-      if (desktopCapturerPromise) {
-        return await desktopCapturerPromise;
+      if (
+        (isStale(buckets.screens) || isStale(buckets.windows)) &&
+        !enumerationPromise &&
+        cooldownElapsed()
+      ) {
+        void scheduleRefresh(stalestBucket());
       }
 
-      refreshDesktopCapturerCache(options);
-      if (desktopCapturerPromise) {
-        return await desktopCapturerPromise;
-      }
-      return [];
+      return getCachedSources();
     } catch (error) {
       console.error('Error in desktop capturer handler:', error);
-      return desktopCapturerCache?.sources || [];
+      return getCachedSources();
     }
   });
 };

--- a/src/screenSharing/main/ScreenSharingRequestTracker.main.spec.ts
+++ b/src/screenSharing/main/ScreenSharingRequestTracker.main.spec.ts
@@ -2,6 +2,7 @@ import type { Event } from 'electron';
 import { desktopCapturer, ipcMain } from 'electron';
 
 import { ScreenSharingRequestTracker } from '../ScreenSharingRequestTracker';
+import { getCachedSources } from '../desktopCapturerCache';
 
 jest.mock('electron', () => ({
   ipcMain: {
@@ -13,12 +14,19 @@ jest.mock('electron', () => ({
   },
 }));
 
+jest.mock('../desktopCapturerCache', () => ({
+  getCachedSources: jest.fn(),
+}));
+
 const onceMock = ipcMain.once as jest.MockedFunction<typeof ipcMain.once>;
 const removeListenerMock = ipcMain.removeListener as jest.MockedFunction<
   typeof ipcMain.removeListener
 >;
 const getSourcesMock = desktopCapturer.getSources as jest.MockedFunction<
   typeof desktopCapturer.getSources
+>;
+const getCachedSourcesMock = getCachedSources as jest.MockedFunction<
+  typeof getCachedSources
 >;
 
 const CHANNEL = 'screen-share:response';
@@ -50,6 +58,9 @@ beforeEach(() => {
   jest.useFakeTimers({ doNotFake: ['setImmediate'] });
   jest.spyOn(console, 'warn').mockImplementation(() => undefined);
   jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  // Default: empty cache, so pre-existing tests that don't care about the
+  // cache path exercise the same direct-getSources fallback they did before.
+  getCachedSourcesMock.mockReturnValue([]);
 });
 
 afterEach(() => {
@@ -345,7 +356,44 @@ describe('ScreenSharingRequestTracker', () => {
   });
 
   describe('response listener', () => {
-    it('resolves with the selected source when a valid sourceId is received', async () => {
+    it('resolves from the cache without calling getSources when the cache is non-empty', async () => {
+      getCachedSourcesMock.mockReturnValue([
+        makeSource('window:1'),
+        makeSource('screen:0'),
+      ]);
+
+      const tracker = new ScreenSharingRequestTracker(CHANNEL, LABEL);
+      const cb = jest.fn();
+      tracker.createRequest(cb, jest.fn());
+
+      const listener = getRegisteredListener();
+      listener(fakeEvent, 'screen:0');
+      await flushPromises();
+
+      expect(getSourcesMock).not.toHaveBeenCalled();
+      expect(cb).toHaveBeenCalledWith({ video: makeSource('screen:0') });
+      expect(tracker.pending).toBe(false);
+      expect(removeListenerMock).toHaveBeenCalledWith(CHANNEL, listener);
+    });
+
+    it('denies when the sourceId is missing from a non-empty cache, without calling getSources', async () => {
+      getCachedSourcesMock.mockReturnValue([makeSource('window:1')]);
+
+      const tracker = new ScreenSharingRequestTracker(CHANNEL, LABEL);
+      const cb = jest.fn();
+      tracker.createRequest(cb, jest.fn());
+
+      const listener = getRegisteredListener();
+      listener(fakeEvent, 'screen:gone');
+      await flushPromises();
+
+      expect(getSourcesMock).not.toHaveBeenCalled();
+      expect(cb).toHaveBeenCalledWith(null);
+      expect(tracker.pending).toBe(false);
+    });
+
+    it('falls back to a single direct getSources call when the cache is empty', async () => {
+      getCachedSourcesMock.mockReturnValue([]);
       getSourcesMock.mockResolvedValue([
         makeSource('window:1'),
         makeSource('screen:0'),
@@ -359,6 +407,7 @@ describe('ScreenSharingRequestTracker', () => {
       listener(fakeEvent, 'screen:0');
       await flushPromises();
 
+      expect(getSourcesMock).toHaveBeenCalledTimes(1);
       expect(getSourcesMock).toHaveBeenCalledWith({
         types: ['window', 'screen'],
       });
@@ -381,7 +430,7 @@ describe('ScreenSharingRequestTracker', () => {
       expect(tracker.pending).toBe(false);
     });
 
-    it('resolves with no video when the selected source is no longer available', async () => {
+    it('resolves with no video via the fallback getSources call when the selected source is no longer available', async () => {
       getSourcesMock.mockResolvedValue([makeSource('window:1')]);
 
       const tracker = new ScreenSharingRequestTracker(CHANNEL, LABEL);

--- a/src/screenSharing/main/desktopCapturerCache.main.spec.ts
+++ b/src/screenSharing/main/desktopCapturerCache.main.spec.ts
@@ -3,6 +3,7 @@ import { desktopCapturer } from 'electron';
 import { handle } from '../../ipc/main';
 import {
   clearDesktopCapturerCache,
+  getCachedSources,
   getDesktopCapturerCacheStatus,
   handleDesktopCapturerGetSources,
   prewarmDesktopCapturerCache,
@@ -36,13 +37,14 @@ const makeSource = (id: string, name: string, empty = false): SourceStub => ({
   thumbnail: { isEmpty: () => empty },
 });
 
-const flushPromises = () =>
-  new Promise<void>((resolve) => setImmediate(resolve));
+// Flushes pending microtasks under fake timers (no real time passes).
+const flushMicrotasks = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};
 
-const OPTIONS = { types: ['window', 'screen'] } as Electron.SourcesOptions;
-
-// Registers the IPC handler and returns the captured callback. Filtered
-// results are only observable through this handler (it returns the cache).
+// Registers the IPC handler and returns the captured callback.
 const getHandler = () => {
   handleDesktopCapturerGetSources();
   const lastCall = handleMock.mock.calls[handleMock.mock.calls.length - 1];
@@ -53,54 +55,189 @@ const getHandler = () => {
 describe('screenSharing/desktopCapturerCache', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.useRealTimers();
+    // Fake timers stay on for the whole suite: the module reads Date.now()
+    // directly, and toggling real/fake timers mid-test discards the fake
+    // clock's advance instead of merging it into real time.
+    jest.useFakeTimers();
     clearDesktopCapturerCache();
   });
 
   afterEach(() => {
-    // The module schedules no timers of its own, but two tests opt into fake
-    // timers; clear any pending fake handle before restoring real timers so
-    // nothing survives into the next test or blocks jest --forceExit.
     jest.clearAllTimers();
     jest.useRealTimers();
     clearDesktopCapturerCache();
   });
 
-  describe('refreshDesktopCapturerCache', () => {
-    it('fetches sources and populates the cache with valid sources', async () => {
-      getSourcesMock.mockResolvedValueOnce([
-        makeSource('1', 'Screen 1') as any,
-        makeSource('2', 'Window 2') as any,
-      ]);
+  describe('handleDesktopCapturerGetSources — first-ever call', () => {
+    it('awaits a screens refresh and kicks a background windows refresh', async () => {
+      getSourcesMock.mockImplementation(async (options) => {
+        if (options?.types?.[0] === 'screen') {
+          return [makeSource('screen:0', 'Screen 1') as any];
+        }
+        return [makeSource('window:1', 'Window 1') as any];
+      });
 
-      refreshDesktopCapturerCache(OPTIONS);
-      await flushPromises();
+      const handler = getHandler();
+      const resultPromise = handler({ id: 1 }, undefined);
+      await flushMicrotasks();
+      const result = await resultPromise;
 
-      expect(getSourcesMock).toHaveBeenCalledWith(OPTIONS);
-      const status = getDesktopCapturerCacheStatus();
-      expect(status.cached).toBe(true);
-      expect(status.pending).toBe(false);
+      // Screens content is present immediately (awaited).
+      expect(result.map((s: SourceStub) => s.id)).toContain('screen:0');
+      expect(getSourcesMock).toHaveBeenCalledWith({ types: ['screen'] });
+
+      await flushMicrotasks();
+
+      // Windows refresh was kicked off in the background.
+      expect(getSourcesMock).toHaveBeenCalledWith({ types: ['window'] });
+      expect(getCachedSources().map((s) => s.id)).toEqual(
+        expect.arrayContaining(['screen:0', 'window:1'])
+      );
     });
 
-    it('does not start a second fetch while one is pending', async () => {
-      let resolveFetch: (value: any) => void = () => undefined;
-      getSourcesMock.mockReturnValueOnce(
-        new Promise((resolve) => {
-          resolveFetch = resolve;
-        }) as any
+    it('populates both buckets on cold start without waiting out the cooldown, but still gates the next steady-state refresh', async () => {
+      getSourcesMock.mockImplementation(async (options) => {
+        if (options?.types?.[0] === 'screen') {
+          return [makeSource('screen:0', 'Screen 1') as any];
+        }
+        return [makeSource('window:1', 'Window 1') as any];
+      });
+
+      const handler = getHandler();
+      const resultPromise = handler({ id: 1 }, undefined);
+      await flushMicrotasks();
+      await resultPromise;
+      await flushMicrotasks();
+
+      // No time was advanced between the screens and windows legs, yet both
+      // buckets are populated: the cold-start windows kick bypassed the
+      // cooldown gate.
+      expect(getCachedSources().map((s) => s.id)).toEqual(
+        expect.arrayContaining(['screen:0', 'window:1'])
       );
+      expect(getSourcesMock).toHaveBeenCalledTimes(2);
 
-      refreshDesktopCapturerCache(OPTIONS);
-      // Second call should short-circuit because a promise is in flight.
-      refreshDesktopCapturerCache(OPTIONS);
+      // Immediately after, a steady-state refresh is still cooldown-gated.
+      getSourcesMock.mockClear();
+      refreshDesktopCapturerCache({ types: ['screen'] });
+      await flushMicrotasks();
+      expect(getSourcesMock).not.toHaveBeenCalled();
 
+      jest.advanceTimersByTime(4001);
+      refreshDesktopCapturerCache({ types: ['screen'] });
+      await flushMicrotasks();
       expect(getSourcesMock).toHaveBeenCalledTimes(1);
-      expect(getDesktopCapturerCacheStatus().pending).toBe(true);
+    });
 
-      resolveFetch([makeSource('1', 'Screen 1') as any]);
-      await flushPromises();
+    it('only ever calls getSources with a single type per enumeration', async () => {
+      getSourcesMock.mockResolvedValue([]);
 
-      expect(getDesktopCapturerCacheStatus().pending).toBe(false);
+      const handler = getHandler();
+      await handler({ id: 1 }, undefined);
+      await flushMicrotasks();
+
+      getSourcesMock.mock.calls.forEach(([options]) => {
+        expect(options?.types).toHaveLength(1);
+      });
+    });
+  });
+
+  describe('empty results never clobber a populated bucket', () => {
+    it('keeps existing screens bucket when a later enumeration returns empty', async () => {
+      getSourcesMock.mockResolvedValueOnce([
+        makeSource('screen:0', 'Screen 1') as any,
+      ]);
+      refreshDesktopCapturerCache({ types: ['screen'] });
+      await flushMicrotasks();
+
+      expect(getCachedSources().map((s) => s.id)).toEqual(['screen:0']);
+
+      // Advance past cooldown so a second enumeration is allowed.
+      jest.advanceTimersByTime(4001);
+
+      getSourcesMock.mockResolvedValueOnce([]);
+      refreshDesktopCapturerCache({ types: ['screen'] });
+      await flushMicrotasks();
+
+      expect(getCachedSources().map((s) => s.id)).toEqual(['screen:0']);
+    });
+
+    it('warns only once per occurrence of an empty result on a populated bucket', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+      getSourcesMock.mockResolvedValueOnce([
+        makeSource('screen:0', 'Screen 1') as any,
+      ]);
+      refreshDesktopCapturerCache({ types: ['screen'] });
+      await flushMicrotasks();
+
+      jest.advanceTimersByTime(4001);
+
+      getSourcesMock.mockResolvedValueOnce([]);
+      refreshDesktopCapturerCache({ types: ['screen'] });
+      await flushMicrotasks();
+
+      const emptyWarnings = warnSpy.mock.calls.filter(([msg]) =>
+        String(msg).includes('keeping previous cache')
+      );
+      expect(emptyWarnings).toHaveLength(1);
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('thumbnail merge by id', () => {
+    it('keeps the last good thumbnail for a source whose new thumbnail is empty', async () => {
+      const goodThumbnail = { isEmpty: () => false };
+      getSourcesMock.mockResolvedValueOnce([
+        { id: 'window:1', name: 'Window 1', thumbnail: goodThumbnail } as any,
+      ]);
+      refreshDesktopCapturerCache({ types: ['window'] });
+      await flushMicrotasks();
+
+      jest.advanceTimersByTime(4001);
+
+      getSourcesMock.mockResolvedValueOnce([
+        {
+          id: 'window:1',
+          name: 'Window 1',
+          thumbnail: { isEmpty: () => true },
+          appIcon: 'icon-data',
+        } as any,
+      ]);
+      refreshDesktopCapturerCache({ types: ['window'] });
+      await flushMicrotasks();
+
+      const merged = getCachedSources().find((s) => s.id === 'window:1');
+      expect(merged?.thumbnail).toBe(goodThumbnail);
+      expect((merged as any)?.appIcon).toBe('icon-data');
+    });
+
+    it('drops a source with an empty thumbnail and no cached fallback', async () => {
+      getSourcesMock.mockResolvedValueOnce([
+        makeSource('window:1', 'Window 1', true) as any,
+      ]);
+      refreshDesktopCapturerCache({ types: ['window'] });
+      await flushMicrotasks();
+
+      expect(getCachedSources()).toEqual([]);
+    });
+
+    it('drops an id absent from a non-empty result (window really closed)', async () => {
+      getSourcesMock.mockResolvedValueOnce([
+        makeSource('window:1', 'Window 1') as any,
+      ]);
+      refreshDesktopCapturerCache({ types: ['window'] });
+      await flushMicrotasks();
+
+      jest.advanceTimersByTime(4001);
+
+      getSourcesMock.mockResolvedValueOnce([
+        makeSource('window:2', 'Window 2') as any,
+      ]);
+      refreshDesktopCapturerCache({ types: ['window'] });
+      await flushMicrotasks();
+
+      expect(getCachedSources().map((s) => s.id)).toEqual(['window:2']);
     });
 
     it('filters out sources with empty or whitespace names', async () => {
@@ -109,76 +246,76 @@ describe('screenSharing/desktopCapturerCache', () => {
         makeSource('2', '   ') as any,
         makeSource('3', 'Valid') as any,
       ]);
+      refreshDesktopCapturerCache({ types: ['window'] });
+      await flushMicrotasks();
 
-      refreshDesktopCapturerCache(OPTIONS);
-      await flushPromises();
-
-      // Filtered results are observable through the cache via the handler.
-      const handler = getHandler();
-      const result = (await handler({ id: 1 }, OPTIONS)) as any[];
-
-      expect(result).toHaveLength(1);
-      expect(result[0].id).toBe('3');
+      expect(getCachedSources().map((s) => s.id)).toEqual(['3']);
     });
+  });
 
-    it('filters out sources with an empty thumbnail', async () => {
-      getSourcesMock.mockResolvedValueOnce([
-        makeSource('1', 'Empty thumb', true) as any,
-        makeSource('2', 'Good thumb', false) as any,
+  describe('cooldown', () => {
+    it('prevents a second enumeration within 4s of the previous completion', async () => {
+      getSourcesMock.mockResolvedValue([
+        makeSource('screen:0', 'Screen 1') as any,
       ]);
 
-      refreshDesktopCapturerCache(OPTIONS);
-      await flushPromises();
+      refreshDesktopCapturerCache();
+      await flushMicrotasks();
+      expect(getSourcesMock).toHaveBeenCalledTimes(1);
 
-      const handler = getHandler();
-      const result = (await handler({ id: 1 }, OPTIONS)) as any[];
+      jest.advanceTimersByTime(2000);
+      refreshDesktopCapturerCache();
+      await flushMicrotasks();
+      // Still within cooldown: no second call.
+      expect(getSourcesMock).toHaveBeenCalledTimes(1);
 
-      expect(result.map((s) => s.id)).toEqual(['2']);
+      jest.advanceTimersByTime(2001);
+      refreshDesktopCapturerCache();
+      await flushMicrotasks();
+      // Cooldown elapsed: second enumeration allowed.
+      expect(getSourcesMock).toHaveBeenCalledTimes(2);
     });
 
-    it('serves a cached validation hit without re-checking the thumbnail', async () => {
-      // First refresh caches source "2" as valid.
-      getSourcesMock.mockResolvedValueOnce([
-        makeSource('2', 'Good thumb', false) as any,
-      ]);
-      refreshDesktopCapturerCache(OPTIONS);
-      await flushPromises();
+    it('never runs two enumerations concurrently (single-flight)', async () => {
+      let resolveFetch: (value: any) => void = () => undefined;
+      getSourcesMock.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        }) as any
+      );
 
-      // Second refresh: same id, now reports an empty thumbnail, but the
-      // validation cache should still treat it as valid (within TTL).
-      const emptyThumbSource = makeSource('2', 'Good thumb', true);
-      const isEmptySpy = jest.spyOn(emptyThumbSource.thumbnail, 'isEmpty');
-      getSourcesMock.mockResolvedValueOnce([emptyThumbSource as any]);
+      refreshDesktopCapturerCache();
+      refreshDesktopCapturerCache();
 
-      refreshDesktopCapturerCache(OPTIONS);
-      await flushPromises();
+      expect(getSourcesMock).toHaveBeenCalledTimes(1);
+      expect(getDesktopCapturerCacheStatus().pending).toBe(true);
 
-      const handler = getHandler();
-      const result = (await handler({ id: 1 }, OPTIONS)) as any[];
+      resolveFetch([makeSource('screen:0', 'Screen 1') as any]);
+      await flushMicrotasks();
 
-      expect(result.map((s) => s.id)).toEqual(['2']);
-      expect(isEmptySpy).not.toHaveBeenCalled();
+      expect(getDesktopCapturerCacheStatus().pending).toBe(false);
     });
+  });
 
+  describe('error handling', () => {
     it('keeps the previous cached sources when a background fetch rejects', async () => {
-      // Seed a cache first.
-      getSourcesMock.mockResolvedValueOnce([makeSource('1', 'Seeded') as any]);
-      refreshDesktopCapturerCache(OPTIONS);
-      await flushPromises();
+      getSourcesMock.mockResolvedValueOnce([
+        makeSource('screen:0', 'Seeded') as any,
+      ]);
+      refreshDesktopCapturerCache({ types: ['screen'] });
+      await flushMicrotasks();
+
+      jest.advanceTimersByTime(4001);
 
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
       getSourcesMock.mockRejectedValueOnce(new Error('boom'));
 
-      refreshDesktopCapturerCache(OPTIONS);
-      await flushPromises();
+      refreshDesktopCapturerCache({ types: ['screen'] });
+      await flushMicrotasks();
 
-      // Cache untouched: handler still serves the seeded source.
-      const handler = getHandler();
-      const result = (await handler({ id: 1 }, OPTIONS)) as any[];
-
-      expect(result.map((s) => s.id)).toEqual(['1']);
+      expect(getCachedSources().map((s) => s.id)).toEqual(['screen:0']);
       expect(consoleSpy).toHaveBeenCalledWith(
-        'Background cache refresh failed:',
+        expect.stringContaining('Background cache refresh failed'),
         expect.any(Error)
       );
       consoleSpy.mockRestore();
@@ -188,15 +325,12 @@ describe('screenSharing/desktopCapturerCache', () => {
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
       getSourcesMock.mockRejectedValueOnce(new Error('boom'));
 
-      refreshDesktopCapturerCache(OPTIONS);
-      await flushPromises();
+      refreshDesktopCapturerCache();
+      await flushMicrotasks();
 
-      expect(getDesktopCapturerCacheStatus()).toEqual({
-        cached: false,
-        pending: false,
-      });
+      expect(getDesktopCapturerCacheStatus().cached).toBe(false);
       expect(consoleSpy).toHaveBeenCalledWith(
-        'Background cache refresh failed:',
+        expect.stringContaining('Background cache refresh failed'),
         expect.any(Error)
       );
       consoleSpy.mockRestore();
@@ -204,24 +338,22 @@ describe('screenSharing/desktopCapturerCache', () => {
   });
 
   describe('prewarmDesktopCapturerCache', () => {
-    it('refreshes with window and screen source types', async () => {
-      getSourcesMock.mockResolvedValueOnce([]);
+    it('refreshes screens first when both buckets are empty', async () => {
+      getSourcesMock.mockResolvedValue([]);
       prewarmDesktopCapturerCache();
-      await flushPromises();
+      await flushMicrotasks();
 
-      expect(getSourcesMock).toHaveBeenCalledWith({
-        types: ['window', 'screen'],
-      });
+      expect(getSourcesMock).toHaveBeenCalledWith({ types: ['screen'] });
     });
   });
 
   describe('clearDesktopCapturerCache', () => {
     it('resets cache and pending state', async () => {
       getSourcesMock.mockResolvedValueOnce([
-        makeSource('1', 'Screen 1') as any,
+        makeSource('screen:0', 'Screen 1') as any,
       ]);
-      refreshDesktopCapturerCache(OPTIONS);
-      await flushPromises();
+      refreshDesktopCapturerCache();
+      await flushMicrotasks();
       expect(getDesktopCapturerCacheStatus().cached).toBe(true);
 
       clearDesktopCapturerCache();
@@ -230,6 +362,7 @@ describe('screenSharing/desktopCapturerCache', () => {
         cached: false,
         pending: false,
       });
+      expect(getCachedSources()).toEqual([]);
     });
   });
 
@@ -242,96 +375,82 @@ describe('screenSharing/desktopCapturerCache', () => {
     });
   });
 
+  describe('getCachedSources', () => {
+    it('returns merged screens + windows sources, screens first', async () => {
+      getSourcesMock.mockImplementation(async (options) => {
+        if (options?.types?.[0] === 'screen') {
+          return [makeSource('screen:0', 'Screen 1') as any];
+        }
+        return [makeSource('window:1', 'Window 1') as any];
+      });
+
+      const handler = getHandler();
+      const resultPromise = handler({ id: 1 }, undefined);
+      await flushMicrotasks();
+      await resultPromise;
+      await flushMicrotasks();
+
+      expect(getCachedSources().map((s) => s.id)).toEqual([
+        'screen:0',
+        'window:1',
+      ]);
+    });
+
+    it('returns an empty array when no bucket has been populated', () => {
+      expect(getCachedSources()).toEqual([]);
+    });
+  });
+
   describe('handleDesktopCapturerGetSources', () => {
     it('registers the IPC handler on the expected channel', () => {
       getHandler();
     });
 
-    it('returns cached sources immediately when a fresh cache exists', async () => {
-      getSourcesMock.mockResolvedValueOnce([makeSource('1', 'Cached') as any]);
-      refreshDesktopCapturerCache(OPTIONS);
-      await flushPromises();
+    it('serves merged cached sources immediately on subsequent calls', async () => {
+      getSourcesMock.mockImplementation(async (options) => {
+        if (options?.types?.[0] === 'screen') {
+          return [makeSource('screen:0', 'Screen 1') as any];
+        }
+        return [makeSource('window:1', 'Window 1') as any];
+      });
 
       const handler = getHandler();
-      const result = await handler({ id: 1 }, OPTIONS);
+      const firstCall = handler({ id: 1 }, undefined);
+      await flushMicrotasks();
+      await firstCall;
+      await flushMicrotasks();
 
-      expect(result.map((s: SourceStub) => s.id)).toEqual(['1']);
-    });
+      getSourcesMock.mockClear();
+      const result = await handler({ id: 1 }, undefined);
 
-    it('unwraps an array-wrapped options argument', async () => {
-      const handler = getHandler();
-      getSourcesMock.mockResolvedValueOnce([makeSource('1', 'Cached') as any]);
-
-      await handler({ id: 1 }, [OPTIONS]);
-
-      expect(getSourcesMock).toHaveBeenCalledWith(OPTIONS);
-    });
-
-    it('triggers a background refresh when the cache is stale', async () => {
-      jest.useFakeTimers();
-      getSourcesMock.mockResolvedValue([makeSource('1', 'Cached') as any]);
-
-      refreshDesktopCapturerCache(OPTIONS);
-      // Allow the initial fetch to settle under fake timers.
-      await Promise.resolve();
-      await Promise.resolve();
-
-      // Advance beyond the 3000ms stale threshold.
-      jest.advanceTimersByTime(3001);
-
-      const handler = getHandler();
-      const result = await handler({ id: 1 }, OPTIONS);
-
-      // Still returns the (stale) cached sources synchronously.
-      expect(result.map((s: SourceStub) => s.id)).toEqual(['1']);
-      // A background refresh was kicked off (second getSources call).
-      expect(getSourcesMock).toHaveBeenCalledTimes(2);
-    });
-
-    it('does not refresh when a fresh cache is within the stale threshold', async () => {
-      jest.useFakeTimers();
-      getSourcesMock.mockResolvedValue([makeSource('1', 'Cached') as any]);
-
-      refreshDesktopCapturerCache(OPTIONS);
-      await Promise.resolve();
-      await Promise.resolve();
-
-      jest.advanceTimersByTime(1000);
-
-      const handler = getHandler();
-      await handler({ id: 1 }, OPTIONS);
-
-      expect(getSourcesMock).toHaveBeenCalledTimes(1);
-    });
-
-    it('awaits the in-flight promise when one is pending and no cache exists', async () => {
-      let resolveFetch: (value: any) => void = () => undefined;
-      getSourcesMock.mockReturnValueOnce(
-        new Promise((resolve) => {
-          resolveFetch = resolve;
-        }) as any
+      expect(result.map((s: SourceStub) => s.id)).toEqual(
+        expect.arrayContaining(['screen:0', 'window:1'])
       );
-
-      // Start a fetch so a promise is pending but cache is still null.
-      refreshDesktopCapturerCache(OPTIONS);
-
-      const handler = getHandler();
-      const handlerPromise = handler({ id: 1 }, OPTIONS);
-
-      resolveFetch([makeSource('9', 'Pending') as any]);
-      const result = await handlerPromise;
-
-      expect(result.map((s: SourceStub) => s.id)).toEqual(['9']);
     });
 
-    it('refreshes then awaits when there is neither cache nor pending promise', async () => {
-      getSourcesMock.mockResolvedValueOnce([makeSource('5', 'Fresh') as any]);
+    it('kicks a background refresh of the stalest bucket when stale and cooldown elapsed', async () => {
+      getSourcesMock.mockImplementation(async (options) => {
+        if (options?.types?.[0] === 'screen') {
+          return [makeSource('screen:0', 'Screen 1') as any];
+        }
+        return [makeSource('window:1', 'Window 1') as any];
+      });
 
       const handler = getHandler();
-      const result = await handler({ id: 1 }, OPTIONS);
+      const firstCall = handler({ id: 1 }, undefined);
+      await flushMicrotasks();
+      await firstCall;
+      await flushMicrotasks();
 
-      expect(getSourcesMock).toHaveBeenCalledWith(OPTIONS);
-      expect(result.map((s: SourceStub) => s.id)).toEqual(['5']);
+      const callsAfterFirst = getSourcesMock.mock.calls.length;
+
+      // Advance beyond stale threshold (5000ms) and cooldown (4000ms).
+      jest.advanceTimersByTime(5001);
+
+      await handler({ id: 1 }, undefined);
+      await flushMicrotasks();
+
+      expect(getSourcesMock.mock.calls.length).toBeGreaterThan(callsAfterFirst);
     });
   });
 });

--- a/src/screenSharing/screenSharePicker.tsx
+++ b/src/screenSharing/screenSharePicker.tsx
@@ -86,7 +86,8 @@ export function ScreenSharePicker({
       }
     } catch (error) {
       console.error('Error fetching screen sharing sources:', error);
-      setSources([]);
+      // Keep the previous sources list instead of clearing it — a transient
+      // enumeration failure shouldn't blank out an otherwise valid picker.
     }
   }, [selectedSourceId]);
 


### PR DESCRIPTION
## What

On macOS, the screen picker could intermittently show "No windows found" / "No screens found" seconds after listing sources, and clicking **Share** on a visible source could be silently denied with `selected source no longer available`. This PR makes the picker's source pipeline resilient to the new `desktopCapturer.getSources()` behavior in Electron 42.

## Why

Electron 42's macOS capture backend (ScreenCaptureKit) bounds `getSources()` at ~3s — upstream fixes for an indefinite hang and a DCHECK crash (electron/electron#51128, electron/electron#50960 — the latter shipped in 42.0.1). Instead of blocking until enumeration completes (~24s observed under Electron 41.9 on the same machine), calls now return whatever arrived within ~3s.

Measured on macOS with Electron 42.5.0 (scripts in `docs/KNOWN_ISSUES.md` entry):

| Call pattern | Result |
|---|---|
| `['window','screen']`, back-to-back | ~75% of calls return **0 sources**; the rest mostly-empty thumbnails |
| `['screen']` only, back-to-back | ~700ms, 3/3 sources, never fails |
| Alternating `['screen']` / `['window']`, 4s gaps | complete results every round |

The app's previous design assumed `getSources()` was reliable: the cache overwrote itself with empty results (picker blanks), the picker polled every 3s (continuous back-to-back enumeration), and the post-Share validation re-enumerated and denied the share when it hit an empty result.

## How

- **Per-type cache buckets** (`desktopCapturerCache.ts`): screens and windows enumerate separately — screens are cheap and reliable, windows are paced with a 4s post-completion cooldown (single-flight preserved; the one-time cold-start chain bypasses the cooldown so the first picker open populates both tabs promptly). IPC contract unchanged.
- **Empty results never overwrite a non-empty bucket** — the bucket stays stale and retries at the next paced opportunity.
- **Thumbnail merge by id** — a source arriving with an empty thumbnail keeps its last good preview instead of being dropped (replaces the previous 30s validation-set heuristic).
- **Share validates against the cache** (`ScreenSharingRequestTracker.ts`) — the same list the picker rendered from — instead of a fresh enumeration; a single direct enumeration remains only as the empty-cache fallback.
- **Renderer keeps the previous list** when a fetch fails (`screenSharePicker.tsx`).

Windows/Linux X11 use the same cache path with fast native backends — the pacing is a no-op there in practice. The Linux Wayland portal path doesn't use this pipeline and is untouched.

## Testing

- `desktopCapturerCache.main.spec.ts` (21 tests): empty-result preservation, thumbnail merge, cooldown gating, cold-start bypass, single-flight, merged accessor.
- `ScreenSharingRequestTracker.main.spec.ts` (36 tests): cache-based validation, deny on genuinely-missing source, empty-cache fallback.
- `npx tsc --noEmit` and `yarn lint` clean.
- Live verification on macOS dev build: picker held open >60s with both tabs continuously populated (main-process log confirmed empty enumerations being absorbed by the cache), repeated Share attempts succeeded.

## Follow-up

Adopt `setDisplayMediaRequestHandler(..., { useSystemPicker: true })` (native SCContentSharingPicker) on macOS 15+, which removes `getSources()` from the flow entirely — tracked separately; experimental API with an open audio caveat (electron/electron#44685).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved screen sharing reliability by reusing recently discovered screens and windows when available.
  - Reduced delays and duplicate source lookups when opening the screen-sharing picker.
  - Preserved previously displayed sharing options when a temporary source-enumeration error occurs.
  - Improved handling when a selected screen or window is no longer available.
- **Documentation**
  - Expanded known-issue guidance for macOS screen capture in Electron 42, including symptoms, status, and workarounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->