### PR TITLE
fix: keep macOS native fullscreen when pressing ESC

### DIFF
--- a/qa/README.md
+++ b/qa/README.md
@@ -9,13 +9,13 @@ lowercase, and specific, for example `qa/telephony-deeplink/`.
 
 ## Pack Structure
 
-| Path | Required | Purpose |
-| --- | --- | --- |
-| `README.md` | Yes | Entry point, prerequisites, smoke order, result format |
-| `flows/` | Yes | One Markdown file per scenario |
-| `test-links.html` | When useful | Static browser page for protocol/deep-link/manual click targets |
-| `scripts/` | Optional | Small helper scripts for repeatable environment checks |
-| `results/` | Optional | Local evidence notes; do not commit run-specific artifacts by default |
+| Path              | Required    | Purpose                                                               |
+| ----------------- | ----------- | --------------------------------------------------------------------- |
+| `README.md`       | Yes         | Entry point, prerequisites, smoke order, result format                |
+| `flows/`          | Yes         | One Markdown file per scenario                                        |
+| `test-links.html` | When useful | Static browser page for protocol/deep-link/manual click targets       |
+| `scripts/`        | Optional    | Small helper scripts for repeatable environment checks                |
+| `results/`        | Optional    | Local evidence notes; do not commit run-specific artifacts by default |
 
 ## Flow Files
 
@@ -167,3 +167,8 @@ unless a release owner explicitly asks for them.
 
 - `qa/telephony-deeplink/` covers telephony `tel:` / `callto:` links, settings,
   diagnostics, workspace selection, default handlers, and installer policy.
+- `qa/supported-versions/` covers supported-version exception matching and the
+  unsupported-version block.
+- `qa/macos-fullscreen-escape/` covers the macOS native fullscreen behavior of the
+  Escape key, including video HTML5 fullscreen, and the Windows/Linux regression
+  check.

--- a/qa/macos-fullscreen-escape/README.md
+++ b/qa/macos-fullscreen-escape/README.md
@@ -1,0 +1,63 @@
+# macOS Fullscreen Escape QA Pack
+
+This folder contains manual and agent-readable QA flows for the macOS native
+fullscreen behavior of the Escape key. It covers the case where the app window is
+in native fullscreen and the Escape key must not drop the window out of
+fullscreen, whether or not a video is playing in HTML5 fullscreen.
+
+This behavior cannot be proven by the Jest suite. The bug lives in how macOS
+AppKit reacts to a real key event coming from the operating system, and any test
+generated key event is synthetic and never reaches AppKit. Automated tests only
+protect the desktop-side wiring, so these flows are the coverage for the OS half
+and must be run on real macOS hardware.
+
+The flows are intentionally written for testers without implementation context.
+
+## Quick Start
+
+From the repo root:
+
+```sh
+node qa/scripts/validate-flows.mjs qa/macos-fullscreen-escape
+node qa/scripts/export-qase-csv.mjs qa/macos-fullscreen-escape
+```
+
+## Smoke Order
+
+1. Run `flows/01-video-fullscreen-escape.md`.
+2. Run `flows/02-plain-escape-keeps-fullscreen.md`.
+3. Run `flows/03-escape-and-shortcut-regressions.md`.
+4. Run `flows/04-windows-linux-escape-unchanged.md` on Windows and Linux.
+
+## Flow Result Format
+
+```text
+Flow ID:
+Platform:
+Build:
+Review range:
+Coverage: Full requested range | Partial surface review
+Result: Pass | Fail | Blocked
+Finding status: confirmed | suspected | blocked | none
+Evidence:
+Notes:
+```
+
+## Folder Map
+
+| Path       | Purpose                                                           |
+| ---------- | ----------------------------------------------------------------- |
+| `flows/`   | Structured QA flows                                               |
+| `exports/` | Generated Qase CSV exports                                        |
+| `results/` | Optional local evidence area; do not commit run-specific evidence |
+
+## Source Of Truth
+
+When updating this pack, derive expected behavior from:
+
+- `src/ui/main/escapeFullscreenGuard.ts`
+- `src/ui/main/escapeFullscreenGuard.main.spec.ts`
+- `src/ui/main/serverView/index.ts` (`before-input-event` handling for guest views)
+- `src/ui/main/rootWindow.ts` (`before-input-event` handling for the app chrome)
+- `src/ui/main/menuBar.ts` (macOS `Full screen` item, `Control+Command+F`)
+- `src/ui/components/TabBar/styles.tsx` (`TrafficLightSpacer` collapses in fullscreen)

--- a/qa/macos-fullscreen-escape/exports/README.md
+++ b/qa/macos-fullscreen-escape/exports/README.md
@@ -1,0 +1,15 @@
+# Qase Exports
+
+This directory is for generated Qase import files.
+
+Run:
+
+```sh
+node qa/scripts/export-qase-csv.mjs qa/macos-fullscreen-escape
+```
+
+The script writes `qase-import.csv`. Import it in Qase with source type
+`Qase.io`.
+
+Do not hand-edit generated CSV files. Edit the Markdown flows, validate them,
+and export again.

