### PR TITLE
fix: eliminate unread badge dispatch storm that crashed TabBar rendering

### DIFF
--- a/src/injected.ts
+++ b/src/injected.ts
@@ -527,6 +527,19 @@ const start = async () => {
       // only sees rooms that changed after the listener attached, so it can
       // undercount; we prefer the aggregate for the numeric total and use the
       // map solely to rebuild the alert-only "•" indicator.
+      // Server boot floods this path: the webapp fires one
+      // `unread-changed-by-subscription` event per room when it starts, and
+      // dispatching a badge update for each one storms the root window's
+      // Redux store hard enough that React aborts with "Maximum update depth
+      // exceeded". Recomputes are therefore coalesced into a single
+      // trailing-edge call, and the dispatch is skipped entirely when the
+      // resolved badge value did not change.
+      const BADGE_COALESCE_MS = 100;
+      let resolveBadgeTimer: ReturnType<typeof setTimeout> | null = null;
+      let pendingAggregateCount: number | undefined;
+      let lastSentBadge: number | '•' | undefined;
+      let hasSentBadge = false;
+
       const resolveBadge = (aggregateCount?: number): void => {
         let unreadCount = 0;
         let alertIndicator: '•' | undefined;
@@ -557,11 +570,28 @@ const start = async () => {
             ? aggregateCount
             : unreadCount;
 
-        if (total > 0) {
-          window.RocketChatDesktop.setBadge(total);
+        const badge = total > 0 ? total : alertIndicator ?? 0;
+        if (hasSentBadge && badge === lastSentBadge) {
           return;
         }
-        window.RocketChatDesktop.setBadge(alertIndicator ?? 0);
+        hasSentBadge = true;
+        lastSentBadge = badge;
+        window.RocketChatDesktop.setBadge(badge);
+      };
+
+      const scheduleResolveBadge = (aggregateCount?: number): void => {
+        if (aggregateCount !== undefined) {
+          pendingAggregateCount = aggregateCount;
+        }
+        if (resolveBadgeTimer !== null) {
+          return;
+        }
+        resolveBadgeTimer = setTimeout(() => {
+          resolveBadgeTimer = null;
+          const aggregate = pendingAggregateCount;
+          pendingAggregateCount = undefined;
+          resolveBadge(aggregate);
+        }, BADGE_COALESCE_MS);
       };
 
       window.addEventListener('unread-changed-by-subscription', (event) => {
@@ -581,7 +611,7 @@ const start = async () => {
           alert: subscription.alert,
           unreadAlert: subscription.unreadAlert,
         });
-        resolveBadge();
+        scheduleResolveBadge();
       });
 
       window.addEventListener('unread-changed', (event) => {
@@ -590,7 +620,7 @@ const start = async () => {
           typeof detail === 'number' && Number.isFinite(detail)
             ? detail
             : undefined;
-        resolveBadge(aggregateCount);
+        scheduleResolveBadge(aggregateCount);
       });
 
       setupFlags.unreadChangedEvent = true;

--- a/src/servers/bootWatchdog.ts
+++ b/src/servers/bootWatchdog.ts
@@ -209,9 +209,11 @@ export const attachBootWatchdog = (
     booted: false,
     reportedForCurrentLoad: false,
   };
+  // The deadline is armed by the first committed navigation (did-navigate),
+  // not here: webviews can attach and legitimately never navigate (lazy or
+  // error-view panes), and reporting those is pure noise.
   watchStates.set(serverUrl, state);
   record(state, 'attached');
-  startDeadline(state);
 
   webContents.on('console-message', (event) => {
     const message = String(event.message ?? '').slice(0, MESSAGE_LENGTH_LIMIT);

--- a/src/servers/preload/badge.ts
+++ b/src/servers/preload/badge.ts
@@ -3,7 +3,19 @@ import { WEBVIEW_UNREAD_CHANGED } from '../../ui/actions';
 import type { Server } from '../common';
 import { getServerUrl } from './urls';
 
+let hasDispatched = false;
+let lastBadge: Server['badge'];
+
 export const setBadge = (badge: Server['badge']): void => {
+  // The pre-7.8.0 Session autorun and the unread event listeners can both
+  // re-emit unchanged values in rapid succession; a no-op dispatch still
+  // re-renders every server-subscribed component in the root window.
+  if (hasDispatched && Object.is(badge, lastBadge)) {
+    return;
+  }
+  hasDispatched = true;
+  lastBadge = badge;
+
   dispatch({
     type: WEBVIEW_UNREAD_CHANGED,
     payload: {

--- a/src/servers/reducers.ts
+++ b/src/servers/reducers.ts
@@ -77,6 +77,16 @@ type ServersActionTypes =
   | ActionOf<typeof WEBVIEW_PAGE_TITLE_CHANGED>
   | ActionOf<typeof SIDE_BAR_SERVER_REMOVE>;
 
+// Returns the original object (preserving identity) when the patch would not
+// change any field — a new array identity here re-renders every
+// server-subscribed component, so no-op actions must not mint one.
+const patchServer = (server: Server, patch: Server): Server => {
+  const changed = Object.entries(patch).some(
+    ([key, value]) => !Object.is(server[key as keyof Server], value)
+  );
+  return changed ? { ...server, ...patch } : server;
+};
+
 const upsert = (state: Server[], server: Server): Server[] => {
   const index = state.findIndex(({ url }) => url === server.url);
 
@@ -84,9 +94,10 @@ const upsert = (state: Server[], server: Server): Server[] => {
     return [...state, server];
   }
 
-  return state.map((_server, i) =>
-    i === index ? { ..._server, ...server } : _server
-  );
+  const patched = patchServer(state[index], server);
+  return patched === state[index]
+    ? state
+    : state.map((_server, i) => (i === index ? patched : _server));
 };
 
 const update = (state: Server[], server: Server): Server[] => {
@@ -96,9 +107,10 @@ const update = (state: Server[], server: Server): Server[] => {
     return state;
   }
 
-  return state.map((_server, i) =>
-    i === index ? { ..._server, ...server } : _server
-  );
+  const patched = patchServer(state[index], server);
+  return patched === state[index]
+    ? state
+    : state.map((_server, i) => (i === index ? patched : _server));
 };
 
 export const servers: Reducer<Server[], ServersActionTypes> = (


### PR DESCRIPTION
## Summary

Root-causes and fixes the long-standing intermittent `Maximum update depth exceeded` storm (first reported as 119 errors within ~1 second, ~20s after startup). The trigger turned out to be **data-dependent, not code-dependent** — which is why it always looked random.

## How it was found

After #3435 and #3436 merged, the error storm still reproduced — now deterministically, ~2s after every startup, at reduced intensity (10–14 errors). Two techniques pinned it down:

**1. Build bisection.** Five builds were launched under identical conditions and the error count measured after startup:

| Build | Errors per startup |
|---|---|
| master (#3434 + #3435 + #3436) | 12–14 |
| master without the `setVersion` dispatch | 12 |
| #3434 + #3435 | 10 |
| #3434 only | 12 |
| **4.16.0-alpha.2 baseline (no merged PRs)** | **12** |

Every build reproduced, including the untouched baseline — so no merged PR caused it. The environment had changed instead: the storm only fires when servers have **unread rooms at boot**. Earlier same-day runs with no unread state were consistently clean, which is also why the bug historically appeared intermittent.

**2. react-dom instrumentation.** Patching `getRootForUpdatedFiber` (locally, dev only) to print the fiber chain at the moment of the throw identified the crashing subscriber:

```
[LOOP-DEBUG] fiber chain: TabBar < div < TooltipProvider < Shell < I18nextProvider < ReactRedux < Provider < ErrorCatcher < App
```

## Root cause

On webapp boot, the server fires one `unread-changed-by-subscription` event **per room**. The chain amplified each one:

1. `injected.ts` recomputed and called `setBadge` for every event — no coalescing, no value dedupe
2. `preload/badge.ts` dispatched `WEBVIEW_UNREAD_CHANGED` unconditionally, even for identical values
3. the servers reducer's `upsert`/`update` minted a new array (and server object) even when the patch changed nothing
4. every server-subscribed component re-rendered per dispatch; with enough unread rooms, React hit its nested-update limit inside `TabBar` and aborted

## Changes

- **`src/injected.ts`** — badge recomputes are coalesced into a single 100ms trailing-edge call, and `setBadge` is skipped when the resolved value is unchanged
- **`src/servers/preload/badge.ts`** — consecutive identical badge values no longer dispatch (also covers the pre-7.8.0 Session autorun path)
- **`src/servers/reducers.ts`** — `upsert`/`update` preserve object and array identity for no-op patches, so no-op actions no longer re-render every consumer
- **`src/servers/bootWatchdog.ts`** — the boot deadline now arms on the first committed navigation instead of on attach; webviews that legitimately never navigate (lazy or error panes) were producing false `boot-deadline-exceeded` reports

## Validation

- **Runtime, against the live trigger:** 0 errors across the startup window, versus 10–14 in six consecutive pre-fix runs under the same account state
- `npx tsc --noEmit` clean, `yarn lint` clean
- `yarn test`: 155 suites, 1666 passed, 2 skipped
- `yarn build` clean (externals check passed)

## Relationship to previous PRs

#3435's fixes remain valid and necessary — they reduced the storm's amplification (119 → ~12) by stabilizing subscribers. This PR removes the storm at its source. Whether the badge storm also explains the intermittent boot wedge (stuck throbber, #3436) is not yet confirmed; the boot watchdog from #3436 remains in place to capture forensic reports if a wedge recurs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unread badge updates are now smoother and avoid redundant refreshes during rapid event bursts.
  * Badge counts continue updating correctly when values change.
  * Boot timeout reports are avoided for panes that have not started navigation.
  * Unchanged server updates no longer trigger unnecessary refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->