### PR TITLE
fix: keep first Jitsi call on its jwt navigation on cold cache (SUP-1072)

### DIFF
--- a/src/videoCallWindow/video-call-window.ts
+++ b/src/videoCallWindow/video-call-window.ts
@@ -61,6 +61,9 @@ let loadingTimeout: NodeJS.Timeout | null = null;
 let recoveryTimeout: NodeJS.Timeout | null = null;
 let loadingDisplayTimeout: NodeJS.Timeout | null = null;
 let errorDisplayTimeout: NodeJS.Timeout | null = null;
+// True while recovery attempt 2's about:blank placeholder hop is in flight,
+// so its dom-ready doesn't reset recoveryAttempt before the real URL commits.
+let isAboutBlankRecoveryHop = false;
 
 const initializeI18n = async (): Promise<void> => {
   try {
@@ -235,11 +238,9 @@ const showErrorWithDelay = (
 
 const attemptAutoRecovery = (): void => {
   if (state.recoveryAttempt >= MAX_RECOVERY_ATTEMPTS) {
-    if (process.env.NODE_ENV === 'development') {
-      console.log(
-        'Video call window: Max recovery attempts reached, showing error'
-      );
-    }
+    console.warn(
+      'Video call window: Max recovery attempts reached, showing error'
+    );
     state.status = 'error';
     state.errorMessage = t(
       'videoCall.error.maxRetriesReached',
@@ -274,18 +275,35 @@ const attemptAutoRecovery = (): void => {
       return;
   }
 
-  if (process.env.NODE_ENV === 'development') {
-    console.log(
-      `Video call window: Auto-recovery attempt ${currentAttempt}/${MAX_RECOVERY_ATTEMPTS} - ${strategy}`
-    );
-  }
+  console.warn(
+    `Video call window: Auto-recovery attempt ${currentAttempt}/${MAX_RECOVERY_ATTEMPTS} - ${strategy}`
+  );
 
   recoveryTimeout = setTimeout(() => {
     const webview = state.webview as any;
 
     switch (currentAttempt) {
       case 1:
-        if (webview) {
+        if (webview && state.url) {
+          try {
+            webview.src = validateVideoCallUrl(state.url);
+          } catch (error) {
+            console.error(
+              'Video call window: URL validation failed during recovery:',
+              error
+            );
+            console.error(
+              'Video call window: Skipping webview reload recovery step, proceeding to next recovery attempt'
+            );
+            if (recoveryTimeout) {
+              clearTimeout(recoveryTimeout);
+              recoveryTimeout = null;
+            }
+            state.recoveryAttempt = currentAttempt;
+            attemptAutoRecovery();
+            return;
+          }
+        } else if (webview) {
           webview.reload();
         }
         break;
@@ -293,8 +311,10 @@ const attemptAutoRecovery = (): void => {
         if (webview && state.url) {
           try {
             const validatedUrl = validateVideoCallUrl(state.url);
+            isAboutBlankRecoveryHop = true;
             webview.src = 'about:blank';
             setTimeout(() => {
+              isAboutBlankRecoveryHop = false;
               if (webview) {
                 webview.src = validatedUrl;
               }
@@ -402,11 +422,9 @@ const setupWebviewEventHandlers = (webview: HTMLElement): void => {
     });
 
     loadingTimeout = setTimeout(() => {
-      if (process.env.NODE_ENV === 'development') {
-        console.log(
-          'Video call window: Loading timeout reached - starting auto-recovery'
-        );
-      }
+      console.warn(
+        'Video call window: Loading timeout reached - starting auto-recovery'
+      );
       loadingTimeout = null;
       attemptAutoRecovery();
     }, LOADING_TIMEOUT_MS);
@@ -419,6 +437,22 @@ const setupWebviewEventHandlers = (webview: HTMLElement): void => {
 
   const handleDomReady = (): void => {
     console.log('Video call window: Webview DOM ready');
+
+    // Page has committed and consumed the URL (Jitsi strips the jwt via
+    // history.replaceState here); auto-recovery reloading now would abort
+    // in-flight subresource loads, so disarm the "navigation never
+    // committed" timeout and stop counting this as a failed attempt.
+    // Skip this for the `about:blank` placeholder hop used by recovery
+    // attempt 2 (URL refresh) - it commits instantly but isn't real
+    // content, so resetting the counter here would defeat the bounded
+    // 3-attempt escalation ladder.
+    if (!isAboutBlankRecoveryHop) {
+      if (loadingTimeout) {
+        clearTimeout(loadingTimeout);
+        loadingTimeout = null;
+      }
+      state.recoveryAttempt = 0;
+    }
 
     if (state.shouldAutoOpenDevtools) {
       console.log('Video call window: Auto-opening devtools for webview');
@@ -500,6 +534,13 @@ const setupWebviewEventHandlers = (webview: HTMLElement): void => {
     };
 
     console.error('Video call window: Webview failed to load:', errorInfo);
+
+    if (event.errorCode === -3) {
+      console.warn(
+        'Video call window: Ignoring ERR_ABORTED (-3) - self-inflicted navigation abort'
+      );
+      return;
+    }
 
     if (event.isMainFrame) {
       clearAllTimeouts();


### PR DESCRIPTION
## What

Fixes the cold-cache first-call flow in the video call window: the first Jitsi call after a fresh install/update (or cleared cache) no longer drops to the Jitsi prejoin page — it stays on the jwt-carrying navigation and auto-joins.

Jira: [SUP-1072](https://rocketchat.atlassian.net/browse/SUP-1072)

## Why

On a cold cache, the Jitsi page commits and consumes the `jwt=...&prejoinPageEnabled=false` URL while its bundles are still downloading, so `did-finish-load` can arrive after the 15s loading timeout. The auto-recovery path — designed for navigations that never load — did not cover this committed-but-still-downloading case: it reloaded the current URL, which Jitsi had already jwt-stripped via `history.replaceState`, aborting the in-flight load (`did-fail-load` with `ERR_ABORTED -3`) and finishing on the tokenless URL, i.e. the prejoin page. All recovery logging was dev-gated, so production logs showed no trace of the trigger.

## How

All changes in `src/videoCallWindow/video-call-window.ts`:

- **Page commit disarms the loading timeout** (`dom-ready` on the webview): once the page committed, Jitsi already consumed the jwt; the timeout now only covers navigations that never commit.
- **Recovery attempt 1 re-navigates to the original validated call URL** (`state.url`, frozen at webview creation with the jwt intact) instead of blind `reload()` of the current — possibly tokenless — URL. Falls back to `reload()` only when no stored URL exists.
- **`did-fail-load` ignores `ERR_ABORTED (-3)`** so self-inflicted navigation aborts don't trigger the error UI or further recovery.
- **Timeout/recovery logs are now unconditional `console.warn`** so support logs capture recovery activity in production.
- **`about:blank` hop guard**: recovery attempt 2's placeholder navigation no longer resets the bounded 3-attempt escalation ladder.

## Validation

- `yarn lint`, `npx tsc --noEmit`: clean
- `yarn test` (videoCallWindow suites): 44/44 pass
- `yarn build`: clean
- Runtime cold-cache repro requires a throttled network + Jitsi with JWT; QA steps: clear app cache, throttle to ~1 Mbps, start a Jitsi call → expect auto-join with no prejoin page.

## Notes

- Base is `hotfix/4.15.5` (created from the `4.15.4` tag) targeting a 4.15.5 hotfix release.
- Follow-up candidate for the same hotfix: backport of #3411 (rollup subpath externals) — the `exports is not defined` error in the customer logs comes from the bundled `react-dom/client` chunk in the screen-share picker path at 4.15.x.

[SUP-1072]: https://rocketchat.atlassian.net/browse/SUP-1072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video call recovery during interrupted or failed navigation.
  * Prevented temporary recovery navigation states from incorrectly resetting recovery progress.
  * Avoided showing error states for expected, internally aborted navigations.
  * Added clearer warnings when loading timeouts or recovery limits are reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->