--- a/qa/macos-fullscreen-escape/exports/qase-import.csv
+++ b/qa/macos-fullscreen-escape/exports/qase-import.csv
@@ -1,0 +1,142 @@
+v2.id,suite_id,suite,suite_without_cases,title,description,preconditions,postconditions,severity,priority,status,automation,steps_type,tags,steps_actions,steps_data,steps_results
+"","1","Window and fullscreen","1","","","","","","","","","","","","",""
+"","1","Window and fullscreen","","Escape leaves only the video fullscreen while the app window stays fullscreen","Source flow: FSESC-QA-001
+
+Pressing Escape while a video plays in HTML5 fullscreen returns the video to its inline size and the app window remains in macOS native fullscreen.","installed_branch_build
+workspace_logged_in","- Screenshot taken right after the Escape press showing the inline video and a
+  window that still covers the whole screen.
+- Note of the `View` -> `Full screen` checkmark state before and after Escape.
+- macOS version and build identifier.","major","high","actual","manual","classic","FSESC-QA-001,source:repo-qa,platform:macos,requires:installed_branch_build,requires:workspace_logged_in","1. ""Launch the Rocket.Chat Desktop build under test on macOS and wait until a workspace channel list is visible on the left and message content fills the rest of the window.""
+2. ""Put the window into macOS native fullscreen: click the green circular button at the top-left corner of the window, the third of the three colored dots.""
+3. ""Confirm the app itself knows it is fullscreen: move the pointer to the very top of the screen so the macOS menu bar appears, click `View` in that menu bar, and look at the `Full screen` item.""
+4. ""In the message box at the bottom of the channel, attach and send a short video file, then click the play button in the middle of the video player that appears in the message list.""
+5. ""Hover the playing video to reveal its control bar, then click the fullscreen button at the right end of that bar, the icon drawn as four outward-pointing corner brackets.""
+6. ""Press the `Escape` key once.""
+7. ""Move the pointer to the top of the screen, click `View` in the macOS menu bar and confirm `Full screen` still shows a checkmark.""
+8. ""Repeat steps 5 to 7 with an embedded player instead of an attachment: send a message containing a YouTube video link, wait for the preview player to render under the message, click its play button, then click the fullscreen button at the right end of the player's own control bar.""
+9. ""Record the result using the format in `qa/macos-fullscreen-escape/README.md`.""","1. ""Build from branch `fix/macos-escape-exits-fullscreen` or the release candidate containing it; any workspace where you can post a file.
+Agent: Launch the build and confirm the workspace view rendered.""
+2. ""No input data.
+Agent: Enter fullscreen through the window control and confirm the window covers the screen.""
+3. ""Menu path: macOS menu bar -> `View` -> `Full screen` (keyboard equivalent `Control+Command+F`).
+Agent: Read the menu state or the app's fullscreen state and confirm it reports fullscreen.""
+4. ""Any small `.mp4` file, for example a 5 to 10 second clip.
+Agent: Post the video and start playback.""
+5. ""No input data.
+Agent: Enter the video's HTML5 fullscreen and confirm only the video is visible.""
+6. ""Key: `Escape`.
+Agent: Send one Escape key press and then compare the window bounds against the screen bounds.""
+7. ""Menu path: macOS menu bar -> `View` -> `Full screen`.
+Agent: Re-read the fullscreen state and confirm it is unchanged.""
+8. ""Any public YouTube URL, for example a short clip link pasted as plain text.
+Agent: Repeat the fullscreen and Escape sequence on the embedded player and re-check the window bounds.""
+9. ""Include macOS version, build, and whether both the attachment and the embedded player were covered.
+Agent: Write a concise result note without committing machine-specific logs unless requested.""","1. ""The workspace is loaded and messages are readable.""
+2. ""The window fills the whole screen, the macOS menu bar hides until you move the pointer to the top edge, and the row of colored dots disappears.""
+3. ""The `Full screen` item shows a checkmark. Close the menu with a click elsewhere.""
+4. ""The video plays inline inside the message, with a control bar along the bottom edge of the player.""
+5. ""The video expands to cover the entire screen; the channel list and message list are no longer visible.""
+6. ""The video returns to its inline size inside the message list, and the app window is still in macOS fullscreen: it still covers the whole screen, the colored window dots are still hidden, and the macOS menu bar still auto-hides. This is the pass condition of the flow.""
+7. ""The checkmark is still present, confirming the window never left fullscreen.""
+8. ""Escape returns the embedded player to its inline preview size and the app window is still in macOS fullscreen. This covers a video inside a cross-origin frame.""
+9. ""The result states clearly which video sources were exercised."""
+"","1","Window and fullscreen","","Escape with nothing to dismiss keeps the app window in macOS fullscreen","Source flow: FSESC-QA-002
+
+Pressing Escape in the workspace or in the desktop app chrome while the window is in macOS native fullscreen never takes the window out of fullscreen.","installed_branch_build
+workspace_logged_in","- Screenshot after the repeated Escape presses showing a window that still covers
+  the whole screen.
+- Note of how many Escape presses and whether the held-key repeat case was run.
+- macOS version and build identifier.","major","high","actual","manual","classic","FSESC-QA-002,source:repo-qa,platform:macos,requires:installed_branch_build,requires:workspace_logged_in","1. ""Launch the Rocket.Chat Desktop build under test on macOS, then click the green circular button at the top-left corner of the window, the third of the three colored dots, to enter macOS native fullscreen.""
+2. ""Click once on an empty area of the message list, for example the blank space to the right of a message timestamp, so keyboard focus is in the workspace content and no search field, modal, or side panel is open.""
+3. ""Press the `Escape` key once.""
+4. ""Press the `Escape` key five more times, once per second.""
+5. ""Press and hold the `Escape` key for about three seconds so macOS generates key repeats, then release it.""
+6. ""Move focus to the desktop app chrome instead of the workspace: move the pointer to the very top of the screen so the macOS menu bar appears, click `Window` in that menu bar, then click `App settings`.""
+7. ""Click once on an empty area of the App settings screen, away from any input field, then press the `Escape` key once.""
+8. ""Record the result using the format in `qa/macos-fullscreen-escape/README.md`.""","1. ""Build from branch `fix/macos-escape-exits-fullscreen` or the release candidate containing it.
+Agent: Launch the build and enter fullscreen.""
+2. ""No input data.
+Agent: Focus the workspace content and confirm no dismissable UI is open.""
+3. ""Key: `Escape`.
+Agent: Send one Escape press and compare window bounds against screen bounds.""
+4. ""Key: `Escape`, six presses total including step 3.
+Agent: Send repeated Escape presses with a short delay and re-check the window bounds after each.""
+5. ""Key: `Escape` held down.
+Agent: Send an auto-repeating Escape and re-check the window bounds.""
+6. ""Menu path: macOS menu bar -> `Window` -> `App settings`, keyboard equivalent `Command+,`.
+Agent: Navigate to the desktop App settings screen.""
+7. ""Key: `Escape`.
+Agent: Send one Escape press with the App settings screen focused and re-check the window bounds.""
+8. ""Include macOS version, build, and whether both the workspace and the App settings screen were covered.
+Agent: Write a concise result note without committing machine-specific logs unless requested.""","1. ""The window fills the whole screen and the three colored dots are hidden.""
+2. ""No dialog, dropdown, search field, or contextual panel is visible on screen.""
+3. ""Nothing happens visually and the window is still fullscreen: it still covers the whole screen, the colored window dots stay hidden, and the macOS menu bar still auto-hides.""
+4. ""The window is still fullscreen after every press. Repeated presses matter because the fix has to re-arm between presses.""
+5. ""The window is still fullscreen.""
+6. ""The desktop App settings screen replaces the workspace content, showing tabs such as `General` near the top.""
+7. ""The window is still fullscreen and the App settings screen is still shown.""
+8. ""The result states which focus locations were exercised."""
+"","1","Window and fullscreen","","Escape, menu shortcuts and fullscreen toggles still work on macOS","Source flow: FSESC-QA-003
+
+Escape still dismisses workspace UI, menu keyboard shortcuts still fire from the workspace, and both fullscreen toggles still enter and leave fullscreen.","installed_branch_build
+workspace_logged_in","- Note or screenshot for each check: search closes on Escape while windowed and
+  while fullscreen, `Command+R` reloads, `Control+Command+F` toggles both ways,
+  the `View` -> `Full screen` item toggles both ways, and the windowed video
+  fullscreen cycle returns to the previous window size.
+- macOS version and build identifier.","major","high","actual","manual","classic","FSESC-QA-003,source:repo-qa,platform:macos,requires:installed_branch_build,requires:workspace_logged_in","1. ""Launch the Rocket.Chat Desktop build under test on macOS in a normal, non-fullscreen window, and wait for a workspace channel list to appear on the left.""
+2. ""Click the magnifier search icon in the top row of the workspace channel list on the left, type three or four letters of a channel name, then press `Escape` once.""
+3. ""Click the green circular button at the top-left corner of the window, the third of the three colored dots, to enter macOS native fullscreen, then repeat the search and `Escape` sequence from step 2.""
+4. ""With the window still fullscreen and focus in the workspace message list, press `Command+R`.""
+5. ""With the window still fullscreen, press `Control+Command+F`.""
+6. ""Press `Control+Command+F` again, then move the pointer to the very top of the screen so the macOS menu bar appears, click `View`, and check the `Full screen` item.""
+7. ""With the window in a normal, non-fullscreen state, post or open a short video in the message list, play it, then click the fullscreen button at the right end of the video control bar, the icon drawn as four outward-pointing corner brackets. Press `Escape` once.""
+8. ""Record the result using the format in `qa/macos-fullscreen-escape/README.md`.""","1. ""Build from branch `fix/macos-escape-exits-fullscreen` or the release candidate containing it.
+Agent: Launch the build and confirm the window is not fullscreen.""
+2. ""Search text: any short string such as `gen`.
+Agent: Open workspace search, type, send Escape, and confirm the search UI closed.""
+3. ""Search text: any short string such as `gen`.
+Agent: Enter fullscreen, repeat the search and Escape check, and re-check the window bounds.""
+4. ""Shortcut: `Command+R`, matching the macOS menu bar item `View` -> `Reload`.
+Agent: Send the shortcut and confirm the workspace reloaded.""
+5. ""Shortcut: `Control+Command+F`, matching the macOS menu bar item `View` -> `Full screen`.
+Agent: Send the shortcut and confirm the window is no longer fullscreen.""
+6. ""Menu path: macOS menu bar -> `View` -> `Full screen`.
+Agent: Toggle fullscreen through both the shortcut and the menu item and confirm each direction works.""
+7. ""Any small `.mp4` file, for example a 5 to 10 second clip.
+Agent: Run the windowed video fullscreen cycle and confirm the window returned to its previous bounds.""
+8. ""Include macOS version, build, and which of the checks passed.
+Agent: Write a concise result note without committing machine-specific logs unless requested.""","1. ""The workspace is loaded and the window is windowed, with the three colored dots visible at the top-left.""
+2. ""The search field and its result list close and the normal channel list returns, proving Escape still reaches the workspace web app while windowed.""
+3. ""The search UI closes on Escape and the window is still fullscreen. Escape is delivered to the workspace and does not leave fullscreen.""
+4. ""The workspace view reloads, showing a loading state and then the channel list again. Menu keyboard shortcuts still reach the macOS menu from the workspace.""
+5. ""The window leaves fullscreen and returns to a normal window, with the three colored dots visible again at the top-left.""
+6. ""The window is fullscreen again and the `Full screen` item shows a checkmark. Click the item to leave fullscreen and confirm the window returns to a normal window.""
+7. ""The video fills the screen while fullscreen, and after Escape both the video and the window return to the previous normal window size. The windowed case must not regress.""
+8. ""The result names each regression check separately."""
+"","1","Window and fullscreen","","Escape and video fullscreen behave exactly as before on Windows and Linux","Source flow: FSESC-QA-004
+
+On Windows and Linux, Escape and video fullscreen behave the same as before the macOS fix, with no swallowed keys and no changed window state.","installed_branch_build
+workspace_logged_in","- Note or screenshot showing workspace search closing on Escape.
+- Note of the window bounds before and after the video fullscreen cycle.
+- OS name and version plus build identifier.","normal","medium","actual","manual","classic","FSESC-QA-004,source:repo-qa,platform:windows,platform:linux,requires:installed_branch_build,requires:workspace_logged_in","1. ""Launch the Rocket.Chat Desktop build under test on Windows or Linux and wait for a workspace channel list to appear on the left.""
+2. ""Click the magnifier search icon in the top row of the workspace channel list on the left, type three or four letters of a channel name, then press `Escape` once.""
+3. ""Post or open a short video in the message list, click its play button, then click the fullscreen button at the right end of the video control bar, the icon drawn as four outward-pointing corner brackets.""
+4. ""Press `Escape` once.""
+5. ""Put the window into fullscreen using the platform control: on Windows press `F11` if the build exposes it, otherwise maximize the window; on Linux use the window manager fullscreen action for the window. Then click an empty area of the message list and press `Escape` once.""
+6. ""Record the result using the format in `qa/macos-fullscreen-escape/README.md`, naming the platform covered.""","1. ""Build from branch `fix/macos-escape-exits-fullscreen` or the release candidate containing it. Record which OS this run covers.
+Agent: Launch the build and confirm the workspace view rendered.""
+2. ""Search text: any short string such as `gen`.
+Agent: Open workspace search, type, send Escape, and confirm the search UI closed.""
+3. ""Any small `.mp4` file, for example a 5 to 10 second clip.
+Agent: Enter the video's fullscreen and confirm only the video is visible.""
+4. ""Key: `Escape`.
+Agent: Send one Escape press and compare the window bounds with the pre-fullscreen bounds.""
+5. ""Note which control was used to reach fullscreen or maximized state.
+Agent: Reach the platform fullscreen or maximized state, send Escape, and confirm the window state did not change.""
+6. ""Include OS and version, build, and which checks passed.
+Agent: Write a concise result note without committing machine-specific logs unless requested.""","1. ""The workspace is loaded.""
+2. ""The search field and its result list close and the normal channel list returns, proving Escape still reaches the workspace web app.""
+3. ""The video fills the whole screen.""
+4. ""The video returns to its inline size inside the message list and the window returns to the size it had before the video went fullscreen.""
+5. ""The window state is unchanged by the Escape press; Escape neither leaves fullscreen nor restores the window.""
+6. ""The result names the platform explicitly, because this flow must be run once per platform."""

