### PR TITLE
fix: break renderer infinite re-render loop causing 'Maximum update depth exceeded'

### DIFF
--- a/src/ui/components/SupportedVersionDialog/index.tsx
+++ b/src/ui/components/SupportedVersionDialog/index.tsx
@@ -55,6 +55,21 @@ export const SupportedVersionDialog = () => {
     });
   };
 
+  const setExpirationMessageIfChanged = useCallback(
+    (translatedMessage: MessageTranslated) => {
+      setExpirationMessage((previous) =>
+        previous &&
+        previous.title === translatedMessage.title &&
+        previous.subtitle === translatedMessage.subtitle &&
+        previous.description === translatedMessage.description &&
+        previous.link === translatedMessage.link
+          ? previous
+          : translatedMessage
+      );
+    },
+    []
+  );
+
   const checkServerVersion = useCallback(async () => {
     if (
       !server?.supportedVersions ||
@@ -101,7 +116,7 @@ export const SupportedVersionDialog = () => {
           ) as MessageTranslated;
 
           if (translatedMessage) {
-            setExpirationMessage(translatedMessage);
+            setExpirationMessageIfChanged(translatedMessage);
             setIsVisible(supported.supported);
           }
         }
@@ -134,10 +149,10 @@ export const SupportedVersionDialog = () => {
     ) as MessageTranslated;
 
     if (translatedMessage) {
-      setExpirationMessage(translatedMessage);
+      setExpirationMessageIfChanged(translatedMessage);
       setIsVisible(supported.supported);
     }
-  }, [server, setExpirationMessage, setIsVisible]);
+  }, [server, setExpirationMessageIfChanged, setIsVisible]);
 
   useEffect(() => {
     checkServerVersion();

--- a/src/ui/components/TabBar/useTabBarLayout.ts
+++ b/src/ui/components/TabBar/useTabBarLayout.ts
@@ -98,9 +98,15 @@ export const useTabBarLayout = <S extends Server>(
       }
 
       rafRef.current = requestAnimationFrame(() => {
-        const width =
-          entry.contentRect.width - (hasAddButton ? ADD_BUTTON_WIDTH : 0);
-        setAvailableWidth(Math.max(0, width));
+        const width = Math.max(
+          0,
+          Math.round(
+            entry.contentRect.width - (hasAddButton ? ADD_BUTTON_WIDTH : 0)
+          )
+        );
+        setAvailableWidth((previous) =>
+          previous === width ? previous : width
+        );
       });
     });
 

--- a/src/ui/components/hooks/useServers.ts
+++ b/src/ui/components/hooks/useServers.ts
@@ -1,24 +1,24 @@
-import { useSelector } from 'react-redux';
+import { shallowEqual, useSelector } from 'react-redux';
 import { createSelector } from 'reselect';
 
 import type { Server } from '../../../servers/common';
 import type { RootState } from '../../../store/rootReducer';
+
 // TODO: change currentView.url string to URL type
+const selectServersWithSelection = createSelector(
+  ({ currentView }: RootState) => currentView,
+  ({ servers }: RootState) => servers,
+  (currentView, servers): (Server & { selected: boolean })[] => {
+    const currentViewHref =
+      typeof currentView === 'object' ? new URL(currentView.url).href : null;
+    return servers.map((server) => ({
+      ...server,
+      selected:
+        currentViewHref !== null &&
+        currentViewHref === new URL(server.url).href,
+    }));
+  }
+);
+
 export const useServers = (): (Server & { selected: boolean })[] =>
-  useSelector(
-    createSelector(
-      ({ currentView }: RootState) => currentView,
-      ({ servers }: RootState) => servers,
-      (currentView, servers) => {
-        const currentViewUrl =
-          typeof currentView === 'object' ? new URL(currentView.url) : false;
-        return servers.map((server) =>
-          Object.assign(server, {
-            selected:
-              currentViewUrl &&
-              currentViewUrl.href === new URL(server.url).href,
-          })
-        );
-      }
-    )
-  );
+  useSelector(selectServersWithSelection, shallowEqual);

--- a/src/ui/components/hooks/useSorting.tsx
+++ b/src/ui/components/hooks/useSorting.tsx
@@ -73,7 +73,7 @@ export const useSorting = <S extends Server>(
   };
 
   const sortedServers = serversSorting
