### PR TITLE
fix: align workspace tab bar spacing with Chrome tab strip metrics

### DIFF
--- a/src/ui/components/AddServerView/styles.tsx
+++ b/src/ui/components/AddServerView/styles.tsx
@@ -6,7 +6,7 @@ export const Wrapper = styled.section`
   top: 0;
   right: 0;
   bottom: 0;
-  background-color: var(--rcx-color-surface-sidebar, #2f343d);
+  background-color: var(--rcx-color-surface-tint, #2f343d);
 
   overflow-y: auto;
   align-items: center;

--- a/src/ui/components/TabBar/styles.tsx
+++ b/src/ui/components/TabBar/styles.tsx
@@ -12,7 +12,7 @@ export const Strip = styled.div<StripProps>`
   align-items: stretch;
   flex: 0 0 auto;
   width: 100%;
-  height: 36px;
+  height: 38px;
   -webkit-app-region: drag;
   user-select: none;
   background-color: ${({ isTransparentWindowEnabled }) =>
@@ -27,7 +27,7 @@ type TrafficLightSpacerProps = {
 
 export const TrafficLightSpacer = styled.div<TrafficLightSpacerProps>`
   flex: 0 0 auto;
-  width: ${({ collapsed }) => (collapsed ? '0px' : '78px')};
+  width: ${({ collapsed }) => (collapsed ? '0px' : '82px')};
   -webkit-app-region: drag;
   transition: width var(--transitions-duration, 100ms);
 `;
@@ -39,7 +39,7 @@ export const TabList = styled.div`
   flex: 1 1 auto;
   min-width: 0;
   gap: 4px;
-  padding-left: 4px;
+  padding-left: 8px;
   overflow: hidden;
   -webkit-app-region: drag;
 `;

--- a/src/ui/main/rootWindow.ts
+++ b/src/ui/main/rootWindow.ts
@@ -110,7 +110,7 @@ export const createRootWindow = (): void => {
     minWidth: 400,
     minHeight: 400,
     titleBarStyle: platformTitleBarStyle,
-    ...(isMac ? { trafficLightPosition: { x: 16, y: 11 } } : {}),
+    ...(isMac ? { trafficLightPosition: { x: 12, y: 13 } } : {}),
     backgroundColor: getInitialBackgroundColor(enableVibrancy),
     show: false,
     webPreferences,
@@ -355,7 +355,7 @@ export const setupRootWindow = (): void => {
             async (navigationLayout) => {
               await safeWindowOperation((browserWindow) => {
                 browserWindow.setWindowButtonPosition(
-                  navigationLayout === 'tabs' ? { x: 16, y: 11 } : null
+                  navigationLayout === 'tabs' ? { x: 12, y: 13 } : null
                 );
               }, 'Window button position update');
             }


### PR DESCRIPTION
## What

Polish pass on the workspace tab bar (follow-up to #3394 / #3413) matching macOS Chrome's tab strip metrics, measured from a side-by-side screenshot at 2x:

| Metric (CSS px) | Chrome | Before | After |
|---|---|---|---|
| Padding above tab | ~5-6 | 4 | 6 (strip 36 → 38) |
| Traffic light inset / vertical center | 12 / ~19 | 16 / 17 | 12 / 19 (x:12 y:13) |
| Green light → first tab gap | ~19.5 | ~12 | ~20 (spacer 78 → 82, list padding-left 4 → 8) |

Also makes the AddServerView background use `--rcx-color-surface-tint` (same token as the tab strip) instead of the sidebar surface, so the "add new server" screen blends with the tab bar.

## Why

The strip read as cramped next to Chrome: tabs almost touching the window top edge and the traffic lights sitting too close to the first tab.

## How to test

macOS, tabs navigation layout:
1. Open the app next to a Chrome window and compare the tab strip: space above tabs, traffic light position, and gap between the green light and the first tab.
2. Toggle fullscreen — tabs slide to the left edge (spacer collapses) with an 8px lead-in.
3. Click `+` (or remove all servers) — the add-server screen background matches the tab strip color in light and dark themes.

`tsc --noEmit` passes; spacing-only diff (6 lines).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the tab bar layout with improved spacing and height.
  * Adjusted macOS window control positioning for a more consistent appearance.
  * Updated the server view background styling to use the latest surface tint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->