--- a/qa/macos-fullscreen-escape/flows/01-video-fullscreen-escape.md
+++ b/qa/macos-fullscreen-escape/flows/01-video-fullscreen-escape.md
@@ -1,0 +1,68 @@
+---
+id: FSESC-QA-001
+title: Escape leaves only the video fullscreen while the app window stays fullscreen
+platforms: [macos]
+priority: smoke
+qase:
+  suite: Window and fullscreen
+  priority: high
+  severity: major
+  status: actual
+  automation: manual
+  qase_id: null
+requires: [installed_branch_build, workspace_logged_in]
+test_links: []
+expected_result: Pressing Escape while a video plays in HTML5 fullscreen returns the video to its inline size and the app window remains in macOS native fullscreen.
+---
+
+# Escape Leaves Only The Video Fullscreen
+
+## Review Basis
+
+- Comparison range: `master` (`7aa3dae6d`) to `fix/macos-escape-exits-fullscreen`
+  (`3bdd1e747`).
+- Changed surface: Electron main process keyboard handling for server webviews
+  and the root window (`src/ui/main/escapeFullscreenGuard.ts`,
+  `src/ui/main/serverView/index.ts`, `src/ui/main/rootWindow.ts`).
+- User-visible risk: A customer watching a video in a fullscreen app window
+  presses Escape to leave the video and the whole app drops out of macOS
+  fullscreen, losing their window arrangement and Space.
+- Hypothesis: With the app window in macOS native fullscreen and a video in HTML5
+  fullscreen, one Escape press returns the video to its inline size and the app
+  window is still fullscreen, matching Google Chrome.
+- Smallest useful proof: OS-level repro on macOS hardware. The Jest suite covers
+  the desktop wiring only
+  (`src/ui/main/escapeFullscreenGuard.main.spec.ts`,
+  `src/ui/main/serverView/index.spec.ts`), because a test generated key event is
+  synthetic and never reaches macOS AppKit, which is what caused the original
+  regression.
+
+## Steps
+
+| Step | Action | Test data | Expected result | Agent action |
+| --- | --- | --- | --- | --- |
+| 1 | Launch the Rocket.Chat Desktop build under test on macOS and wait until a workspace channel list is visible on the left and message content fills the rest of the window. | Build from branch `fix/macos-escape-exits-fullscreen` or the release candidate containing it; any workspace where you can post a file. | The workspace is loaded and messages are readable. | Launch the build and confirm the workspace view rendered. |
+| 2 | Put the window into macOS native fullscreen: click the green circular button at the top-left corner of the window, the third of the three colored dots. | No input data. | The window fills the whole screen, the macOS menu bar hides until you move the pointer to the top edge, and the row of colored dots disappears. | Enter fullscreen through the window control and confirm the window covers the screen. |
+| 3 | Confirm the app itself knows it is fullscreen: move the pointer to the very top of the screen so the macOS menu bar appears, click `View` in that menu bar, and look at the `Full screen` item. | Menu path: macOS menu bar -> `View` -> `Full screen` (keyboard equivalent `Control+Command+F`). | The `Full screen` item shows a checkmark. Close the menu with a click elsewhere. | Read the menu state or the app's fullscreen state and confirm it reports fullscreen. |
+| 4 | In the message box at the bottom of the channel, attach and send a short video file, then click the play button in the middle of the video player that appears in the message list. | Any small `.mp4` file, for example a 5 to 10 second clip. | The video plays inline inside the message, with a control bar along the bottom edge of the player. | Post the video and start playback. |
+| 5 | Hover the playing video to reveal its control bar, then click the fullscreen button at the right end of that bar, the icon drawn as four outward-pointing corner brackets. | No input data. | The video expands to cover the entire screen; the channel list and message list are no longer visible. | Enter the video's HTML5 fullscreen and confirm only the video is visible. |
+| 6 | Press the `Escape` key once. | Key: `Escape`. | The video returns to its inline size inside the message list, and the app window is still in macOS fullscreen: it still covers the whole screen, the colored window dots are still hidden, and the macOS menu bar still auto-hides. This is the pass condition of the flow. | Send one Escape key press and then compare the window bounds against the screen bounds. |
+| 7 | Move the pointer to the top of the screen, click `View` in the macOS menu bar and confirm `Full screen` still shows a checkmark. | Menu path: macOS menu bar -> `View` -> `Full screen`. | The checkmark is still present, confirming the window never left fullscreen. | Re-read the fullscreen state and confirm it is unchanged. |
+| 8 | Repeat steps 5 to 7 with an embedded player instead of an attachment: send a message containing a YouTube video link, wait for the preview player to render under the message, click its play button, then click the fullscreen button at the right end of the player's own control bar. | Any public YouTube URL, for example a short clip link pasted as plain text. | Escape returns the embedded player to its inline preview size and the app window is still in macOS fullscreen. This covers a video inside a cross-origin frame. | Repeat the fullscreen and Escape sequence on the embedded player and re-check the window bounds. |
+| 9 | Record the result using the format in `qa/macos-fullscreen-escape/README.md`. | Include macOS version, build, and whether both the attachment and the embedded player were covered. | The result states clearly which video sources were exercised. | Write a concise result note without committing machine-specific logs unless requested. |
+
+## Evidence
+
+- Screenshot taken right after the Escape press showing the inline video and a
+  window that still covers the whole screen.
+- Note of the `View` -> `Full screen` checkmark state before and after Escape.
+- macOS version and build identifier.
+
+## Failure Signals
+
+- The app window leaves macOS fullscreen when Escape is pressed.
+- The video stays in fullscreen after Escape, or needs a second Escape press.
+- The `View` -> `Full screen` checkmark clears after Escape.
+- The window leaves fullscreen for the embedded player but not for the attachment,
+  or the reverse.
+- The window visibly starts leaving fullscreen and then animates back in.

--- a/qa/macos-fullscreen-escape/flows/02-plain-escape-keeps-fullscreen.md
+++ b/qa/macos-fullscreen-escape/flows/02-plain-escape-keeps-fullscreen.md
@@ -1,0 +1,66 @@
+---
+id: FSESC-QA-002
+title: Escape with nothing to dismiss keeps the app window in macOS fullscreen
+platforms: [macos]
+priority: release
+qase:
+  suite: Window and fullscreen
+  priority: high
+  severity: major
+  status: actual
+  automation: manual
+  qase_id: null
+requires: [installed_branch_build, workspace_logged_in]
+test_links: []
+expected_result: Pressing Escape in the workspace or in the desktop app chrome while the window is in macOS native fullscreen never takes the window out of fullscreen.
+---
+
+# Plain Escape Keeps The Window Fullscreen
+
+## Review Basis
+
+- Comparison range: `master` (`7aa3dae6d`) to `fix/macos-escape-exits-fullscreen`
+  (`3bdd1e747`).
+- Changed surface: Escape handling for both the server webview
+  (`src/ui/main/serverView/index.ts`) and the desktop app chrome
+  (`src/ui/main/rootWindow.ts`), sharing
+  `src/ui/main/escapeFullscreenGuard.ts`.
+- User-visible risk: A customer in fullscreen presses Escape out of habit, with no
+  modal or search open, and the app leaves fullscreen. This is the general form of
+  the bug; the video case is only its most visible symptom.
+- Hypothesis: With the app window in macOS native fullscreen, an Escape press that
+  has nothing to dismiss leaves the window fullscreen, both when focus is in the
+  workspace content and when focus is in the desktop App settings screen.
+- Smallest useful proof: OS-level repro on macOS hardware. The desktop wiring is
+  covered by `src/ui/main/rootWindow.spec.ts`
+  (`rootWindow Escape fullscreen guard`) and
+  `src/ui/main/escapeFullscreenGuard.main.spec.ts`, but a synthetic key event
+  cannot reproduce the macOS AppKit behavior under test.
+
+## Steps
+
+| Step | Action | Test data | Expected result | Agent action |
+| --- | --- | --- | --- | --- |
+| 1 | Launch the Rocket.Chat Desktop build under test on macOS, then click the green circular button at the top-left corner of the window, the third of the three colored dots, to enter macOS native fullscreen. | Build from branch `fix/macos-escape-exits-fullscreen` or the release candidate containing it. | The window fills the whole screen and the three colored dots are hidden. | Launch the build and enter fullscreen. |
+| 2 | Click once on an empty area of the message list, for example the blank space to the right of a message timestamp, so keyboard focus is in the workspace content and no search field, modal, or side panel is open. | No input data. | No dialog, dropdown, search field, or contextual panel is visible on screen. | Focus the workspace content and confirm no dismissable UI is open. |
+| 3 | Press the `Escape` key once. | Key: `Escape`. | Nothing happens visually and the window is still fullscreen: it still covers the whole screen, the colored window dots stay hidden, and the macOS menu bar still auto-hides. | Send one Escape press and compare window bounds against screen bounds. |
+| 4 | Press the `Escape` key five more times, once per second. | Key: `Escape`, six presses total including step 3. | The window is still fullscreen after every press. Repeated presses matter because the fix has to re-arm between presses. | Send repeated Escape presses with a short delay and re-check the window bounds after each. |
+| 5 | Press and hold the `Escape` key for about three seconds so macOS generates key repeats, then release it. | Key: `Escape` held down. | The window is still fullscreen. | Send an auto-repeating Escape and re-check the window bounds. |
+| 6 | Move focus to the desktop app chrome instead of the workspace: move the pointer to the very top of the screen so the macOS menu bar appears, click `Window` in that menu bar, then click `App settings`. | Menu path: macOS menu bar -> `Window` -> `App settings`, keyboard equivalent `Command+,`. | The desktop App settings screen replaces the workspace content, showing tabs such as `General` near the top. | Navigate to the desktop App settings screen. |
+| 7 | Click once on an empty area of the App settings screen, away from any input field, then press the `Escape` key once. | Key: `Escape`. | The window is still fullscreen and the App settings screen is still shown. | Send one Escape press with the App settings screen focused and re-check the window bounds. |
+| 8 | Record the result using the format in `qa/macos-fullscreen-escape/README.md`. | Include macOS version, build, and whether both the workspace and the App settings screen were covered. | The result states which focus locations were exercised. | Write a concise result note without committing machine-specific logs unless requested. |
+
+## Evidence
+
+- Screenshot after the repeated Escape presses showing a window that still covers
+  the whole screen.
+- Note of how many Escape presses and whether the held-key repeat case was run.
+- macOS version and build identifier.
+
+## Failure Signals
+
+- The window leaves macOS fullscreen on any Escape press.
+- The first Escape press is safe but a later press, or a held key, leaves
+  fullscreen. That points at the guard failing to re-arm.
+- Escape leaves fullscreen only when focus is in the desktop App settings screen,
+  or only when focus is in the workspace content.