-    ? servers.sort(
+    ? [...servers].sort(
         ({ url: a }, { url: b }) =>
           serversSorting.indexOf(a) - serversSorting.indexOf(b)
       )

--- a/src/ui/components/utils/ReparentingContainer.tsx
+++ b/src/ui/components/utils/ReparentingContainer.tsx
@@ -1,5 +1,5 @@
 import { useMergedRefs } from '@rocket.chat/fuselage-hooks';
-import type { ReactElement, ReactNode, Key } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import { useLayoutEffect, useRef, forwardRef } from 'react';
 import { createPortal } from 'react-dom';
 import flattenChildren from 'react-keyed-flatten-children';
@@ -8,44 +8,54 @@ type ReparentingContainerProps = {
   children?: ReactNode;
 };
 
+const KEY_SEPARATOR = '\u0000';
+
+const joinKeys = (keys: string[]): string => keys.join(KEY_SEPARATOR);
+
+const splitKeys = (joinedKeys: string): string[] =>
+  joinedKeys === '' ? [] : joinedKeys.split(KEY_SEPARATOR);
+
 export const ReparentingContainer = forwardRef<
   HTMLDivElement,
   ReparentingContainerProps
 >(function ReparentingContainer({ children, ...props }, ref) {
   const innerRef = useRef<HTMLDivElement>(null);
 
-  const childrenArray = flattenChildren(children) as ReactElement<any>[];
+  const keyedChildren = (
+    flattenChildren(children) as ReactElement<any>[]
+  ).filter((child): child is ReactElement<any> & { key: string } =>
+    Boolean(child.key)
+  );
 
-  const prevChildrenArrayRef = useRef<ReactElement<any>[]>([]);
-  useLayoutEffect(() => {
-    prevChildrenArrayRef.current = childrenArray;
-  }, [childrenArray]);
+  const prevKeysRef = useRef<string[]>([]);
+  const prevKeys = prevKeysRef.current;
+  const keys = keyedChildren.map((child) => child.key);
 
-  const prevKeys = prevChildrenArrayRef.current.map((child) => child.key);
-  const keys = childrenArray.map((child) => child.key);
-
-  const childrenAdded = childrenArray.filter(
+  const childrenAdded = keyedChildren.filter(
     (child) => !prevKeys.includes(child.key)
   );
-  const childrenKept = childrenArray.filter((child) =>
+  const childrenKept = keyedChildren.filter((child) =>
     prevKeys.includes(child.key)
   );
-  const childrenRemoved = prevChildrenArrayRef.current.filter(
-    (child) => !keys.includes(child.key)
+
+  const keysJoined = joinKeys(keys);
+  const addedKeysJoined = joinKeys(childrenAdded.map((child) => child.key));
+  const removedKeysJoined = joinKeys(
+    prevKeys.filter((key) => !keys.includes(key))
   );
 
-  const nodesRef = useRef(new Map<Key, Element>());
+  useLayoutEffect(() => {
+    prevKeysRef.current = splitKeys(keysJoined);
+  }, [keysJoined]);
+
+  const nodesRef = useRef(new Map<string, Element>());
 
   const portals = [
     ...childrenKept.map((child) => {
-      const element = child.key ? nodesRef.current.get(child.key) : undefined;
+      const element = nodesRef.current.get(child.key);
       return element ? createPortal(child, element, String(child.key)) : null;
     }),
     ...childrenAdded.map((child) => {
-      if (!child.key) {
-        return null;
-      }
-
       const node = document.createElement('div');
       nodesRef.current.set(child.key, node);
       return createPortal(child, node, String(child.key));
@@ -57,12 +67,8 @@ export const ReparentingContainer = forwardRef<
       return;
     }
 
-    for (const child of childrenAdded) {
-      if (!child.key) {
-        continue;
-      }
-
-      const node = nodesRef.current.get(child.key);
+    for (const key of splitKeys(addedKeysJoined)) {
+      const node = nodesRef.current.get(key);
 
       if (!node) {
         continue;
@@ -74,20 +80,22 @@ export const ReparentingContainer = forwardRef<
       node.toggleAttribute('data-container', true);
       innerRef.current.parentElement?.insertBefore(node, innerRef.current);
     }
-  }, [childrenAdded]);
+  }, [addedKeysJoined]);
 
   useLayoutEffect(() => {
-    setTimeout(() => {
-      for (const child of childrenRemoved) {
-        if (!child.key) {
-          continue;
-        }
+    const removedKeys = splitKeys(removedKeysJoined);
 
-        nodesRef.current.get(child.key)?.remove();
-        nodesRef.current.delete(child.key);
+    if (removedKeys.length === 0) {
+      return;
+    }
+
+    setTimeout(() => {
+      for (const key of removedKeys) {
+        nodesRef.current.get(key)?.remove();
+        nodesRef.current.delete(key);
       }
     }, 1000);
-  }, [childrenRemoved]);
+  }, [removedKeysJoined]);
 
   useLayoutEffect(
     () => () => {

--- a/src/ui/components/utils/ReparentingContainer.tsx
+++ b/src/ui/components/utils/ReparentingContainer.tsx
@@ -8,12 +8,10 @@ type ReparentingContainerProps = {
   children?: ReactNode;
 };
 
-const KEY_SEPARATOR = '\u0000';
-
-const joinKeys = (keys: string[]): string => keys.join(KEY_SEPARATOR);
+const joinKeys = (keys: string[]): string => JSON.stringify(keys);
 
 const splitKeys = (joinedKeys: string): string[] =>
-  joinedKeys === '' ? [] : joinedKeys.split(KEY_SEPARATOR);
+  joinedKeys === '' ? [] : JSON.parse(joinedKeys);
 
 export const ReparentingContainer = forwardRef<
   HTMLDivElement,


### PR DESCRIPTION
## What

Fixes an intermittent renderer infinite re-render loop in 4.16.0-alpha.2. Logs showed 119 `Maximum update depth exceeded` errors within ~1 second, starting ~17s after startup, all with the same stack: react-redux `forceStoreRerender` triggered by store subscription notifications.

## Root cause

The loop was a self-sustaining cycle across three components, amplified by two unstable hooks:

1. **`ReparentingContainer`** — `flattenChildren(children)` returns a fresh array (with cloned elements) every render, and that array plus its `.filter` derivatives were used as `useLayoutEffect` deps. All three layout effects ran on every render, writing to a ref read during render and re-inserting nodes into the DOM (`insertBefore`) each pass.
2. **`SupportedVersionDialog`** — the supported-versions check resolves tens of seconds after launch; each resolution dispatched server updates, giving `server` a new identity, re-running the effect and calling `setExpirationMessage` with a freshly built object every pass — so React never bailed out.
3. **`useTabBarLayout`** (new in #3424) — the `ResizeObserver` called `setAvailableWidth` unguarded; DOM churn from (1) produced sub-pixel width changes that kept pumping the loop instead of letting it settle.

Amplifiers: `useServers` created its `createSelector` **inside** the hook (memoization never worked across renders) and mutated store objects via `Object.assign(server, ...)`; `useSorting` sorted the selector-cached array in place.

## Changes

- `ReparentingContainer.tsx`: key layout effects on joined key strings so they only run when the set of workspace keys actually changes; portal/reparenting behavior (including the 1s removal timeout) is preserved
- `hooks/useServers.ts`: module-level selector, immutable `.map` (spread instead of `Object.assign`), `shallowEqual` on `useSelector`
- `SupportedVersionDialog/index.tsx`: equality bail-out in `setExpirationMessage` (`setExpirationMessageIfChanged`)
- `TabBar/useTabBarLayout.ts`: round measured width and skip `setAvailableWidth` when unchanged
- `hooks/useSorting.tsx`: `[...servers].sort(...)` instead of mutating in place

## Validation

- `npx tsc --noEmit` clean
- `yarn lint` clean
- `yarn test`: 155 suites, 1662 passed, 2 skipped
- `yarn build` clean (externals check passed)
- All `server.selected` consumers (TabBar, ServerSwitcher, SupportedVersionDialog) read via `useServers()`, none relied on the removed store mutation

## Manual testing

The bug is intermittent, so the strongest signal is absence: run with multiple workspaces for a few minutes and confirm the log shows no `Maximum update depth exceeded`; switch between tabs/sidebar layouts and resize the window to exercise the ResizeObserver path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab bar sizing to prevent invalid or inconsistent widths.
  * Improved server selection handling when switching views or navigating between server URLs.
  * Prevented sorting from unexpectedly changing the original server order.
  * Improved component reparenting behavior when tabs or other keyed content are added or removed.
  * Reduced unnecessary updates when version expiration messages remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->