### PR TITLE
fix: dedupe duplicated notification reply events on Windows

### DIFF
--- a/src/notifications/main.ts
+++ b/src/notifications/main.ts
@@ -48,6 +48,7 @@ const resolveIcon = async (
 const notifications = new Map();
 const notificationTypes = new Map<string, 'voice' | 'text'>();
 const notificationCategories = new Map<string, 'DOWNLOADS' | 'SERVER'>();
+const repliedNotifications = new Set<string>();
 
 const createNotification = async (
   id: string,
@@ -79,6 +80,8 @@ const createNotification = async (
   });
 
   notification.addListener('show', () => {
+    repliedNotifications.delete(id);
+
     dispatchSingle({
       type: NOTIFICATIONS_NOTIFICATION_SHOWN,
       payload: { id },
@@ -126,6 +129,12 @@ const createNotification = async (
   });
 
   notification.addListener('reply', (_event, reply) => {
+    // Electron 42 on Windows can dispatch a single toast reply twice (WinRT+COM activation paths)
+    if (repliedNotifications.has(id)) {
+      return;
+    }
+    repliedNotifications.add(id);
+
     dispatchSingle({
       type: NOTIFICATIONS_NOTIFICATION_REPLIED,
       payload: { id, reply },

--- a/src/notifications/main/main.spec.ts
+++ b/src/notifications/main/main.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * Regression tests for the reply-dedup guard in `src/notifications/main.ts`
+ * (Electron 42 on Windows can dispatch a single toast reply twice).
+ *
+ * Location note: jest.config.js routes MAIN-process tests via
+ *   '<rootDir>/src/*\/main/**\/*.(spec|test)...'  and
+ *   '<rootDir>/src/**\/main.(spec|test)...'
+ * A flat `src/notifications/main.spec.ts` would collide with the source file
+ * `main.ts` and does not match either main-process pattern, so this spec
+ * lives in a sibling `main/` directory to match the first pattern.
+ *
+ * `createNotification` is not exported, so the flow is driven through the
+ * real public entry point: `setupNotifications()` registers a `listen()`
+ * callback for `NOTIFICATIONS_CREATE_REQUESTED`; invoking that callback goes
+ * through the same `handleCreateEvent` -> `createNotification` path used in
+ * production.
+ */
+
+const listenRegistry = new Map<string, (action: any) => any>();
+const dispatch = jest.fn();
+const dispatchSingle = jest.fn();
+jest.mock('../../store', () => ({
+  dispatch: (...a: any[]) => dispatch(...a),
+  dispatchSingle: (...a: any[]) => dispatchSingle(...a),
+  listen: jest.fn((type: string, cb: (action: any) => any) => {
+    listenRegistry.set(type, cb);
+    return () => listenRegistry.delete(type);
+  }),
+}));
+
+jest.mock('../../store/fsa', () => ({
+  hasMeta: jest.fn(() => true),
+}));
+
+jest.mock('../../ipc/main', () => ({
+  invoke: jest.fn(),
+}));
+
+jest.mock('../../ui/main/rootWindow', () => ({
+  getRootWindow: jest.fn(),
+}));
+
+jest.mock('../../ui/main/serverView', () => ({
+  getServerUrlByWebContentsId: jest.fn(),
+}));
+
+jest.mock('../attentionDrawing', () => ({
+  __esModule: true,
+  default: {
+    drawAttention: jest.fn(),
+    stopAttention: jest.fn(),
+  },
+}));
+
+type Listener = (...args: any[]) => void;
+
+class FakeNotification {
+  static instances: FakeNotification[] = [];
+
+  listeners: Record<string, Listener[]> = {};
+
+  constructor(public options: any) {
+    FakeNotification.instances.push(this);
+  }
+
+  addListener(event: string, fn: Listener) {
+    (this.listeners[event] ??= []).push(fn);
+  }
+
+  show = jest.fn();
+
+  fire(event: string, ...args: any[]) {
+    (this.listeners[event] ?? []).forEach((fn) => fn(...args));
+  }
+}
+
+jest.mock('electron', () => ({
+  Notification: jest
+    .fn()
+    .mockImplementation((options: any) => new FakeNotification(options)),
+  nativeImage: { createFromDataURL: jest.fn() },
+}));
+
+describe('notifications/main — reply dedup guard', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    listenRegistry.clear();
+    FakeNotification.instances.length = 0;
+  });
+
+  const create = async (tag = 'notif-1') => {
+    const { setupNotifications } = (await import('../main')) as any;
+    setupNotifications();
+    const createRequestedHandler = listenRegistry.get(
+      'notifications/create-requested'
+    );
+    if (!createRequestedHandler) {
+      throw new Error('create-requested listener not registered');
+    }
+    await createRequestedHandler({
+      type: 'notifications/create-requested',
+      payload: { tag, title: 'Hello' },
+      meta: { id: 'req-1' },
+    });
+    return FakeNotification.instances[FakeNotification.instances.length - 1];
+  };
+
+  const repliedCalls = () =>
+    dispatchSingle.mock.calls.filter(
+      ([action]) => action.type === 'notifications/notification-replied'
+    );
+
+  it('dispatches REPLIED exactly once when the same reply event fires twice', async () => {
+    const notification = await create();
+
+    notification.fire('reply', {}, 'hi there');
+    notification.fire('reply', {}, 'hi there');
+
+    expect(repliedCalls()).toHaveLength(1);
+    expect(repliedCalls()[0][0].payload).toEqual({
+      id: 'notif-1',
+      reply: 'hi there',
+    });
+  });
+
+  it('re-arms the guard after another show event, allowing a subsequent reply to dispatch', async () => {
+    const notification = await create();
+
+    notification.fire('reply', {}, 'first reply');
+    notification.fire('show');
+    notification.fire('reply', {}, 'second reply');
+
+    expect(repliedCalls()).toHaveLength(2);
+    expect(repliedCalls()[1][0].payload).toEqual({
+      id: 'notif-1',
+      reply: 'second reply',
+    });
+  });
+});


### PR DESCRIPTION
## What

Replying to a desktop notification on Windows sent the message twice.

## Why

The 4.15.x line ships Electron 42.5.0. Before Electron 42, inline-reply events from Windows toasts were not dispatched at all on non-MSIX installs; electron/electron#51286 (landed in 42) enabled them, but a single user reply can now be delivered more than once to the app:

- both the WinRT in-process activation path and the COM toast-activator path can dispatch the same reply, with no upstream dedupe, and
- re-showing the same `Notification` instance (our same-tag update path in `src/notifications/main.ts`) registers additional toast event handlers, and per Electron docs the reply event "can be fired multiple times".

Each duplicated `'reply'` event flowed main → preload → webapp (that chain is strictly 1:1) and the webapp sent the message once per event.

## How

Idempotency guard at the source boundary in the main process: a `repliedNotifications` set keyed by notification id.

- `'reply'` listener dispatches `NOTIFICATIONS_NOTIFICATION_REPLIED` only for ids not in the set.
- The set entry is cleared on `'show'` (each display cycle re-arms the reply), so replying again to a re-displayed notification still works.
- Deliberately **not** cleared on `'close'`: the duplicate event can arrive after the toast dismisses, so clearing there would let it through.

Cross-platform by design — a second reply within one show-cycle is never a legitimate user action (submitting a reply dismisses the toast on every OS).

## Testing

- New main-process spec `src/notifications/main/main.spec.ts` driving the real `setupNotifications()` → create-requested → listener path: duplicate `'reply'` dispatches exactly once; a subsequent `'show'` re-arms the guard.
- `tsc --noEmit`, targeted Jest, and ESLint pass on the 4.15.5 base.
- Runtime toast behavior on Windows still needs validation with a signed installer — hence `build-artifacts`.

## Release

Targets `hotfix/4.15.6` (branched from the 4.15.5 tag) for a 4.15.6 patch release. Should also be cherry-picked to `master` (applies clean; `src/notifications/main.ts` is identical there).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate notification reply events from triggering repeated actions.
  - Reply handling is correctly reset when a notification is shown again.

- **Tests**
  - Added regression coverage for duplicate replies and notification re-display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->