--- a/qa/macos-fullscreen-escape/flows/03-escape-and-shortcut-regressions.md
+++ b/qa/macos-fullscreen-escape/flows/03-escape-and-shortcut-regressions.md
@@ -1,0 +1,70 @@
+---
+id: FSESC-QA-003
+title: Escape, menu shortcuts and fullscreen toggles still work on macOS
+platforms: [macos]
+priority: release
+qase:
+  suite: Window and fullscreen
+  priority: high
+  severity: major
+  status: actual
+  automation: manual
+  qase_id: null
+requires: [installed_branch_build, workspace_logged_in]
+test_links: []
+expected_result: Escape still dismisses workspace UI, menu keyboard shortcuts still fire from the workspace, and both fullscreen toggles still enter and leave fullscreen.
+---
+
+# Escape And Shortcut Regressions On macOS
+
+## Review Basis
+
+- Comparison range: `master` (`7aa3dae6d`) to `fix/macos-escape-exits-fullscreen`
+  (`3bdd1e747`).
+- Changed surface: `before-input-event` interception on the server webview and the
+  root window contents. The fix cancels the original Escape key event and replays
+  a synthetic one, and it stops forwarding the Escape key up to the desktop
+  window.
+- User-visible risk: The interception could swallow Escape entirely, so workspace
+  search and modals would stop closing; it could break macOS menu keyboard
+  shortcuts typed while the workspace has focus; or it could leave the window
+  unable to enter or leave fullscreen through the normal controls.
+- Hypothesis: After the fix, Escape still reaches the workspace web app, menu
+  shortcuts still fire while the workspace has focus, and both `Control+Command+F`
+  and the `View` -> `Full screen` menu item still toggle fullscreen in both
+  directions.
+- Smallest useful proof: Local UI repro on macOS. Automated coverage exists for the
+  key forwarding contract in `src/ui/main/serverView/index.spec.ts` and
+  `src/ui/main/rootWindow.spec.ts`, but keyboard delivery to the web app and to the
+  macOS menu bar can only be observed at runtime.
+
+## Steps
+
+| Step | Action | Test data | Expected result | Agent action |
+| --- | --- | --- | --- | --- |
+| 1 | Launch the Rocket.Chat Desktop build under test on macOS in a normal, non-fullscreen window, and wait for a workspace channel list to appear on the left. | Build from branch `fix/macos-escape-exits-fullscreen` or the release candidate containing it. | The workspace is loaded and the window is windowed, with the three colored dots visible at the top-left. | Launch the build and confirm the window is not fullscreen. |
+| 2 | Click the magnifier search icon in the top row of the workspace channel list on the left, type three or four letters of a channel name, then press `Escape` once. | Search text: any short string such as `gen`. | The search field and its result list close and the normal channel list returns, proving Escape still reaches the workspace web app while windowed. | Open workspace search, type, send Escape, and confirm the search UI closed. |
+| 3 | Click the green circular button at the top-left corner of the window, the third of the three colored dots, to enter macOS native fullscreen, then repeat the search and `Escape` sequence from step 2. | Search text: any short string such as `gen`. | The search UI closes on Escape and the window is still fullscreen. Escape is delivered to the workspace and does not leave fullscreen. | Enter fullscreen, repeat the search and Escape check, and re-check the window bounds. |
+| 4 | With the window still fullscreen and focus in the workspace message list, press `Command+R`. | Shortcut: `Command+R`, matching the macOS menu bar item `View` -> `Reload`. | The workspace view reloads, showing a loading state and then the channel list again. Menu keyboard shortcuts still reach the macOS menu from the workspace. | Send the shortcut and confirm the workspace reloaded. |
+| 5 | With the window still fullscreen, press `Control+Command+F`. | Shortcut: `Control+Command+F`, matching the macOS menu bar item `View` -> `Full screen`. | The window leaves fullscreen and returns to a normal window, with the three colored dots visible again at the top-left. | Send the shortcut and confirm the window is no longer fullscreen. |
+| 6 | Press `Control+Command+F` again, then move the pointer to the very top of the screen so the macOS menu bar appears, click `View`, and check the `Full screen` item. | Menu path: macOS menu bar -> `View` -> `Full screen`. | The window is fullscreen again and the `Full screen` item shows a checkmark. Click the item to leave fullscreen and confirm the window returns to a normal window. | Toggle fullscreen through both the shortcut and the menu item and confirm each direction works. |
+| 7 | With the window in a normal, non-fullscreen state, post or open a short video in the message list, play it, then click the fullscreen button at the right end of the video control bar, the icon drawn as four outward-pointing corner brackets. Press `Escape` once. | Any small `.mp4` file, for example a 5 to 10 second clip. | The video fills the screen while fullscreen, and after Escape both the video and the window return to the previous normal window size. The windowed case must not regress. | Run the windowed video fullscreen cycle and confirm the window returned to its previous bounds. |
+| 8 | Record the result using the format in `qa/macos-fullscreen-escape/README.md`. | Include macOS version, build, and which of the checks passed. | The result names each regression check separately. | Write a concise result note without committing machine-specific logs unless requested. |
+
+## Evidence
+
+- Note or screenshot for each check: search closes on Escape while windowed and
+  while fullscreen, `Command+R` reloads, `Control+Command+F` toggles both ways,
+  the `View` -> `Full screen` item toggles both ways, and the windowed video
+  fullscreen cycle returns to the previous window size.
+- macOS version and build identifier.
+
+## Failure Signals
+
+- Escape no longer closes workspace search or workspace modals.
+- `Command+R` or other menu shortcuts stop working while the workspace has focus.
+- `Control+Command+F` or the `View` -> `Full screen` item no longer enters or
+  leaves fullscreen.
+- The `Full screen` checkmark disagrees with the actual window state.
+- After a windowed video fullscreen cycle the window does not return to its
+  previous size, or stays fullscreen.

--- a/qa/macos-fullscreen-escape/flows/04-windows-linux-escape-unchanged.md
+++ b/qa/macos-fullscreen-escape/flows/04-windows-linux-escape-unchanged.md
@@ -1,0 +1,62 @@
+---
+id: FSESC-QA-004
+title: Escape and video fullscreen behave exactly as before on Windows and Linux
+platforms: [windows, linux]
+priority: release
+qase:
+  suite: Window and fullscreen
+  priority: medium
+  severity: normal
+  status: actual
+  automation: manual
+  qase_id: null
+requires: [installed_branch_build, workspace_logged_in]
+test_links: []
+expected_result: On Windows and Linux, Escape and video fullscreen behave the same as before the macOS fix, with no swallowed keys and no changed window state.
+---
+
+# Windows And Linux Escape Unchanged
+
+## Review Basis
+
+- Comparison range: `master` (`7aa3dae6d`) to `fix/macos-escape-exits-fullscreen`
+  (`3bdd1e747`).
+- Changed surface: `before-input-event` handling shared by all platforms in
+  `src/ui/main/serverView/index.ts` and `src/ui/main/rootWindow.ts`. Every new code
+  path is behind `process.platform === 'darwin'`, but the Escape key up is no
+  longer forwarded to the desktop window on any platform.
+- User-visible risk: A macOS-only fix silently changing Windows or Linux behavior,
+  either by swallowing Escape, by leaving a video stuck in fullscreen, or by
+  changing how the window responds to fullscreen keys.
+- Hypothesis: On Windows and Linux, Escape still reaches the workspace web app,
+  video fullscreen still exits on Escape, and the window fullscreen state is not
+  affected by Escape at all.
+- Smallest useful proof: Local UI repro per platform. The platform guards are
+  covered by `src/ui/main/escapeFullscreenGuard.main.spec.ts` and the
+  `other platforms` cases in `src/ui/main/serverView/index.spec.ts`, but the
+  desktop build should still be smoke-checked on each platform.
+
+## Steps
+
+| Step | Action | Test data | Expected result | Agent action |
+| --- | --- | --- | --- | --- |
+| 1 | Launch the Rocket.Chat Desktop build under test on Windows or Linux and wait for a workspace channel list to appear on the left. | Build from branch `fix/macos-escape-exits-fullscreen` or the release candidate containing it. Record which OS this run covers. | The workspace is loaded. | Launch the build and confirm the workspace view rendered. |
+| 2 | Click the magnifier search icon in the top row of the workspace channel list on the left, type three or four letters of a channel name, then press `Escape` once. | Search text: any short string such as `gen`. | The search field and its result list close and the normal channel list returns, proving Escape still reaches the workspace web app. | Open workspace search, type, send Escape, and confirm the search UI closed. |
+| 3 | Post or open a short video in the message list, click its play button, then click the fullscreen button at the right end of the video control bar, the icon drawn as four outward-pointing corner brackets. | Any small `.mp4` file, for example a 5 to 10 second clip. | The video fills the whole screen. | Enter the video's fullscreen and confirm only the video is visible. |
+| 4 | Press `Escape` once. | Key: `Escape`. | The video returns to its inline size inside the message list and the window returns to the size it had before the video went fullscreen. | Send one Escape press and compare the window bounds with the pre-fullscreen bounds. |
+| 5 | Put the window into fullscreen using the platform control: on Windows press `F11` if the build exposes it, otherwise maximize the window; on Linux use the window manager fullscreen action for the window. Then click an empty area of the message list and press `Escape` once. | Note which control was used to reach fullscreen or maximized state. | The window state is unchanged by the Escape press; Escape neither leaves fullscreen nor restores the window. | Reach the platform fullscreen or maximized state, send Escape, and confirm the window state did not change. |
+| 6 | Record the result using the format in `qa/macos-fullscreen-escape/README.md`, naming the platform covered. | Include OS and version, build, and which checks passed. | The result names the platform explicitly, because this flow must be run once per platform. | Write a concise result note without committing machine-specific logs unless requested. |
+
+## Evidence
+
+- Note or screenshot showing workspace search closing on Escape.
+- Note of the window bounds before and after the video fullscreen cycle.
+- OS name and version plus build identifier.
+
+## Failure Signals
+
+- Escape stops closing workspace search or workspace modals.
+- The video stays in fullscreen after Escape, or needs a second press.
+- The window does not return to its pre-fullscreen size after the video exits
+  fullscreen.
+- The window state changes on an Escape press.

--- a/qa/macos-fullscreen-escape/results/README.md
+++ b/qa/macos-fullscreen-escape/results/README.md
@@ -1,0 +1,10 @@
+# QA Results
+
+Store local run notes, screenshots, logs, or diagnostics here while testing. Do
+not commit run-specific evidence unless a release owner asks for it.
+
+Recommended filename format:
+
+```text
+YYYY-MM-DD-platform-flow-id-result.md
+```

