### PR TITLE
chore: ignore local agent tooling state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,14 @@ Thumbs.db
 supportedVersions.jwt
 # local research (git-ignored)
 localdev/
+localdev.zip
+
+# local agent tooling state
+.localdev/
+.agents/
+.codex/
+.fuselage-craft/
+prompt-exports/
 
 # caches and temp
 /coverage


### PR DESCRIPTION
Adds gitignore entries for local agent tooling state directories (`.localdev/`, `.agents/`, `.codex/`, `.fuselage-craft/`, `prompt-exports/`) and `localdev.zip` — local working state that currently shows as untracked noise in every checkout. No repo content affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to exclude local development archives and tooling state from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->