### PR TITLE
chore: bump version to 4.16.0-alpha.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "Rocket.Chat",
   "name": "rocketchat",
   "description": "Official OSX, Windows, and Linux Desktop Clients for Rocket.Chat",
-  "version": "4.16.0-alpha.0",
+  "version": "4.16.0-alpha.1",
   "author": "Rocket.Chat Support <support@rocket.chat>",
   "copyright": "© 2016-2026, Rocket.Chat",
   "homepage": "https://rocket.chat",


### PR DESCRIPTION
Version bump for the 4.16.0-alpha.1 prerelease.

## Ships since 4.16.0-alpha.0

### 🐛 Fixes
- Keep screen picker sources stable under Electron 42 macOS capture stack (#3414)
- Workspace tabs QA feedback (CORE-2312) (#3413)
- Externalize dependency subpath imports in rollup bundles (#3411)

### 🔧 Internal
- Apply least privilege pattern to GitHub Actions workflows (#3410)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package to version **4.16.0-alpha.1**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->