### PR TITLE
chore: bump version to 4.16.0-alpha.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "Rocket.Chat",
   "name": "rocketchat",
   "description": "Official OSX, Windows, and Linux Desktop Clients for Rocket.Chat",
-  "version": "4.16.0-alpha.2",
+  "version": "4.16.0-alpha.3",
   "author": "Rocket.Chat Support <support@rocket.chat>",
   "copyright": "© 2016-2026, Rocket.Chat",
   "homepage": "https://rocket.chat",


### PR DESCRIPTION
## Shipped since 4.16.0-alpha.2

- feat(updates): surface updates as a titlebar label instead of a modal (#3427)
- fix: eliminate unread badge dispatch storm that crashed TabBar rendering (#3437)
- fix: recover wedged webview boot instead of dying on injected script failure (#3436)
- fix: break renderer infinite re-render loop causing 'Maximum update depth exceeded' (#3435)
- fix: workspace tab unread badge rendering and priority (#3434)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package to version `4.16.0-alpha.3`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->