### PR TITLE
chore: bump version to 4.16.0-alpha.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "Rocket.Chat",
   "name": "rocketchat",
   "description": "Official OSX, Windows, and Linux Desktop Clients for Rocket.Chat",
-  "version": "4.16.0-alpha.1",
+  "version": "4.16.0-alpha.2",
   "author": "Rocket.Chat Support <support@rocket.chat>",
   "copyright": "© 2016-2026, Rocket.Chat",
   "homepage": "https://rocket.chat",


### PR DESCRIPTION
Bumps the version to `4.16.0-alpha.2` so the release tag can be created.

## What's in this alpha

Two commits since `4.16.0-alpha.1` (tagged 14 Jul):

- **#3424** — reworks workspace navigation into **Tabs**, **Sidebar** and **Titlebar** layouts (45 files, +1696/−1812). Chrome-style horizontal tab strip, icon-only vertical sidebar replacing the old `SideBar`, and a titlebar-only mode with a compact server switcher. Also unifies the window title bar into `TopBar` (drops `WindowsTitleBar`), replaces the React workspace context menus with native ones, makes the shell chrome theme-aware, and restores the Theme selector in Settings → General.
- **#3419** — aligns workspace tab bar spacing with Chrome tab strip metrics (6 lines).

So this alpha is effectively "the navigation rework". It is the highest-risk change in 4.16.0 and it deserves soak time on its own before more work stacks on top.

## Testing focus

The new navigation is a lot of surface that only real usage will shake out:

- All three layouts (Tabs / Sidebar / Titlebar) on **macOS, Windows and Linux**
- Switching layouts via Settings → General and the View menu, plus the ⌘/Ctrl+Shift+S cycle
- Native server context menus (right-click a tab, right-click the titlebar switcher)
- Theme Auto / Light / Dark, including transparent-window mode
- Unread and mention badges in both orientations
- Drag-to-reorder tabs, the add-workspace button, and the ⌘/Ctrl+`<n>` shortcuts

## Known issue in this build

macOS in-app updates do not install — the app quits and offers the same update again on the next launch (#955). The fix is in #3431 but is deliberately held for the next cycle, because it can only be validated on a packaged, signed build against a real update feed and a mistake there costs users the ability to update at all.

**Practical impact for testers:** on macOS, install the next alpha manually rather than expecting the in-app updater to move you off this one. This is pre-existing behaviour, not a regression introduced here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package to version `4.16.0-alpha.2`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->