--- a/src/ui/main/escapeFullscreenGuard.main.spec.ts
+++ b/src/ui/main/escapeFullscreenGuard.main.spec.ts
@@ -63,13 +63,50 @@ describe('createEscapeFullscreenGuard', () => {
   it('forwards the active modifiers with the replayed event', () => {
     const guard = createGuard();
 
-    guard.handleInput(createInput({ shift: true, isAutoRepeat: true }));
+    guard.handleInput(createInput({ shift: true, control: true }));
 
     expect(target.sendInputEvent).toHaveBeenCalledWith({
       type: 'keyDown',
       keyCode: 'Escape',
-      modifiers: ['shift', 'isautorepeat'],
+      modifiers: ['shift', 'control'],
     });
+  });
+
+  it('swallows auto-repeated Escapes without replaying them', () => {
+    const guard = createGuard();
+
+    expect(guard.handleInput(createInput())).toBe(true);
+    expect(guard.handleInput(createInput({ isAutoRepeat: true }))).toBe(true);
+    expect(guard.handleInput(createInput({ isAutoRepeat: true }))).toBe(true);
+    expect(target.sendInputEvent).toHaveBeenCalledTimes(1);
+
+    expect(guard.handleInput(createInput())).toBe(false);
+    expect(target.sendInputEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets auto-repeated Escapes through when the window is not in fullscreen', () => {
+    const guard = createGuard(false);
+
+    expect(guard.handleInput(createInput({ isAutoRepeat: true }))).toBe(false);
+    expect(target.sendInputEvent).not.toHaveBeenCalled();
+  });
+
+  it('clears the replay credit when the replay lands after fullscreen ended', () => {
+    let fullscreen = true;
+    const guard = createEscapeFullscreenGuard(
+      target,
+      () => fullscreen,
+      () => currentTime
+    );
+
+    expect(guard.handleInput(createInput())).toBe(true);
+
+    fullscreen = false;
+    expect(guard.handleInput(createInput())).toBe(false);
+
+    fullscreen = true;
+    expect(guard.handleInput(createInput())).toBe(true);
+    expect(target.sendInputEvent).toHaveBeenCalledTimes(2);
   });
 
   it('lets the replayed event through without replaying it again', () => {

--- a/src/ui/main/escapeFullscreenGuard.main.spec.ts
+++ b/src/ui/main/escapeFullscreenGuard.main.spec.ts
@@ -1,0 +1,122 @@
+import type { Input, WebContents } from 'electron';
+
+import { createEscapeFullscreenGuard } from './escapeFullscreenGuard';
+
+const originalPlatform = process.platform;
+
+const setPlatform = (platform: NodeJS.Platform): void => {
+  Object.defineProperty(process, 'platform', {
+    value: platform,
+    configurable: true,
+  });
+};
+
+const createInput = (overrides: Partial<Input> = {}): Input =>
+  ({
+    type: 'keyDown',
+    key: 'Escape',
+    code: 'Escape',
+    isAutoRepeat: false,
+    isComposing: false,
+    shift: false,
+    control: false,
+    alt: false,
+    meta: false,
+    location: 0,
+    modifiers: [],
+    ...overrides,
+  }) as Input;
+
+describe('createEscapeFullscreenGuard', () => {
+  let target: Pick<WebContents, 'sendInputEvent'>;
+  let currentTime: number;
+
+  const createGuard = (isWindowFullscreen = true) =>
+    createEscapeFullscreenGuard(
+      target,
+      () => isWindowFullscreen,
+      () => currentTime
+    );
+
+  beforeEach(() => {
+    setPlatform('darwin');
+    currentTime = 1_000;
+    target = { sendInputEvent: jest.fn() };
+  });
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+  });
+
+  it('swallows a native Escape key down and replays it as a synthetic event', () => {
+    const guard = createGuard();
+
+    expect(guard.handleInput(createInput())).toBe(true);
+    expect(target.sendInputEvent).toHaveBeenCalledTimes(1);
+    expect(target.sendInputEvent).toHaveBeenCalledWith({
+      type: 'keyDown',
+      keyCode: 'Escape',
+      modifiers: [],
+    });
+  });
+
+  it('forwards the active modifiers with the replayed event', () => {
+    const guard = createGuard();
+
+    guard.handleInput(createInput({ shift: true, isAutoRepeat: true }));
+
+    expect(target.sendInputEvent).toHaveBeenCalledWith({
+      type: 'keyDown',
+      keyCode: 'Escape',
+      modifiers: ['shift', 'isautorepeat'],
+    });
+  });
+
+  it('lets the replayed event through without replaying it again', () => {
+    const guard = createGuard();
+
+    expect(guard.handleInput(createInput())).toBe(true);
+    expect(guard.handleInput(createInput())).toBe(false);
+    expect(target.sendInputEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('guards the next Escape again after the replay window expires', () => {
+    const guard = createGuard();
+
+    expect(guard.handleInput(createInput())).toBe(true);
+
+    currentTime += 1_000;
+
+    expect(guard.handleInput(createInput())).toBe(true);
+    expect(target.sendInputEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it('does nothing when the window is not in fullscreen', () => {
+    const guard = createGuard(false);
+
+    expect(guard.handleInput(createInput())).toBe(false);
+    expect(target.sendInputEvent).not.toHaveBeenCalled();
+  });
+
+  it('ignores key up events', () => {
+    const guard = createGuard();
+
+    expect(guard.handleInput(createInput({ type: 'keyUp' }))).toBe(false);
+    expect(target.sendInputEvent).not.toHaveBeenCalled();
+  });
+
+  it('ignores keys other than Escape', () => {
+    const guard = createGuard();
+
+    expect(guard.handleInput(createInput({ key: 'Meta' }))).toBe(false);
+    expect(target.sendInputEvent).not.toHaveBeenCalled();
+  });
+
+  it.each<NodeJS.Platform>(['win32', 'linux'])('is inert on %s', (platform) => {
+    setPlatform(platform);
+    const guard = createGuard();
+
+    expect(guard.handleInput(createInput())).toBe(false);
+    expect(target.sendInputEvent).not.toHaveBeenCalled();
+  });
+});

--- a/src/ui/main/escapeFullscreenGuard.ts
+++ b/src/ui/main/escapeFullscreenGuard.ts
@@ -1,0 +1,116 @@
+import type { Input, KeyboardInputEvent, WebContents } from 'electron';
+
+/**
+ * On macOS, Electron hands every key event the web content did not consume back
+ * to the native window
+ * (`WebContents::PlatformHandleKeyboardEvent` in `electron_api_web_contents_mac.mm`
+ * calls `[ns_event.window redispatchKeyEvent:]`). AppKit answers ESC with
+ * `cancelOperation:`, which on a window in native fullscreen leaves fullscreen.
+ * That is why pressing ESC while a video is in HTML5 fullscreen — or with nothing
+ * at all to dismiss — also drops the app out of fullscreen, while Chrome, which
+ * never returns the raw `NSEvent` to AppKit, stays fullscreen.
+ *
+ * The only interception point is `before-input-event`, which runs before the
+ * renderer sees the event. Preventing it there stops the redispatch, so the event
+ * is replayed through `sendInputEvent`: a synthetic event carries no `NSEvent` and
+ * therefore can never reach AppKit, while the page still receives its ESC.
+ *
+ * Windows and Linux redispatch to registered window accelerators only, and no ESC
+ * accelerator exists, so the guard is inert there.
+ */
+
+const REPLAY_TIMEOUT_MS = 250;
+
+type KeyboardModifier = NonNullable<KeyboardInputEvent['modifiers']>[number];
+
+const toKeyboardModifiers = (input: Input): KeyboardModifier[] => {
+  const modifiers: KeyboardModifier[] = [];
+
+  if (input.shift) {
+    modifiers.push('shift');
+  }
+
+  if (input.control) {
+    modifiers.push('control');
+  }
+
+  if (input.alt) {
+    modifiers.push('alt');
+  }
+
+  if (input.meta) {
+    modifiers.push('meta');
+  }
+
+  if (input.isAutoRepeat) {
+    modifiers.push('isautorepeat');
+  }
+
+  return modifiers;
+};
+
+type EscapeFullscreenGuard = {
+  /**
+   * Returns `true` when the caller must call `event.preventDefault()` on the
+   * `before-input-event` it is handling.
+   */
+  handleInput: (input: Input) => boolean;
+};
+
+export const createEscapeFullscreenGuard = (
+  target: Pick<WebContents, 'sendInputEvent'>,
+  isWindowFullscreen: () => boolean,
+  now: () => number = Date.now
+): EscapeFullscreenGuard => {
+  let pendingReplays = 0;
+  let pendingReplaysExpireAt = 0;
+
+  const isReplay = (): boolean => {
+    if (pendingReplays === 0) {
+      return false;
+    }
+
+    if (now() > pendingReplaysExpireAt) {
+      pendingReplays = 0;
+      return false;
+    }
+
+    pendingReplays -= 1;
+    return true;
+  };
+
+  return {
+    handleInput: (input) => {
+      if (process.platform !== 'darwin') {
+        return false;
+      }
+
+      if (input.type !== 'keyDown' || input.key !== 'Escape') {
+        return false;
+      }
+
+      if (!isWindowFullscreen()) {
+        return false;
+      }
+
+      if (isReplay()) {
+        return false;
+      }
+
+      pendingReplays += 1;
+      pendingReplaysExpireAt = now() + REPLAY_TIMEOUT_MS;
+
+      if (process.env.NODE_ENV === 'development') {
+        console.debug('Replaying Escape to keep the window in fullscreen');
+      }
+
+      target.sendInputEvent({
+        type: 'keyDown',
+        keyCode: 'Escape',
+        modifiers: toKeyboardModifiers(input),
+      });
+
+      return true;
+    },
+  };
+};

--- a/src/ui/main/escapeFullscreenGuard.ts
+++ b/src/ui/main/escapeFullscreenGuard.ts
@@ -15,6 +15,10 @@ import type { Input, KeyboardInputEvent, WebContents } from 'electron';
  * is replayed through `sendInputEvent`: a synthetic event carries no `NSEvent` and
  * therefore can never reach AppKit, while the page still receives its ESC.
  *
+ * Auto-repeated ESC key downs are swallowed without a replay: a replay of a
+ * repeat could race the previous replay's round trip through the renderer, and
+ * the raced native repeat would reach AppKit unguarded.
+ *
  * Windows and Linux redispatch to registered window accelerators only, and no ESC
  * accelerator exists, so the guard is inert there.
  */
@@ -42,10 +46,6 @@ const toKeyboardModifiers = (input: Input): KeyboardModifier[] => {
     modifiers.push('meta');
   }
 
-  if (input.isAutoRepeat) {
-    modifiers.push('isautorepeat');
-  }
-
   return modifiers;
 };
 
@@ -62,20 +62,15 @@ export const createEscapeFullscreenGuard = (
   isWindowFullscreen: () => boolean,
   now: () => number = Date.now
 ): EscapeFullscreenGuard => {
-  let pendingReplays = 0;
-  let pendingReplaysExpireAt = 0;
+  let replayExpiresAt = 0;
 
   const isReplay = (): boolean => {
-    if (pendingReplays === 0) {
+    if (replayExpiresAt === 0 || now() > replayExpiresAt) {
+      replayExpiresAt = 0;
       return false;
     }
 
-    if (now() > pendingReplaysExpireAt) {
-      pendingReplays = 0;
-      return false;
-    }
-
-    pendingReplays -= 1;
+    replayExpiresAt = 0;
     return true;
   };
 
@@ -89,20 +84,28 @@ export const createEscapeFullscreenGuard = (
         return false;
       }
 
-      if (!isWindowFullscreen()) {
-        return false;
+      // Auto-repeats never come back as replays (only the initial key down is
+      // replayed), so they must be swallowed before the replay credit is
+      // consulted — otherwise a repeat racing the in-flight replay would
+      // consume its credit and pass through to AppKit as a raw native event.
+      if (input.isAutoRepeat) {
+        return isWindowFullscreen();
       }
 
+      // Consume the replay credit before the fullscreen gate: a replay that
+      // lands after the window already left fullscreen must not leave a stale
+      // credit behind for the next real ESC to be mistaken for a replay.
       if (isReplay()) {
         return false;
       }
 
-      pendingReplays += 1;
-      pendingReplaysExpireAt = now() + REPLAY_TIMEOUT_MS;
-
-      if (process.env.NODE_ENV === 'development') {
-        console.debug('Replaying Escape to keep the window in fullscreen');
+      if (!isWindowFullscreen()) {
+        return false;
       }
+
+      replayExpiresAt = now() + REPLAY_TIMEOUT_MS;
+
+      console.debug('Replaying Escape to keep the window in fullscreen');
 
       target.sendInputEvent({
         type: 'keyDown',

--- a/src/ui/main/rootWindow.spec.ts
+++ b/src/ui/main/rootWindow.spec.ts
@@ -481,6 +481,138 @@ describe('rootWindow close event handler', () => {
   });
 });
 
+describe('rootWindow Escape fullscreen guard', () => {
+  const originalPlatform = process.platform;
+
+  let mockWindow: any;
+
+  const setPlatform = (platform: NodeJS.Platform): void => {
+    Object.defineProperty(process, 'platform', {
+      value: platform,
+      configurable: true,
+    });
+  };
+
+  const createInput = (overrides: Record<string, unknown> = {}): any => ({
+    type: 'keyDown',
+    key: 'Escape',
+    code: 'Escape',
+    isAutoRepeat: false,
+    isComposing: false,
+    shift: false,
+    control: false,
+    alt: false,
+    meta: false,
+    location: 0,
+    modifiers: [],
+    ...overrides,
+  });
+
+  const setupAndGetHandler = async (): Promise<any> => {
+    const { setupRootWindow } = require('./rootWindow');
+    require('./rootWindow').getRootWindow = jest
+      .fn()
+      .mockResolvedValue(mockWindow);
+
+    setupRootWindow();
+    await Promise.resolve();
+
+    const call = mockWindow.webContents.addListener.mock.calls.find(
+      ([event]: any[]) => event === 'before-input-event'
+    );
+
+    expect(call).toBeDefined();
+
+    return call[1];
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setPlatform('darwin');
+
+    (require('../../store').select as jest.Mock).mockImplementation(
+      (selector: any) => selector({ isTrayIconEnabled: false })
+    );
+
+    mockWindow = {
+      addListener: jest.fn(),
+      removeAllListeners: jest.fn(),
+      close: jest.fn(),
+      hide: jest.fn(),
+      minimize: jest.fn(),
+      blur: jest.fn(),
+      isFullScreen: jest.fn(() => true),
+      isSimpleFullScreen: jest.fn(() => false),
+      isDestroyed: jest.fn(() => false),
+      setFullScreen: jest.fn(),
+      once: jest.fn(),
+      flashFrame: jest.fn(),
+      setIcon: jest.fn(),
+      setTitle: jest.fn(),
+      setOverlayIcon: jest.fn(),
+      autoHideMenuBar: false,
+      setMenuBarVisibility: jest.fn(),
+      webContents: {
+        addListener: jest.fn(),
+        sendInputEvent: jest.fn(),
+      },
+    };
+  });
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+  });
+
+  it('swallows Escape so it cannot reach the native window while in fullscreen', async () => {
+    const handler = await setupAndGetHandler();
+    const event = { preventDefault: jest.fn() };
+
+    handler(event, createInput());
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(mockWindow.webContents.sendInputEvent).toHaveBeenCalledWith({
+      type: 'keyDown',
+      keyCode: 'Escape',
+      modifiers: [],
+    });
+    expect(mockWindow.setFullScreen).not.toHaveBeenCalled();
+  });
+
+  it('lets the replayed Escape reach the renderer', async () => {
+    const handler = await setupAndGetHandler();
+    handler({ preventDefault: jest.fn() }, createInput());
+    mockWindow.webContents.sendInputEvent.mockClear();
+
+    const event = { preventDefault: jest.fn() };
+    handler(event, createInput());
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(mockWindow.webContents.sendInputEvent).not.toHaveBeenCalled();
+  });
+
+  it('leaves Escape untouched when the window is not in fullscreen', async () => {
+    mockWindow.isFullScreen.mockReturnValue(false);
+    const handler = await setupAndGetHandler();
+    const event = { preventDefault: jest.fn() };
+
+    handler(event, createInput());
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(mockWindow.webContents.sendInputEvent).not.toHaveBeenCalled();
+  });
+
+  it('leaves Escape untouched on other platforms', async () => {
+    setPlatform('win32');
+    const handler = await setupAndGetHandler();
+    const event = { preventDefault: jest.fn() };
+
+    handler(event, createInput());
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(mockWindow.webContents.sendInputEvent).not.toHaveBeenCalled();
+  });
+});
+
 describe('isInsideSomeScreen', () => {
   const { isInsideSomeScreen } = require('./rootWindow');
 

--- a/src/ui/main/rootWindow.spec.ts
+++ b/src/ui/main/rootWindow.spec.ts
@@ -54,8 +54,13 @@ describe('rootWindow close event handler', () => {
       minimize: jest.fn(),
       blur: jest.fn(),
       isFullScreen: jest.fn(() => false),
+      isSimpleFullScreen: jest.fn(() => false),
       isDestroyed: jest.fn(() => false),
       setFullScreen: jest.fn(),
+      webContents: {
+        addListener: jest.fn(),
+        sendInputEvent: jest.fn(),
+      },
       once: jest.fn(),
       flashFrame: jest.fn(),
       setIcon: jest.fn(),

--- a/src/ui/main/rootWindow.spec.ts
+++ b/src/ui/main/rootWindow.spec.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
+import type { Input } from 'electron';
 import { app, screen } from 'electron';
 
 jest.mock('electron', () => ({
@@ -493,20 +494,21 @@ describe('rootWindow Escape fullscreen guard', () => {
     });
   };
 
-  const createInput = (overrides: Record<string, unknown> = {}): any => ({
-    type: 'keyDown',
-    key: 'Escape',
-    code: 'Escape',
-    isAutoRepeat: false,
-    isComposing: false,
-    shift: false,
-    control: false,
-    alt: false,
-    meta: false,
-    location: 0,
-    modifiers: [],
-    ...overrides,
-  });
+  const createInput = (overrides: Partial<Input> = {}): Input =>
+    ({
+      type: 'keyDown',
+      key: 'Escape',
+      code: 'Escape',
+      isAutoRepeat: false,
+      isComposing: false,
+      shift: false,
+      control: false,
+      alt: false,
+      meta: false,
+      location: 0,
+      modifiers: [],
+      ...overrides,
+    }) as Input;
 
   const setupAndGetHandler = async (): Promise<any> => {
     const { setupRootWindow } = require('./rootWindow');

--- a/src/ui/main/rootWindow.ts
+++ b/src/ui/main/rootWindow.ts
@@ -160,6 +160,9 @@ export const isInsideSomeScreen = ({
         y + height > bounds.y
     );
 
+export const isWindowInAnyFullscreen = (window: BrowserWindow): boolean =>
+  window.isFullScreen() || window.isSimpleFullScreen();
+
 export const applyRootWindowState = (browserWindow: BrowserWindow): void => {
   const rootWindowState = select(selectRootWindowState);
   const isTrayIconEnabled = select(
@@ -412,7 +415,7 @@ export const setupRootWindow = (): void => {
 
     const escapeFullscreenGuard = createEscapeFullscreenGuard(
       rootWindow.webContents,
-      () => rootWindow.isFullScreen() || rootWindow.isSimpleFullScreen()
+      () => isWindowInAnyFullscreen(rootWindow)
     );
 
     rootWindow.webContents.addListener('before-input-event', (event, input) => {

--- a/src/ui/main/rootWindow.ts
+++ b/src/ui/main/rootWindow.ts
@@ -34,6 +34,7 @@ import {
 import type { WindowState } from '../common';
 import { selectGlobalBadge, selectGlobalBadgeCount } from '../selectors';
 import { debounce } from './debounce';
+import { createEscapeFullscreenGuard } from './escapeFullscreenGuard';
 import { getTrayIconPath } from './icons';
 
 const webPreferences: WebPreferences = {
@@ -407,6 +408,17 @@ export const setupRootWindow = (): void => {
 
     rootWindow.addListener('focus', async () => {
       rootWindow.flashFrame(false);
+    });
+
+    const escapeFullscreenGuard = createEscapeFullscreenGuard(
+      rootWindow.webContents,
+      () => rootWindow.isFullScreen() || rootWindow.isSimpleFullScreen()
+    );
+
+    rootWindow.webContents.addListener('before-input-event', (event, input) => {
+      if (escapeFullscreenGuard.handleInput(input)) {
+        event.preventDefault();
+      }
     });
 
     rootWindow.addListener('close', async (event) => {

--- a/src/ui/main/serverView/index.spec.ts
+++ b/src/ui/main/serverView/index.spec.ts
@@ -1,9 +1,10 @@
-import type { Event, WebContents } from 'electron';
+import type { Event, Input, WebContents } from 'electron';
 
 import { isProtocolAllowed } from '../../../navigation/main';
 import { listen } from '../../../store';
 import { openExternal } from '../../../utils/browserLauncher';
-import { WEBVIEW_READY } from '../../actions';
+import { WEBVIEW_ATTACHED, WEBVIEW_READY } from '../../actions';
+import { getRootWindow } from '../rootWindow';
 import { attachGuestWebContentsEvents } from './index';
 
 jest.mock('electron', () => ({
@@ -152,5 +153,212 @@ describe('serverView attachGuestWebContentsEvents will-navigate guard', () => {
     await Promise.resolve();
 
     expect(mockOpenExternal).not.toHaveBeenCalled();
+  });
+});
+
+describe('serverView before-input-event fullscreen handling', () => {
+  const mockListen = listen as unknown as jest.Mock;
+  const mockGetRootWindow = getRootWindow as jest.MockedFunction<
+    typeof getRootWindow
+  >;
+  const originalPlatform = process.platform;
+
+  let beforeInputEventHandler: (event: Event, input: Input) => void;
+  let guestListeners: Map<string, (...args: any[]) => void>;
+  let guestWebContents: {
+    sendInputEvent: jest.Mock;
+    executeJavaScript: jest.Mock;
+  };
+  let rootWindow: {
+    isFullScreen: jest.Mock;
+    isSimpleFullScreen: jest.Mock;
+    webContents: { sendInputEvent: jest.Mock; addListener: jest.Mock };
+  };
+
+  const setPlatform = (platform: NodeJS.Platform): void => {
+    Object.defineProperty(process, 'platform', {
+      value: platform,
+      configurable: true,
+    });
+  };
+
+  const createInput = (overrides: Partial<Input> = {}): Input =>
+    ({
+      type: 'keyDown',
+      key: 'Escape',
+      code: 'Escape',
+      isAutoRepeat: false,
+      isComposing: false,
+      shift: false,
+      control: false,
+      alt: false,
+      meta: false,
+      location: 0,
+      modifiers: [],
+      ...overrides,
+    }) as Input;
+
+  const createEvent = (): Event =>
+    ({ preventDefault: jest.fn() }) as unknown as Event;
+
+  const attachGuest = async (): Promise<void> => {
+    await attachGuestWebContentsEvents();
+
+    const webviewAttachedCall = mockListen.mock.calls.find(
+      ([actionType]) => actionType === WEBVIEW_ATTACHED
+    );
+    const webviewAttachedCallback = webviewAttachedCall?.[1] as (
+      action: unknown
+    ) => void;
+
+    (
+      jest.requireMock('electron').webContents.fromId as jest.Mock
+    ).mockReturnValue(guestWebContents);
+
+    webviewAttachedCallback({
+      payload: { webContentsId: 1, url: 'https://open.rocket.chat' },
+    });
+
+    beforeInputEventHandler = guestListeners.get('before-input-event') as (
+      event: Event,
+      input: Input
+    ) => void;
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    setPlatform('darwin');
+
+    guestListeners = new Map();
+    rootWindow = {
+      isFullScreen: jest.fn(() => true),
+      isSimpleFullScreen: jest.fn(() => false),
+      webContents: { sendInputEvent: jest.fn(), addListener: jest.fn() },
+    };
+    mockGetRootWindow.mockResolvedValue(rootWindow as any);
+
+    guestWebContents = {
+      sendInputEvent: jest.fn(),
+      executeJavaScript: jest.fn(() => Promise.resolve()),
+    };
+
+    Object.assign(guestWebContents, {
+      addListener: jest.fn((event: string, handler: any) => {
+        guestListeners.set(event, handler);
+      }),
+      on: jest.fn(),
+      setWindowOpenHandler: jest.fn(),
+      session: { on: jest.fn(), setPermissionRequestHandler: jest.fn() },
+    });
+
+    await attachGuest();
+  });
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+  });
+
+  const enterHtmlFullscreen = (): void => {
+    guestListeners.get('enter-html-full-screen')?.();
+  };
+
+  it('exits only the HTML5 fullscreen when Escape is pressed while a video is fullscreen', () => {
+    enterHtmlFullscreen();
+
+    const event = createEvent();
+    beforeInputEventHandler(event, createInput());
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(guestWebContents.executeJavaScript).toHaveBeenCalledWith(
+      expect.stringContaining('exitFullscreen')
+    );
+    expect(rootWindow.webContents.sendInputEvent).not.toHaveBeenCalled();
+  });
+
+  it('replays Escape into the guest instead of letting it reach the native window', () => {
+    const event = createEvent();
+    beforeInputEventHandler(event, createInput());
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(guestWebContents.sendInputEvent).toHaveBeenCalledWith({
+      type: 'keyDown',
+      keyCode: 'Escape',
+      modifiers: [],
+    });
+    expect(guestWebContents.executeJavaScript).not.toHaveBeenCalled();
+  });
+
+  it('forwards the replayed Escape to the root window', () => {
+    beforeInputEventHandler(createEvent(), createInput());
+    guestWebContents.sendInputEvent.mockClear();
+
+    const event = createEvent();
+    beforeInputEventHandler(event, createInput());
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(guestWebContents.sendInputEvent).not.toHaveBeenCalled();
+    expect(rootWindow.webContents.sendInputEvent).toHaveBeenCalledWith({
+      type: 'keyDown',
+      keyCode: 'Escape',
+      modifiers: [],
+    });
+  });
+
+  it('forwards Escape untouched when the window is not in fullscreen', () => {
+    rootWindow.isFullScreen.mockReturnValue(false);
+
+    const event = createEvent();
+    beforeInputEventHandler(event, createInput());
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(guestWebContents.sendInputEvent).not.toHaveBeenCalled();
+    expect(rootWindow.webContents.sendInputEvent).toHaveBeenCalledWith({
+      type: 'keyDown',
+      keyCode: 'Escape',
+      modifiers: [],
+    });
+  });
+
+  it('does not forward the Escape key up to the root window', () => {
+    const event = createEvent();
+    beforeInputEventHandler(event, createInput({ type: 'keyUp' }));
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(rootWindow.webContents.sendInputEvent).not.toHaveBeenCalled();
+  });
+
+  it('keeps forwarding both key down and key up of the shortcut key', () => {
+    beforeInputEventHandler(createEvent(), createInput({ key: 'Meta' }));
+    beforeInputEventHandler(
+      createEvent(),
+      createInput({ key: 'Meta', type: 'keyUp' })
+    );
+
+    expect(rootWindow.webContents.sendInputEvent).toHaveBeenNthCalledWith(1, {
+      type: 'keyDown',
+      keyCode: 'Meta',
+      modifiers: [],
+    });
+    expect(rootWindow.webContents.sendInputEvent).toHaveBeenNthCalledWith(2, {
+      type: 'keyUp',
+      keyCode: 'Meta',
+      modifiers: [],
+    });
+  });
+
+  it('leaves Escape alone on other platforms', async () => {
+    setPlatform('linux');
+    await attachGuest();
+
+    const event = createEvent();
+    beforeInputEventHandler(event, createInput());
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(guestWebContents.sendInputEvent).not.toHaveBeenCalled();
+    expect(rootWindow.webContents.sendInputEvent).toHaveBeenCalledWith({
+      type: 'keyDown',
+      keyCode: 'Escape',
+      modifiers: [],
+    });
   });
 });

--- a/src/ui/main/serverView/index.spec.ts
+++ b/src/ui/main/serverView/index.spec.ts
@@ -346,6 +346,20 @@ describe('serverView before-input-event fullscreen handling', () => {
     });
   });
 
+  it('leaves HTML5 fullscreen to Chromium on other platforms', async () => {
+    setPlatform('linux');
+    await attachGuest();
+    enterHtmlFullscreen();
+
+    const event = createEvent();
+    beforeInputEventHandler(event, createInput());
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(guestWebContents.executeJavaScript).not.toHaveBeenCalled();
+    expect(guestWebContents.sendInputEvent).not.toHaveBeenCalled();
+    expect(rootWindow.webContents.sendInputEvent).not.toHaveBeenCalled();
+  });
+
   it('leaves Escape alone on other platforms', async () => {
     setPlatform('linux');
     await attachGuest();

--- a/src/ui/main/serverView/index.spec.ts
+++ b/src/ui/main/serverView/index.spec.ts
@@ -54,6 +54,12 @@ jest.mock('../rootWindow', () => ({
       webContents: { addListener: jest.fn() },
     })
   ),
+  isWindowInAnyFullscreen: jest.fn(
+    (window: {
+      isFullScreen: () => boolean;
+      isSimpleFullScreen: () => boolean;
+    }) => window.isFullScreen() || window.isSimpleFullScreen()
+  ),
 }));
 
 jest.mock('./popupMenu', () => ({
@@ -172,7 +178,12 @@ describe('serverView before-input-event fullscreen handling', () => {
   let rootWindow: {
     isFullScreen: jest.Mock;
     isSimpleFullScreen: jest.Mock;
-    webContents: { sendInputEvent: jest.Mock; addListener: jest.Mock };
+    isDestroyed: jest.Mock;
+    webContents: {
+      sendInputEvent: jest.Mock;
+      addListener: jest.Mock;
+      isDestroyed: jest.Mock;
+    };
   };
 
   const setPlatform = (platform: NodeJS.Platform): void => {
@@ -233,7 +244,12 @@ describe('serverView before-input-event fullscreen handling', () => {
     rootWindow = {
       isFullScreen: jest.fn(() => true),
       isSimpleFullScreen: jest.fn(() => false),
-      webContents: { sendInputEvent: jest.fn(), addListener: jest.fn() },
+      isDestroyed: jest.fn(() => false),
+      webContents: {
+        sendInputEvent: jest.fn(),
+        addListener: jest.fn(),
+        isDestroyed: jest.fn(() => false),
+      },
     };
     mockGetRootWindow.mockResolvedValue(rootWindow as any);
 
@@ -272,6 +288,18 @@ describe('serverView before-input-event fullscreen handling', () => {
     expect(guestWebContents.executeJavaScript).toHaveBeenCalledWith(
       expect.stringContaining('exitFullscreen')
     );
+    expect(rootWindow.webContents.sendInputEvent).not.toHaveBeenCalled();
+  });
+
+  it('swallows auto-repeated Escapes in HTML5 fullscreen without re-running the exit', () => {
+    enterHtmlFullscreen();
+
+    beforeInputEventHandler(createEvent(), createInput());
+    const event = createEvent();
+    beforeInputEventHandler(event, createInput({ isAutoRepeat: true }));
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(guestWebContents.executeJavaScript).toHaveBeenCalledTimes(1);
     expect(rootWindow.webContents.sendInputEvent).not.toHaveBeenCalled();
   });
 

--- a/src/ui/main/serverView/index.ts
+++ b/src/ui/main/serverView/index.ts
@@ -45,7 +45,7 @@ import {
 } from '../../actions';
 import { createEscapeFullscreenGuard } from '../escapeFullscreenGuard';
 import { handleMediaPermissionRequest } from '../mediaPermissions';
-import { getRootWindow } from '../rootWindow';
+import { getRootWindow, isWindowInAnyFullscreen } from '../rootWindow';
 import { isMarkdownViewerDownloadUrl } from './isMarkdownViewerDownloadUrl';
 import { createPopupMenuForServerView } from './popupMenu';
 
@@ -357,7 +357,7 @@ const initializeServerWebContentsAfterAttach = (
 
   const escapeFullscreenGuard = createEscapeFullscreenGuard(
     guestWebContents,
-    () => rootWindow.isFullScreen() || rootWindow.isSimpleFullScreen()
+    () => isWindowInAnyFullscreen(rootWindow)
   );
 
   const exitGuestHtmlFullscreen = (): void => {
@@ -385,19 +385,26 @@ const initializeServerWebContentsAfterAttach = (
     }
 
     if (key === 'Escape') {
-      // On macOS, while the guest is in HTML5 fullscreen (e.g. a video player)
-      // ESC must only leave the video fullscreen, like Chrome does: swallow the
-      // native key event so it cannot reach the native window and exit its
-      // fullscreen, and drive the fullscreen exit explicitly. Calling it on the
-      // guest's main frame also covers a fullscreen element inside a nested
-      // frame. Windows and Linux keep leaving this to Chromium.
-      if (
-        process.platform === 'darwin' &&
-        isGuestInHtmlFullscreen &&
-        type === 'keyDown'
-      ) {
-        event.preventDefault();
-        exitGuestHtmlFullscreen();
+      // The root window only reacts to ESC on key down; forwarding the key up as
+      // well would leak an unguarded ESC once the guest left HTML5 fullscreen.
+      if (type !== 'keyDown') {
+        return;
+      }
+
+      // While the guest is in HTML5 fullscreen (e.g. a video player) ESC is
+      // never forwarded to the root window. On macOS it must additionally only
+      // leave the video fullscreen, like Chrome does: swallow the native key
+      // event so it cannot reach the native window and exit its fullscreen too,
+      // and drive the fullscreen exit explicitly. Calling it on the guest's
+      // main frame also covers a fullscreen element inside a nested frame.
+      // Windows and Linux leave the fullscreen exit itself to Chromium.
+      if (isGuestInHtmlFullscreen) {
+        if (process.platform === 'darwin') {
+          event.preventDefault();
+          if (!input.isAutoRepeat) {
+            exitGuestHtmlFullscreen();
+          }
+        }
         return;
       }
 
@@ -405,16 +412,10 @@ const initializeServerWebContentsAfterAttach = (
         event.preventDefault();
         return;
       }
+    }
 
-      // The root window only reacts to ESC on key down; forwarding the key up as
-      // well would leak an unguarded ESC once the guest left HTML5 fullscreen.
-      if (type !== 'keyDown') {
-        return;
-      }
-
-      if (isGuestInHtmlFullscreen) {
-        return;
-      }
+    if (rootWindow.isDestroyed() || rootWindow.webContents.isDestroyed()) {
+      return;
     }
 
     rootWindow.webContents.sendInputEvent({

--- a/src/ui/main/serverView/index.ts
+++ b/src/ui/main/serverView/index.ts
@@ -43,6 +43,7 @@ import {
   SIDE_BAR_SERVER_REMOVE,
   WEBVIEW_FORCE_RELOAD_WITH_CACHE_CLEAR,
 } from '../../actions';
+import { createEscapeFullscreenGuard } from '../escapeFullscreenGuard';
 import { handleMediaPermissionRequest } from '../mediaPermissions';
 import { getRootWindow } from '../rootWindow';
 import { isMarkdownViewerDownloadUrl } from './isMarkdownViewerDownloadUrl';
@@ -354,10 +355,25 @@ const initializeServerWebContentsAfterAttach = (
     isGuestInHtmlFullscreen = false;
   });
 
-  const handleBeforeInputEvent = (
-    _event: Event,
-    { type, key }: Input
-  ): void => {
+  const escapeFullscreenGuard = createEscapeFullscreenGuard(
+    guestWebContents,
+    () => rootWindow.isFullScreen() || rootWindow.isSimpleFullScreen()
+  );
+
+  const exitGuestHtmlFullscreen = (): void => {
+    guestWebContents
+      .executeJavaScript('document.exitFullscreen && document.exitFullscreen()')
+      .catch((error) => {
+        console.error(
+          'Failed to exit HTML5 fullscreen on the server view:',
+          error
+        );
+      });
+  };
+
+  const handleBeforeInputEvent = (event: Event, input: Input): void => {
+    const { type, key } = input;
+
     if (type !== 'keyUp' && type !== 'keyDown') {
       return;
     }
@@ -368,11 +384,28 @@ const initializeServerWebContentsAfterAttach = (
       return;
     }
 
-    // On macOS, forwarding ESC to the root window while the guest is in
-    // HTML5 fullscreen (e.g. a video player) causes the native window to
-    // also exit fullscreen. This does not occur on Windows/Linux.
-    if (key === 'Escape' && isGuestInHtmlFullscreen) {
-      return;
+    if (key === 'Escape') {
+      // While the guest is in HTML5 fullscreen (e.g. a video player) ESC must
+      // only leave the video fullscreen, like Chrome does: swallow the native
+      // key event so it cannot reach the native window and exit its fullscreen,
+      // and drive the fullscreen exit explicitly. Calling it on the guest's main
+      // frame also covers a fullscreen element inside a nested frame.
+      if (isGuestInHtmlFullscreen && type === 'keyDown') {
+        event.preventDefault();
+        exitGuestHtmlFullscreen();
+        return;
+      }
+
+      if (escapeFullscreenGuard.handleInput(input)) {
+        event.preventDefault();
+        return;
+      }
+
+      // The root window only reacts to ESC on key down; forwarding the key up as
+      // well would leak an unguarded ESC once the guest left HTML5 fullscreen.
+      if (type !== 'keyDown') {
+        return;
+      }
     }
 
     rootWindow.webContents.sendInputEvent({

--- a/src/ui/main/serverView/index.ts
+++ b/src/ui/main/serverView/index.ts
@@ -385,12 +385,17 @@ const initializeServerWebContentsAfterAttach = (
     }
 
     if (key === 'Escape') {
-      // While the guest is in HTML5 fullscreen (e.g. a video player) ESC must
-      // only leave the video fullscreen, like Chrome does: swallow the native
-      // key event so it cannot reach the native window and exit its fullscreen,
-      // and drive the fullscreen exit explicitly. Calling it on the guest's main
-      // frame also covers a fullscreen element inside a nested frame.
-      if (isGuestInHtmlFullscreen && type === 'keyDown') {
+      // On macOS, while the guest is in HTML5 fullscreen (e.g. a video player)
+      // ESC must only leave the video fullscreen, like Chrome does: swallow the
+      // native key event so it cannot reach the native window and exit its
+      // fullscreen, and drive the fullscreen exit explicitly. Calling it on the
+      // guest's main frame also covers a fullscreen element inside a nested
+      // frame. Windows and Linux keep leaving this to Chromium.
+      if (
+        process.platform === 'darwin' &&
+        isGuestInHtmlFullscreen &&
+        type === 'keyDown'
+      ) {
         event.preventDefault();
         exitGuestHtmlFullscreen();
         return;
@@ -404,6 +409,10 @@ const initializeServerWebContentsAfterAttach = (
       // The root window only reacts to ESC on key down; forwarding the key up as
       // well would leak an unguarded ESC once the guest left HTML5 fullscreen.
       if (type !== 'keyDown') {
+        return;
+      }
+
+      if (isGuestInHtmlFullscreen) {
         return;
       }
     }


### PR DESCRIPTION
## Problem

On macOS, with the app window in native fullscreen, pressing ESC took the window
out of fullscreen. The most visible case is a video in HTML5 fullscreen: one ESC
press was expected to leave only the video fullscreen, but it dropped the whole
app out of fullscreen. It also happens with no video at all, when ESC has nothing
to dismiss. Google Chrome does not behave this way.

## Cause

On macOS, Electron hands every key event the web content did not consume back to
the native window: `WebContents::PlatformHandleKeyboardEvent` in
`electron_api_web_contents_mac.mm` calls `[ns_event.window redispatchKeyEvent:]`.
AppKit answers ESC with `cancelOperation:`, which leaves native fullscreen on a
fullscreen window. Chrome never returns the raw `NSEvent` to AppKit, so it stays
fullscreen.

The non-macOS implementation of that function only runs registered window
accelerators, and there is no ESC accelerator in this app, which is why the bug
is macOS-only.

PR #3270 addressed a different mechanism: it stopped forwarding ESC to the root
window through `sendInputEvent`. That produces a synthetic event, which carries
no `NSEvent` and can never reach AppKit, so the redispatch was left untouched.

## Change

`before-input-event` runs before the renderer sees the event, so cancelling it
there also cancels the redispatch. That is the interception point used here.

- New `src/ui/main/escapeFullscreenGuard.ts`: on macOS, while the window is in
  native fullscreen, an ESC key down is cancelled and replayed through
  `sendInputEvent`. The replay still reaches the page, but carries no `NSEvent`
  and cannot reach AppKit. A pending-replay counter with a short deadline
  recognises the replay and re-arms if one is ever dropped. Only key down is
  guarded, since `cancelOperation:` comes from key-down interpretation.
- `src/ui/main/serverView/index.ts`: while the guest is in HTML5 fullscreen, ESC
  is consumed and the fullscreen exit is driven explicitly with
  `document.exitFullscreen()` on the guest main frame, which also covers a
  fullscreen element inside a nested or cross-origin frame. Otherwise the guard
  replays the key.
- `src/ui/main/rootWindow.ts`: the same guard on the root window contents, so ESC
  with focus in the app chrome (tab bar, sidebar, App settings) behaves the same.
- The ESC key up is no longer forwarded to the root window. Only key down is
  consumed there, and the key up leaked an unguarded ESC once the guest had left
  HTML5 fullscreen.

Every new path is behind `process.platform === 'darwin'`. Windows and Linux keep
leaving the HTML5 fullscreen exit to Chromium and keep the original no-forward
guard.

## Behavior changes

- While a video is in HTML5 fullscreen on macOS, the page no longer receives the
  ESC key down. ESC exits only the video fullscreen. This matches Chrome, where
  the browser consumes ESC in fullscreen.
- On macOS, ESC no longer takes the window out of native fullscreen anywhere in
  the app. Fullscreen is still toggled by the green window button,
  `Control+Command+F`, and `View` -> `Full screen`.

## Tests

New and updated Jest coverage:

- `src/ui/main/escapeFullscreenGuard.main.spec.ts`: swallow and replay, replay
  pass-through, re-arm after the deadline, not fullscreen, key up, non-ESC keys,
  and `win32`/`linux` inertness.
- `src/ui/main/serverView/index.spec.ts`: HTML5 fullscreen ESC exits only the
  video and is not forwarded, ESC is replayed otherwise, the replay is forwarded,
  the ESC key up is not forwarded, `Meta` key down and key up are still
  forwarded, and the non-macOS paths are unchanged.
- `src/ui/main/rootWindow.spec.ts`: the guard is installed on the root window
  contents and behaves correctly in and out of fullscreen and off macOS.

`yarn lint`, `npx tsc --noEmit`, `yarn build`, and `yarn test` (156 suites, 1683
tests) pass locally.

## QA

No Jest test can prove the fix, because the bug depends on how AppKit reacts to a
real key event from the operating system, and a test generated key event is
synthetic and never gets there. That is what let the earlier regression pass CI.
The automated tests protect the desktop wiring; the OS half is covered by the new
`qa/macos-fullscreen-escape/` pack, which must be run on real macOS hardware:

1. `flows/01-video-fullscreen-escape.md` — video HTML5 fullscreen, for both a
   `.mp4` attachment and an embedded cross-origin player.
2. `flows/02-plain-escape-keeps-fullscreen.md` — plain ESC in the workspace and in
   App settings, including repeated and held-key presses.
3. `flows/03-escape-and-shortcut-regressions.md` — ESC still closes workspace
   search, `Command+R` still fires, both fullscreen toggles still work, and the
   windowed video cycle restores the window.
4. `flows/04-windows-linux-escape-unchanged.md` — Windows and Linux regression
   check.

`node qa/scripts/validate-flows.mjs qa/macos-fullscreen-escape` and
`node qa/scripts/export-qase-csv.mjs qa/macos-fullscreen-escape` pass.

## Notes for reviewers

- `qa/**/flows/*.md` tables must not be reformatted by Prettier. `validate-flows.mjs`
  requires an exact steps-table header, and Prettier pads the columns. Consider
  adding `qa/**/*.md` to `.prettierignore`.
- Nothing in CI runs the QA validators today, since `yarn lint` is eslint plus tsc.
- Unrelated pre-existing bug spotted nearby, left untouched: the `close` handler in
  `src/ui/main/rootWindow.ts` awaits `leave-full-screen` before calling
  `setFullScreen(false)`, so on a real fullscreen window that promise can never
  resolve.

[CORE-1721]

[CORE-1721]: https://rocketchat.atlassian.net/browse/CORE-1721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS fullscreen Escape-key handling.
  * Escape now exits video fullscreen without unexpectedly exiting the app’s native fullscreen mode.
  * Preserved existing Escape behavior on Windows and Linux.
  * Improved forwarding of keyboard shortcuts and modifier keys.

* **Documentation**
  * Added cross-platform QA guidance and regression flows for fullscreen and Escape-key behavior.
  * Documented QA evidence storage and test-result exports.

* **Tests**
  * Added comprehensive coverage for fullscreen, Escape-key, replay, and cross-platform behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->