### PR TITLE
fix: restore breathing room between traffic lights and first tab (CORE-2312)

### DIFF
--- a/src/ui/components/TabBar/styles.tsx
+++ b/src/ui/components/TabBar/styles.tsx
@@ -27,7 +27,7 @@ type TrafficLightSpacerProps = {
 
 export const TrafficLightSpacer = styled.div<TrafficLightSpacerProps>`
   flex: 0 0 auto;
-  width: ${({ collapsed }) => (collapsed ? '0px' : '78px')};
+  width: ${({ collapsed }) => (collapsed ? '0px' : '82px')};
   -webkit-app-region: drag;
   transition: width var(--transitions-duration, 100ms);
 `;


### PR DESCRIPTION
## Summary

Follow-up to #3413 (CORE-2312 design review): the round-4 leading-padding reduction also shrank the breathing room between the macOS traffic lights and the first workspace tab.

## Changes

- Widen the traffic-light spacer (78px → 82px) so the gap after the traffic lights returns to its reviewed width (~18px), while keeping the 4px tab-area leading padding introduced in the design review.

## Testing

- `npx tsc --noEmit`, eslint clean
- Verified on a live macOS build: first tab starts 18px after the traffic lights, matching the designer's "correct" reference screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted expanded tab bar spacing for improved alignment.
  * Collapsed tab bars remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->