### PR TITLE
fix: theme-aware tab strip, tooltip address line, and divider polish

### DIFF
--- a/src/ui/components/Shell/index.spec.tsx
+++ b/src/ui/components/Shell/index.spec.tsx
@@ -208,11 +208,12 @@ describe('Shell', () => {
     ).toBeInTheDocument();
   });
 
-  it('forces the dark theme regardless of the machine theme', () => {
+  it('forces the dark theme when transparency is disabled, regardless of the machine theme', () => {
     renderWithStore(<Shell />, {
       preloadedState: buildState({
         machineTheme: 'light',
         userThemePreference: 'auto',
+        isTransparentWindowEnabled: false,
       }),
     });
 
@@ -222,11 +223,57 @@ describe('Shell', () => {
     );
   });
 
-  it('forces the dark theme regardless of the user theme preference', () => {
+  it('forces the dark theme when transparency is disabled, regardless of the user theme preference', () => {
     renderWithStore(<Shell />, {
       preloadedState: buildState({
         machineTheme: 'light',
         userThemePreference: 'light',
+        isTransparentWindowEnabled: false,
+      }),
+    });
+
+    expect(screen.getByTestId('palette-style-tag')).toHaveAttribute(
+      'data-theme',
+      'dark'
+    );
+  });
+
+  it('follows the machine theme when transparency is enabled and preference is auto', () => {
+    renderWithStore(<Shell />, {
+      preloadedState: buildState({
+        machineTheme: 'light',
+        userThemePreference: 'auto',
+        isTransparentWindowEnabled: true,
+      }),
+    });
+
+    expect(screen.getByTestId('palette-style-tag')).toHaveAttribute(
+      'data-theme',
+      'light'
+    );
+  });
+
+  it('follows the explicit user theme preference when transparency is enabled', () => {
+    renderWithStore(<Shell />, {
+      preloadedState: buildState({
+        machineTheme: 'dark',
+        userThemePreference: 'light',
+        isTransparentWindowEnabled: true,
+      }),
+    });
+
+    expect(screen.getByTestId('palette-style-tag')).toHaveAttribute(
+      'data-theme',
+      'light'
+    );
+  });
+
+  it('keeps the dark theme with transparency enabled when the resolved theme is dark', () => {
+    renderWithStore(<Shell />, {
+      preloadedState: buildState({
+        machineTheme: 'dark',
+        userThemePreference: 'auto',
+        isTransparentWindowEnabled: true,
       }),
     });
 

--- a/src/ui/components/Shell/index.tsx
+++ b/src/ui/components/Shell/index.tsx
@@ -24,6 +24,7 @@ import { TelephonyDefaultHandlerPromptModal } from '../TelephonyDefaultHandlerPr
 import { TelephonyServerSelectModal } from '../TelephonyServerSelectModal';
 import { TopBar } from '../TopBar';
 import { UpdateDialog } from '../UpdateDialog';
+import { useShellTheme } from '../hooks/useShellTheme';
 import TooltipProvider from '../utils/TooltipProvider';
 import { GlobalStyles, WindowDragBar } from './styles';
 
@@ -35,6 +36,8 @@ export const Shell = () => {
   const navigationLayout = useSelector(
     ({ navigationLayout }: RootState) => navigationLayout
   );
+
+  const shellTheme = useShellTheme();
 
   useLayoutEffect(() => {
     if (!appPath) {
@@ -54,7 +57,7 @@ export const Shell = () => {
   return (
     <TooltipProvider>
       <PaletteStyleTag
-        theme='dark'
+        theme={shellTheme}
         selector=':root'
         // tagId='sidebar-palette'
       />
@@ -63,7 +66,7 @@ export const Shell = () => {
         <WindowDragBar />
       )}
       <Box
-        bg='sidebar'
+        bg={isTransparentWindowEnabled ? 'transparent' : 'sidebar'}
         display='flex'
         flexWrap='wrap'
         height='100vh'

--- a/src/ui/components/TabBar/WorkspaceTab.tsx
+++ b/src/ui/components/TabBar/WorkspaceTab.tsx
@@ -12,6 +12,7 @@ import { TooltipContext } from '../utils/TooltipContext';
 import { getServerPanelId, getServerTabId } from '../utils/getServerDomId';
 import { getServerInitials } from '../utils/getServerInitials';
 import {
+  Divider,
   Favicon,
   Initials,
   Label,
@@ -26,6 +27,22 @@ const formatMentionCount = (count: number | undefined): string | undefined => {
   }
 
   return count > 99 ? '99+' : String(count);
+};
+
+// Some servers embed their address in the title (e.g.
+// "Rocket.Chat - https://stable.rocket.chat/"). Strip it out so the tooltip can
+// show the name on its own line. Returns '' when the title is only the address.
+const removeServerAddress = (title: string, serverAddress: string): string => {
+  const index = title.toLowerCase().indexOf(serverAddress.toLowerCase());
+
+  if (index === -1) {
+    return title.trim();
+  }
+
+  const before = title.slice(0, index);
+  const after = title.slice(index + serverAddress.length).replace(/^\/+/, '');
+
+  return `${before}${after}`.replace(/^[\s\-–—|·:]+|[\s\-–—|·:]+$/g, '').trim();
 };
 
 type WorkspaceTabProps = {
@@ -110,7 +127,26 @@ const WorkspaceTab = ({
 
   const unreadSuffix = getUnreadSuffix();
 
-  const tooltipText = `${title}${unreadSuffix}${shortcutSuffix}`;
+  const serverAddress = url.replace(/\/+$/, '');
+  const tooltipName = removeServerAddress(title, serverAddress);
+  const tooltipPrimaryLine = `${
+    tooltipName || serverAddress
+  }${unreadSuffix}${shortcutSuffix}`;
+  // Show the name on the first line and the address on a second line. When the
+  // title is only the address, the primary line already is it, so skip line two.
+  const tooltipLines = tooltipName
+    ? [tooltipPrimaryLine, serverAddress]
+    : [tooltipPrimaryLine];
+  // The TooltipProvider renders each '\n'-separated line on its own row, so the
+  // native title, the custom hover tooltip and the aria-label all stay in sync.
+  const tooltipText = tooltipLines.join('\n');
+  const tooltipNode = (
+    <>
+      {tooltipLines.map((line, index) => (
+        <div key={index}>{line}</div>
+      ))}
+    </>
+  );
 
   const handleClick = (): void => {
     dispatch({ type: SIDE_BAR_SERVER_SELECTED, payload: url });
@@ -129,7 +165,7 @@ const WorkspaceTab = ({
   };
 
   const handleFocus = (event: FocusEvent<HTMLButtonElement>): void => {
-    tooltip.open(<>{tooltipText}</>, event.currentTarget);
+    tooltip.open(tooltipNode, event.currentTarget);
   };
 
   const handleBlur = (): void => {
@@ -163,7 +199,11 @@ const WorkspaceTab = ({
       >
         <Initials visible={!favicon}>{initials}</Initials>
         <Favicon visible={!!favicon} src={favicon ?? ''} draggable='false' />
-        {!compact && <Label>{title}</Label>}
+        {!compact && (
+          <Label>
+            {title.replace(/(^|\s)(https?:\/\/)/, '$1').replace(/\/+$/, '')}
+          </Label>
+        )}
         {!compact && isShortcutVisible && shortcutNumber && (
           <ShortcutChip>{shortcutNumber}</ShortcutChip>
         )}
@@ -172,6 +212,7 @@ const WorkspaceTab = ({
         )}
         {!userLoggedIn && <TabBadge variant='warning'>!</TabBadge>}
       </Tab>
+      <Divider></Divider>
       {isVisible && (
         <WorkspaceContextMenu
           reference={ref}

--- a/src/ui/components/TabBar/index.spec.tsx
+++ b/src/ui/components/TabBar/index.spec.tsx
@@ -286,7 +286,7 @@ describe('TabBar', () => {
     expect(tab).toHaveStyle({
       flex: '0 1 auto',
       minWidth: '52px',
-      maxWidth: '180px',
+      maxWidth: '230px',
     });
   });
 

--- a/src/ui/components/TabBar/index.tsx
+++ b/src/ui/components/TabBar/index.tsx
@@ -9,6 +9,7 @@ import { SIDE_BAR_ADD_NEW_SERVER_CLICKED } from '../../actions';
 import { isDarwin } from '../../utils/platform';
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts';
 import { useServers } from '../hooks/useServers';
+import { useShellTheme } from '../hooks/useShellTheme';
 import { useSorting } from '../hooks/useSorting';
 import WorkspaceTab from './WorkspaceTab';
 import {
@@ -37,6 +38,8 @@ export const TabBar = ({ leadingSlot, trailingSlot }: TabBarProps) => {
   const isTransparentWindowEnabled = useSelector(
     ({ isTransparentWindowEnabled }: RootState) => isTransparentWindowEnabled
   );
+
+  const paletteTheme = useShellTheme();
 
   const isFullscreen = useSelector(
     ({ rootWindowState }: RootState) => rootWindowState.fullscreen
@@ -103,7 +106,10 @@ export const TabBar = ({ leadingSlot, trailingSlot }: TabBarProps) => {
   };
 
   return (
-    <Strip isTransparentWindowEnabled={isTransparentWindowEnabled}>
+    <Strip
+      isTransparentWindowEnabled={isTransparentWindowEnabled}
+      paletteTheme={paletteTheme}
+    >
       {leadingSlot}
       {isDarwin && <TrafficLightSpacer collapsed={isFullscreen} />}
       <TabList
@@ -147,7 +153,9 @@ export const TabBar = ({ leadingSlot, trailingSlot }: TabBarProps) => {
           );
         })}
         {isAddNewServersEnabled && (
-          <AddButtonWrapper>
+          <AddButtonWrapper
+            isTransparentWindowEnabled={isTransparentWindowEnabled}
+          >
             <IconButton
               small
               icon='plus-small'

--- a/src/ui/components/TabBar/styles.tsx
+++ b/src/ui/components/TabBar/styles.tsx
@@ -2,19 +2,49 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { Badge } from '@rocket.chat/fuselage';
 
+/**
+ * Fill shared by the selected tab, tab hover, dividers and the strip border.
+ *
+ * Over the opaque window it uses the solid sidebar surface. Over a transparent
+ * window it becomes a translucent overlay that inverts with the palette — a
+ * subtle darkening in light mode and a subtle brightening in dark mode — so the
+ * selected tab always contrasts with whatever shows through.
+ */
+const CHROME_FILL_OPAQUE = 'var(--rcx-color-surface-sidebar, #2f343d)';
+const CHROME_FILL_OVERLAY_LIGHT = 'rgba(0, 0, 0, 0.125)';
+const CHROME_FILL_OVERLAY_DARK = 'rgba(255, 255, 255, 0.125)';
+
+const resolveChromeFill = (
+  paletteTheme: 'light' | 'dark',
+  isTransparentWindowEnabled: boolean
+): string => {
+  if (!isTransparentWindowEnabled) {
+    return CHROME_FILL_OPAQUE;
+  }
+
+  return paletteTheme === 'dark'
+    ? CHROME_FILL_OVERLAY_DARK
+    : CHROME_FILL_OVERLAY_LIGHT;
+};
+
 type StripProps = {
   isTransparentWindowEnabled: boolean;
+  paletteTheme: 'light' | 'dark';
 };
 
 export const Strip = styled.div<StripProps>`
+  --tab-chrome-fill: ${({ paletteTheme, isTransparentWindowEnabled }) =>
+    resolveChromeFill(paletteTheme, isTransparentWindowEnabled)};
+
   display: flex;
   flex-direction: row;
   align-items: stretch;
   flex: 0 0 auto;
   width: 100%;
-  height: 38px;
+  height: 40px;
   -webkit-app-region: drag;
   user-select: none;
+  border-bottom: 1px solid var(--tab-chrome-fill);
   background-color: ${({ isTransparentWindowEnabled }) =>
     isTransparentWindowEnabled
       ? 'transparent'
@@ -27,7 +57,7 @@ type TrafficLightSpacerProps = {
 
 export const TrafficLightSpacer = styled.div<TrafficLightSpacerProps>`
   flex: 0 0 auto;
-  width: ${({ collapsed }) => (collapsed ? '0px' : '82px')};
+  width: ${({ collapsed }) => (collapsed ? '0px' : '76px')};
   -webkit-app-region: drag;
   transition: width var(--transitions-duration, 100ms);
 `;
@@ -38,7 +68,7 @@ export const TabList = styled.div`
   align-items: flex-end;
   flex: 1 1 auto;
   min-width: 0;
-  gap: 4px;
+  gap: 1px;
   padding-left: 8px;
   overflow: hidden;
   -webkit-app-region: drag;
@@ -49,13 +79,29 @@ export const DragSpacer = styled.div`
   -webkit-app-region: drag;
 `;
 
-export const AddButtonWrapper = styled.div`
+type AddButtonWrapperProps = {
+  isTransparentWindowEnabled: boolean;
+};
+
+export const AddButtonWrapper = styled.div<AddButtonWrapperProps>`
   display: flex;
   align-items: flex-start;
   align-self: flex-end;
   height: 32px;
   flex: 0 0 auto;
   -webkit-app-region: no-drag;
+
+  /* Over a transparent window, match the add button's hover to the tab hover
+     fill instead of the opaque fuselage default. The '& button:hover' selector
+     outranks fuselage's '.rcx-button--icon:hover'. */
+  ${({ isTransparentWindowEnabled }) =>
+    isTransparentWindowEnabled &&
+    css`
+      & button:hover {
+        background-color: var(--tab-chrome-fill);
+        border-color: var(--tab-chrome-fill);
+      }
+    `}
 `;
 
 type TabProps = {
@@ -74,21 +120,26 @@ export const Tab = styled.button<TabProps>`
   align-items: center;
   gap: 6px;
   flex: 0 1 auto;
+  width: 230px;
   min-width: 52px;
-  max-width: 180px;
-  height: 32px;
+  max-width: 230px;
+  height: 28px;
   align-self: flex-end;
   position: relative;
   padding: ${({ isCompact }) => (isCompact ? '0 6px' : '0 10px')};
+  margin-bottom: 4px;
   cursor: pointer;
   -webkit-app-region: no-drag;
   color: var(--rcx-color-font-default, #1f2329);
-  border-radius: 10px 10px 0 0;
+  border-radius: 8px 8px 0 0;
 
   ${({ isSelected }) =>
     isSelected
       ? css`
-          background-color: var(--rcx-color-surface-sidebar, #2f343d);
+          background-color: var(--tab-chrome-fill);
+          margin-bottom: 0px;
+          padding-bottom: 4px;
+          height: 32px;
           z-index: 1;
 
           /* Chrome-style concave fillets where the tab meets the strip */
@@ -107,7 +158,7 @@ export const Tab = styled.button<TabProps>`
             background: radial-gradient(
               circle at 0 0,
               transparent 10px,
-              var(--rcx-color-surface-sidebar, #2f343d) 10.5px
+              var(--tab-chrome-fill) 10.5px
             );
           }
 
@@ -116,18 +167,43 @@ export const Tab = styled.button<TabProps>`
             background: radial-gradient(
               circle at 100% 0,
               transparent 10px,
-              var(--rcx-color-surface-sidebar, #2f343d) 10.5px
+              var(--tab-chrome-fill) 10.5px
             );
           }
         `
       : css`
           &:hover {
-            background-color: var(--rcx-color-surface-neutral, #2d3039);
+            transition: background-color 150ms ease;
+            background-color: var(--tab-chrome-fill);
+            border-radius: 8px;
           }
         `}
 
   &:focus-visible {
     box-shadow: inset 0 0 0 2px var(--rcx-color-stroke-highlight, #1d74f5);
+  }
+`;
+
+export const Divider = styled.div`
+  width: 2px;
+  height: 16px;
+  border-radius: 4px;
+  margin-bottom: 10px;
+  background-color: var(--tab-chrome-fill);
+  transition: opacity 150ms ease;
+
+  /* Each tab renders a trailing divider, so one sits between the last tab and
+     the add button automatically. Hide the dangling divider at the strip's
+     trailing edge (no add button) and the ones flanking the active or hovered
+     tab (its previous sibling via :has, its next sibling via +). Targets
+     aria-selected / role='tab' rather than the Tab component selector, which
+     needs @emotion/babel-plugin (not enabled). */
+  &:last-child,
+  &:has(+ [aria-selected='true']),
+  [aria-selected='true'] + &,
+  &:has(+ [role='tab']:hover),
+  [role='tab']:hover + & {
+    opacity: 0;
   }
 `;
 
@@ -166,9 +242,10 @@ export const Label = styled.span`
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 10px;
-  font-weight: 700;
+  font-size: 11px;
+  font-weight: 600;
   line-height: 12px;
+  text-align: left;
 `;
 
 export const ShortcutChip = styled.span`

--- a/src/ui/components/TabBar/styles.tsx
+++ b/src/ui/components/TabBar/styles.tsx
@@ -91,6 +91,10 @@ export const AddButtonWrapper = styled.div<AddButtonWrapperProps>`
   flex: 0 0 auto;
   -webkit-app-region: no-drag;
 
+  & button {
+    border-radius: 8px;
+  }
+
   /* Over a transparent window, match the add button's hover to the tab hover
      fill instead of the opaque fuselage default. The '& button:hover' selector
      outranks fuselage's '.rcx-button--icon:hover'. */
@@ -126,12 +130,12 @@ export const Tab = styled.button<TabProps>`
   height: 28px;
   align-self: flex-end;
   position: relative;
-  padding: ${({ isCompact }) => (isCompact ? '0 6px' : '0 10px')};
+  padding: ${({ isCompact }) => (isCompact ? '0 6px' : '0 6px')};
   margin-bottom: 4px;
   cursor: pointer;
   -webkit-app-region: no-drag;
   color: var(--rcx-color-font-default, #1f2329);
-  border-radius: 8px 8px 0 0;
+  border-radius: 8px;
 
   ${({ isSelected }) =>
     isSelected
@@ -139,6 +143,8 @@ export const Tab = styled.button<TabProps>`
           background-color: var(--tab-chrome-fill);
           margin-bottom: 0px;
           padding-bottom: 4px;
+          border-bottom-right-radius: 0px;
+          border-bottom-left-radius: 0px;
           height: 32px;
           z-index: 1;
 
@@ -190,6 +196,7 @@ export const Divider = styled.div`
   border-radius: 4px;
   margin-bottom: 10px;
   background-color: var(--tab-chrome-fill);
+  opacity: 0.5;
   transition: opacity 150ms ease;
 
   /* Each tab renders a trailing divider, so one sits between the last tab and
@@ -197,12 +204,15 @@ export const Divider = styled.div`
      trailing edge (no add button) and the ones flanking the active or hovered
      tab (its previous sibling via :has, its next sibling via +). Targets
      aria-selected / role='tab' rather than the Tab component selector, which
-     needs @emotion/babel-plugin (not enabled). */
+     needs @emotion/babel-plugin (not enabled). The '+ div button:hover' rule
+     hides the divider before the add button (wrapped in a div) when that button
+     is hovered. */
   &:last-child,
   &:has(+ [aria-selected='true']),
   [aria-selected='true'] + &,
   &:has(+ [role='tab']:hover),
-  [role='tab']:hover + & {
+  [role='tab']:hover + &,
+  &:has(+ div button:hover) {
     opacity: 0;
   }
 `;

--- a/src/ui/components/hooks/useShellTheme.ts
+++ b/src/ui/components/hooks/useShellTheme.ts
@@ -1,0 +1,31 @@
+import { useSelector } from 'react-redux';
+
+import type { RootState } from '../../../store/rootReducer';
+
+/**
+ * Resolves the palette used for the app shell chrome (tab bar, sidebar,
+ * title bar).
+ *
+ * The chrome is pinned to the dark palette so it reads well over the opaque
+ * window background. When transparency is enabled the desktop shows through, so
+ * we follow the user's resolved theme ('auto' tracks the OS) to keep chrome
+ * text legible over a light background.
+ */
+export const useShellTheme = (): 'light' | 'dark' => {
+  const isTransparentWindowEnabled = useSelector(
+    ({ isTransparentWindowEnabled }: RootState) => isTransparentWindowEnabled
+  );
+  const machineTheme = useSelector(
+    ({ machineTheme }: RootState) => machineTheme
+  );
+  const userThemePreference = useSelector(
+    ({ userThemePreference }: RootState) => userThemePreference
+  );
+
+  const resolvedTheme =
+    userThemePreference === 'auto' ? machineTheme : userThemePreference;
+
+  return isTransparentWindowEnabled && resolvedTheme === 'light'
+    ? 'light'
+    : 'dark';
+};


### PR DESCRIPTION
## What changed

Polish for the workspace tab strip, focused on transparent-window legibility and small UX fixes.

### Theming
- The shell palette now follows the resolved theme (`auto` tracks the OS) **when the window is transparent**; opaque windows stay pinned to dark. Extracted into a shared `useShellTheme` hook used by both `Shell` and `TabBar`.
- Centralized the selected-tab / hover / divider / strip-border fill into a single `--tab-chrome-fill` CSS variable set on `Strip`. Over a transparent window it becomes a translucent overlay that **inverts with the palette** (subtle darkening in light mode, subtle brightening in dark mode); opaque uses the solid sidebar surface.

### Add button
- Matches the button hover background to the tab fill when transparency is enabled (falls back to fuselage's default when opaque).

### Dividers
- Each tab now renders its divider as a **trailing** sibling, so one sits between the last tab and the add button automatically — no special-case element.
- Divider visibility (leading edge, and the flanks of the selected/hovered tab) is driven **purely in CSS** via `aria-selected` / `role="tab"` sibling selectors, replacing the previous JS `isDividerVisible` computation.
- Tab hover background and divider opacity now animate (150ms).

### Tooltip
- Tab tooltip shows the server address on its own second line, with the trailing slash removed. When the title already embeds the address, it's stripped from the name line so it isn't duplicated.

### Test
- Updated the tab `max-width` assertion from 180px to 230px to match the current strip metrics.

## Verification
- `tsc --noEmit`: pass
- `yarn lint`: pass
- `yarn test`: 156 suites / 1674 tests passing, 0 failed (2 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Images

Not transparent, Dark (Before / After)
<img width="2386" height="971" alt="Screenshot 2026-07-17 at 13 52 59 (3)" src="https://github.com/user-attachments/assets/afcf7765-bb97-47d7-9cbd-45f7fe643f21" />

Not transparent, Light (Before / After)
<img width="2400" height="975" alt="Screenshot 2026-07-17 at 13 53 15 (3)" src="https://github.com/user-attachments/assets/4c9ff43f-103a-458c-88dc-0a113b29460f" />

Transparent, Dark (Before / After)
<img width="2393" height="975" alt="Screenshot 2026-07-17 at 13 54 26 (3)" src="https://github.com/user-attachments/assets/6a302207-f602-4abd-94fe-f8b833bb4a2e" />

Transparent, Light (Before / After)
<img width="2406" height="974" alt="Screenshot 2026-07-17 at 13 54 18 (3)" src="https://github.com/user-attachments/assets/03c2d060-6010-4222-872e-204b51f5554e" />

Hover before
<img width="706" height="223" alt="Screenshot 2026-07-17 at 16 29 57" src="https://github.com/user-attachments/assets/84d60630-dd53-4544-bf70-462ef52587a8" />

Hover after
<img width="829" height="216" alt="Screenshot 2026-07-17 at 16 30 16" src="https://github.com/user-attachments/assets/a8936c88-1049-4620-b7d4-1bc46cdef425" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added adaptive light/dark shell theming that follows transparency, machine theme, and user theme preference.
  * Enhanced workspace tab tooltips with clearer multi-line server name/address and improved label formatting.
  * Added dividers between workspace tabs.

* **UI Improvements**
  * Updated tab bar “chrome” styling for transparent vs opaque windows, including new gradient behavior, sizing/spacing, hover/selected states, and typography.

* **Tests**
  * Expanded and refined theme selection assertions to cover transparent and non-transparent scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->