### PR TITLE
feat(ui): unify Windows/Linux shell chrome and menu bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ a single server mode.
 | `"isFlashFrameEnabled": true`              | Sets if the flash frame will be enabled.                                                               |
 | `"isMinimizeOnCloseEnabled": false`        | Sets if the app will be minimized on close.                                                            |
 | `"doCheckForUpdatesOnStartup": true`       | Sets if the app will check for updates on startup.                                                     |
-| `"isMenuBarEnabled": false`                | Windows/Linux: keep the menu bar always visible. When false, Alt shows it temporarily. Unused on macOS. |
+| `"isMenuBarEnabled": false`                | Windows/Linux: `true` keeps the menu bar always visible; `false` auto-hides it (Alt shows it temporarily). Unused on macOS. |
 | `"isTrayIconEnabled": true`                | Enables Tray Icon, the app will be hidden to the tray on close. Overrides `"isMinimizeOnCloseEnabled"` |
 | `"isUpdatingEnabled": true`                | Sets if the app can be updated by the user.                                                            |
 | `"isAddNewServersEnabled": true`           | Sets if the user can add new servers.                                                                  |

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ a single server mode.
 | `"isFlashFrameEnabled": true`              | Sets if the flash frame will be enabled.                                                               |
 | `"isMinimizeOnCloseEnabled": false`        | Sets if the app will be minimized on close.                                                            |
 | `"doCheckForUpdatesOnStartup": true`       | Sets if the app will check for updates on startup.                                                     |
-| `"isMenuBarEnabled": true`                 | Sets if the menu bar will be enabled.                                                                  |
+| `"isMenuBarEnabled": false`                | Windows/Linux: keep the menu bar always visible. When false, Alt shows it temporarily. Unused on macOS. |
 | `"isTrayIconEnabled": true`                | Enables Tray Icon, the app will be hidden to the tray on close. Overrides `"isMinimizeOnCloseEnabled"` |
 | `"isUpdatingEnabled": true`                | Sets if the app can be updated by the user.                                                            |
 | `"isAddNewServersEnabled": true`           | Sets if the user can add new servers.                                                                  |

--- a/docs/silent-installation.md
+++ b/docs/silent-installation.md
@@ -524,7 +524,7 @@ Same locations as `servers.json` (see table above).
 | `isFlashFrameEnabled`              | boolean | `false` | Flash taskbar on new messages          |
 | `isMinimizeOnCloseEnabled`         | boolean | `false` | Minimize to taskbar instead of closing |
 | `doCheckForUpdatesOnStartup`       | boolean | `true`  | Check for updates on startup           |
-| `isMenuBarEnabled`                 | boolean | `false` (Windows/Linux; unused on macOS) | Keep the menu bar always visible. When `false`, press Alt to show it temporarily. |
+| `isMenuBarEnabled`                 | boolean | `false` (Windows/Linux; unused on macOS) | `true` keeps the menu bar always visible; `false` auto-hides it (press Alt to show temporarily). |
 | `isTrayIconEnabled`                | boolean | `true`  | Enable system tray icon                |
 | `isUpdatingEnabled`                | boolean | `true`  | Allow user to update the app           |
 | `isAddNewServersEnabled`           | boolean | `true`  | Allow adding new servers               |

--- a/docs/silent-installation.md
+++ b/docs/silent-installation.md
@@ -524,7 +524,7 @@ Same locations as `servers.json` (see table above).
 | `isFlashFrameEnabled`              | boolean | `false` | Flash taskbar on new messages          |
 | `isMinimizeOnCloseEnabled`         | boolean | `false` | Minimize to taskbar instead of closing |
 | `doCheckForUpdatesOnStartup`       | boolean | `true`  | Check for updates on startup           |
-| `isMenuBarEnabled`                 | boolean | `true`  | Show menu bar                          |
+| `isMenuBarEnabled`                 | boolean | `false` (Windows/Linux; unused on macOS) | Keep the menu bar always visible. When `false`, press Alt to show it temporarily. |
 | `isTrayIconEnabled`                | boolean | `true`  | Enable system tray icon                |
 | `isUpdatingEnabled`                | boolean | `true`  | Allow user to update the app           |
 | `isAddNewServersEnabled`           | boolean | `true`  | Allow adding new servers               |

--- a/src/app/PersistableValues.ts
+++ b/src/app/PersistableValues.ts
@@ -126,10 +126,22 @@ type PersistableValues_4_16_1 = PersistableValues_4_16_0 & {
   isDownloadsPercentageEnabled: boolean;
 };
 
+type PersistableValues_4_16_2 = PersistableValues_4_16_1 & {
+  /**
+   * Bumped when the Windows/Linux menu-bar default changes so existing
+   * installs pick up the new auto-hide default once without clobbering a
+   * later user choice. macOS ignores this field.
+   */
+  menuBarDefaultRevision?: number;
+};
+
 export type PersistableValues = Pick<
-  PersistableValues_4_16_1,
-  keyof PersistableValues_4_16_1
+  PersistableValues_4_16_2,
+  keyof PersistableValues_4_16_2
 >;
+
+/** Current menu-bar default policy for Windows/Linux (auto-hide, Alt reveals). */
+export const MENU_BAR_DEFAULT_REVISION = 1;
 
 export const migrations = {
   '>=3.1.0': (before: PersistableValues_0_0_0): PersistableValues_3_1_0 => {
@@ -250,4 +262,20 @@ export const migrations = {
     ...before,
     isDownloadsPercentageEnabled: false,
   }),
+  '>=4.16.2': (before: PersistableValues_4_16_1): PersistableValues_4_16_2 => {
+    // electron-store only runs this when projectVersion satisfies >=4.16.2.
+    // mergePersistableValues also applies the same revision for builds that
+    // ship the policy before that version bump (see MENU_BAR_DEFAULT_REVISION).
+    if (process.platform === 'darwin') {
+      return {
+        ...before,
+        menuBarDefaultRevision: MENU_BAR_DEFAULT_REVISION,
+      };
+    }
+    return {
+      ...before,
+      isMenuBarEnabled: false,
+      menuBarDefaultRevision: MENU_BAR_DEFAULT_REVISION,
+    };
+  },
 };

--- a/src/app/__tests__/PersistableValues.spec.ts
+++ b/src/app/__tests__/PersistableValues.spec.ts
@@ -337,4 +337,58 @@ describe('PersistableValues migrations', () => {
       expect.objectContaining({ navigationLayout: 'tabs' })
     );
   });
+
+  describe('4.16.2 menu bar default (auto-hide on Windows/Linux)', () => {
+    const originalPlatform = process.platform;
+
+    afterEach(() => {
+      Object.defineProperty(process, 'platform', {
+        value: originalPlatform,
+        configurable: true,
+      });
+    });
+
+    it('forces isMenuBarEnabled off on linux and stamps the revision', () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'linux',
+        configurable: true,
+      });
+      const before = {
+        isMenuBarEnabled: true,
+        isDownloadsPercentageEnabled: false,
+      } as unknown as Parameters<(typeof migrations)['>=4.16.2']>[0];
+
+      const after = migrations['>=4.16.2'](before);
+      expect(after.isMenuBarEnabled).toBe(false);
+      expect(after.menuBarDefaultRevision).toBe(1);
+    });
+
+    it('forces isMenuBarEnabled off on win32 (was always hidden while stored true)', () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'win32',
+        configurable: true,
+      });
+      const before = {
+        isMenuBarEnabled: true,
+        isDownloadsPercentageEnabled: false,
+      } as unknown as Parameters<(typeof migrations)['>=4.16.2']>[0];
+
+      expect(migrations['>=4.16.2'](before).isMenuBarEnabled).toBe(false);
+    });
+
+    it('preserves isMenuBarEnabled on darwin and still stamps the revision', () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'darwin',
+        configurable: true,
+      });
+      const before = {
+        isMenuBarEnabled: true,
+        isDownloadsPercentageEnabled: false,
+      } as unknown as Parameters<(typeof migrations)['>=4.16.2']>[0];
+
+      const after = migrations['>=4.16.2'](before);
+      expect(after.isMenuBarEnabled).toBe(true);
+      expect(after.menuBarDefaultRevision).toBe(1);
+    });
+  });
 });

--- a/src/app/main/data.spec.ts
+++ b/src/app/main/data.spec.ts
@@ -1,7 +1,12 @@
 import * as store from '../../store';
 import { APP_SETTINGS_LOADED } from '../actions';
+import { MENU_BAR_DEFAULT_REVISION } from '../PersistableValues';
 import { mergePersistableValues } from './data';
-import { getPersistedValues } from './persistence';
+import {
+  getPersistedMeta,
+  getPersistedValues,
+  setPersistedMeta,
+} from './persistence';
 
 jest.mock('electron', () => ({
   app: {
@@ -22,6 +27,9 @@ jest.mock('../../store');
 jest.mock('./persistence', () => ({
   getPersistedValues: jest.fn().mockReturnValue({}),
   persistValues: jest.fn(),
+  // Literal 1 matches MENU_BAR_DEFAULT_REVISION (jest.mock factories are hoisted).
+  getPersistedMeta: jest.fn().mockReturnValue(1),
+  setPersistedMeta: jest.fn(),
 }));
 
 jest.mock('fs', () => ({
@@ -50,6 +58,7 @@ beforeEach(() => {
   (store.dispatch as jest.Mock).mockImplementation(mockDispatch);
   (store.select as jest.Mock).mockImplementation(mockSelect);
   (getPersistedValues as jest.Mock).mockReturnValue({});
+  (getPersistedMeta as jest.Mock).mockReturnValue(MENU_BAR_DEFAULT_REVISION);
 });
 
 describe('mergePersistableValues', () => {
@@ -72,7 +81,7 @@ describe('mergePersistableValues', () => {
     mockSelect.mockReturnValue(mockInitialValues);
   });
 
-  describe('menubar recovery mechanism', () => {
+  describe('menu bar settings (no layout coupling)', () => {
     const originalPlatform = process.platform;
 
     afterEach(() => {
@@ -83,57 +92,9 @@ describe('mergePersistableValues', () => {
       });
     });
 
-    it('should enable menubar on Linux when in tabs layout with menubar disabled', async () => {
+    it('preserves isMenuBarEnabled=false on Linux with tabs layout (no recovery force-on)', async () => {
       Object.defineProperty(process, 'platform', {
         value: 'linux',
-        writable: true,
-        configurable: true,
-      });
-      const localStorage = {};
-
-      mockSelect.mockReturnValue({
-        ...mockInitialValues,
-        isMenuBarEnabled: false,
-        navigationLayout: 'tabs',
-      });
-
-      await mergePersistableValues(localStorage);
-
-      expect(mockDispatch).toHaveBeenCalledWith({
-        type: APP_SETTINGS_LOADED,
-        payload: expect.objectContaining({
-          isMenuBarEnabled: true,
-        }),
-      });
-    });
-
-    it('should not modify settings on Linux when in sidebar layout with menubar disabled', async () => {
-      Object.defineProperty(process, 'platform', {
-        value: 'linux',
-        writable: true,
-        configurable: true,
-      });
-      const localStorage = {};
-
-      mockSelect.mockReturnValue({
-        ...mockInitialValues,
-        isMenuBarEnabled: false,
-        navigationLayout: 'sidebar',
-      });
-
-      await mergePersistableValues(localStorage);
-
-      expect(mockDispatch).toHaveBeenCalledWith({
-        type: APP_SETTINGS_LOADED,
-        payload: expect.objectContaining({
-          isMenuBarEnabled: false,
-        }),
-      });
-    });
-
-    it('should not modify settings on non-Linux platforms when in tabs layout with menubar disabled', async () => {
-      Object.defineProperty(process, 'platform', {
-        value: 'darwin',
         writable: true,
         configurable: true,
       });
@@ -155,21 +116,71 @@ describe('mergePersistableValues', () => {
       });
     });
 
-    it('should not modify settings when menubar is already enabled', async () => {
+    it('preserves isMenuBarEnabled=false on Windows with tabs layout', async () => {
       Object.defineProperty(process, 'platform', {
-        value: 'linux',
+        value: 'win32',
         writable: true,
         configurable: true,
       });
       const localStorage = {};
 
+      mockSelect.mockReturnValue({
+        ...mockInitialValues,
+        isMenuBarEnabled: false,
+        navigationLayout: 'tabs',
+      });
+
+      await mergePersistableValues(localStorage);
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: APP_SETTINGS_LOADED,
+        payload: expect.objectContaining({
+          isMenuBarEnabled: false,
+        }),
+      });
+    });
+
+    it('one-shot: forces isMenuBarEnabled off on Linux when menuBarDefaultRevision is stale', async () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'linux',
+        writable: true,
+        configurable: true,
+      });
+      (getPersistedMeta as jest.Mock).mockReturnValue(0);
       mockSelect.mockReturnValue({
         ...mockInitialValues,
         isMenuBarEnabled: true,
-        navigationLayout: 'sidebar',
+        navigationLayout: 'tabs',
       });
 
-      await mergePersistableValues(localStorage);
+      await mergePersistableValues({});
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: APP_SETTINGS_LOADED,
+        payload: expect.objectContaining({
+          isMenuBarEnabled: false,
+        }),
+      });
+      expect(setPersistedMeta).toHaveBeenCalledWith(
+        'menuBarDefaultRevision',
+        MENU_BAR_DEFAULT_REVISION
+      );
+    });
+
+    it('one-shot: does not re-force isMenuBarEnabled after revision is applied', async () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'linux',
+        writable: true,
+        configurable: true,
+      });
+      (getPersistedMeta as jest.Mock).mockReturnValue(MENU_BAR_DEFAULT_REVISION);
+      mockSelect.mockReturnValue({
+        ...mockInitialValues,
+        isMenuBarEnabled: true,
+        navigationLayout: 'tabs',
+      });
+
+      await mergePersistableValues({});
 
       expect(mockDispatch).toHaveBeenCalledWith({
         type: APP_SETTINGS_LOADED,
@@ -177,6 +188,7 @@ describe('mergePersistableValues', () => {
           isMenuBarEnabled: true,
         }),
       });
+      expect(setPersistedMeta).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/main/data.spec.ts
+++ b/src/app/main/data.spec.ts
@@ -1,6 +1,6 @@
 import * as store from '../../store';
-import { APP_SETTINGS_LOADED } from '../actions';
 import { MENU_BAR_DEFAULT_REVISION } from '../PersistableValues';
+import { APP_SETTINGS_LOADED } from '../actions';
 import { mergePersistableValues } from './data';
 import {
   getPersistedMeta,
@@ -173,7 +173,9 @@ describe('mergePersistableValues', () => {
         writable: true,
         configurable: true,
       });
-      (getPersistedMeta as jest.Mock).mockReturnValue(MENU_BAR_DEFAULT_REVISION);
+      (getPersistedMeta as jest.Mock).mockReturnValue(
+        MENU_BAR_DEFAULT_REVISION
+      );
       mockSelect.mockReturnValue({
         ...mockInitialValues,
         isMenuBarEnabled: true,

--- a/src/app/main/data.ts
+++ b/src/app/main/data.ts
@@ -8,8 +8,14 @@ import { select, dispatch, watch } from '../../store';
 import { getSystemCertificateStatus } from '../../systemCertificates';
 import { normalizeNumber } from '../../ui/main/rootWindow';
 import { APP_SETTINGS_LOADED } from '../actions';
+import { MENU_BAR_DEFAULT_REVISION } from '../PersistableValues';
 import { selectPersistableValues } from '../selectors';
-import { getPersistedValues, persistValues } from './persistence';
+import {
+  getPersistedMeta,
+  getPersistedValues,
+  persistValues,
+  setPersistedMeta,
+} from './persistence';
 
 const loadUserDataOverriddenSettings = async (): Promise<
   Record<string, string>
@@ -164,15 +170,22 @@ export const mergePersistableValues = async (
     },
   };
 
-  if (
-    values.navigationLayout !== 'sidebar' &&
-    !values.isMenuBarEnabled &&
-    process.platform === 'linux'
-  ) {
-    values = {
-      ...values,
-      isMenuBarEnabled: true,
-    };
+  // One-shot policy: Windows used to force-hide the bar while storing
+  // isMenuBarEnabled=true; Linux defaulted to always-on. Both now auto-hide
+  // (Alt reveals) unless the user pins the bar. The revision is stored as
+  // config meta so later persistValues() snapshots cannot re-apply the force.
+  const appliedMenuBarRevision = getPersistedMeta(
+    'menuBarDefaultRevision',
+    0
+  );
+  if (appliedMenuBarRevision < MENU_BAR_DEFAULT_REVISION) {
+    if (process.platform !== 'darwin') {
+      values = {
+        ...values,
+        isMenuBarEnabled: false,
+      };
+    }
+    setPersistedMeta('menuBarDefaultRevision', MENU_BAR_DEFAULT_REVISION);
   }
 
   const mergedOverrides: Record<string, unknown> = {

--- a/src/app/main/data.ts
+++ b/src/app/main/data.ts
@@ -7,8 +7,8 @@ import { logger } from '../../logging';
 import { select, dispatch, watch } from '../../store';
 import { getSystemCertificateStatus } from '../../systemCertificates';
 import { normalizeNumber } from '../../ui/main/rootWindow';
-import { APP_SETTINGS_LOADED } from '../actions';
 import { MENU_BAR_DEFAULT_REVISION } from '../PersistableValues';
+import { APP_SETTINGS_LOADED } from '../actions';
 import { selectPersistableValues } from '../selectors';
 import {
   getPersistedMeta,
@@ -174,10 +174,7 @@ export const mergePersistableValues = async (
   // isMenuBarEnabled=true; Linux defaulted to always-on. Both now auto-hide
   // (Alt reveals) unless the user pins the bar. The revision is stored as
   // config meta so later persistValues() snapshots cannot re-apply the force.
-  const appliedMenuBarRevision = getPersistedMeta(
-    'menuBarDefaultRevision',
-    0
-  );
+  const appliedMenuBarRevision = getPersistedMeta('menuBarDefaultRevision', 0);
   if (appliedMenuBarRevision < MENU_BAR_DEFAULT_REVISION) {
     if (process.platform !== 'darwin') {
       values = {

--- a/src/app/main/persistence.ts
+++ b/src/app/main/persistence.ts
@@ -28,6 +28,21 @@ const getElectronStore = (): ElectronStore<PersistableValues> => {
 export const getPersistedValues = (): PersistableValues =>
   getElectronStore().store;
 
+/** Read a store key that is not necessarily mirrored in Redux. */
+export const getPersistedMeta = <T>(key: string, fallback: T): T => {
+  const value = getElectronStore().get(key as keyof PersistableValues);
+  return (value as T | undefined) ?? fallback;
+};
+
+/** Write a store key without replacing the rest of the config. */
+export const setPersistedMeta = (key: string, value: unknown): void => {
+  try {
+    getElectronStore().set(key as keyof PersistableValues, value as never);
+  } catch (error) {
+    error instanceof Error && console.error(error);
+  }
+};
+
 let lastSavedTime = 0;
 
 export const persistValues = (values: PersistableValues): void => {

--- a/src/i18n/en.i18n.json
+++ b/src/i18n/en.i18n.json
@@ -295,8 +295,7 @@
       },
       "menubar": {
         "title": "Menu bar",
-        "description": "Show menu bar on the top of the window.",
-        "disabledHint": "Cannot disable menu bar when the workspace bar is disabled. App settings would become inaccessible."
+        "description": "Keep the menu bar always visible at the top of the window. When off, press Alt to show it temporarily."
       },
       "sidebar": {
         "title": "Workspace bar",
@@ -308,8 +307,7 @@
         "description": "Choose how to switch between workspaces",
         "workspaceTabs": "Tabs",
         "workspaceBar": "Sidebar",
-        "workspaceHidden": "Titlebar",
-        "disabledHint": "Enable the menu bar first to use Workspace tabs."
+        "workspaceHidden": "Titlebar"
       },
       "trayIcon": {
         "title": "Tray icon",

--- a/src/ui/components/SettingsView/GeneralTab.tsx
+++ b/src/ui/components/SettingsView/GeneralTab.tsx
@@ -31,7 +31,7 @@ export const GeneralTab = () => {
           {isDarwin && <TransparentWindow />}
           <TrayIcon />
           {isWin32 && <MinimizeOnClose />}
-          {!isDarwin && !isWin32 && <MenuBar />}
+          {!isDarwin && <MenuBar />}
           <FlashFrame />
           <DownloadsPercentage />
         </FieldGroup>

--- a/src/ui/components/SettingsView/features/MenuBar.tsx
+++ b/src/ui/components/SettingsView/features/MenuBar.tsx
@@ -17,9 +17,6 @@ export const MenuBar = (props: MenuBarProps) => {
   const isMenuBarEnabled = useSelector(
     ({ isMenuBarEnabled }: RootState) => isMenuBarEnabled
   );
-  const navigationLayout = useSelector(
-    ({ navigationLayout }: RootState) => navigationLayout
-  );
   const dispatch = useDispatch<Dispatch<RootAction>>();
   const { t } = useTranslation();
   const handleChange = useCallback(
@@ -34,20 +31,14 @@ export const MenuBar = (props: MenuBarProps) => {
   );
 
   const isMenuBarEnabledId = useId();
-  const canToggle = !isMenuBarEnabled || navigationLayout === 'sidebar';
 
   return (
     <ToggleField
       id={isMenuBarEnabledId}
       label={t('settings.options.menubar.title')}
-      description={
-        navigationLayout !== 'sidebar' && isMenuBarEnabled
-          ? t('settings.options.menubar.disabledHint')
-          : t('settings.options.menubar.description')
-      }
+      description={t('settings.options.menubar.description')}
       checked={isMenuBarEnabled}
       onChange={handleChange}
-      disabled={!canToggle}
       className={props.className}
     />
   );

--- a/src/ui/components/SettingsView/features/NavigationLayout.spec.tsx
+++ b/src/ui/components/SettingsView/features/NavigationLayout.spec.tsx
@@ -11,7 +11,7 @@ jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-type PartialState = Pick<RootState, 'navigationLayout' | 'isMenuBarEnabled'>;
+type PartialState = Pick<RootState, 'navigationLayout'>;
 
 const makeStore = (partial: PartialState) => {
   const reducer = (state: PartialState = partial) => state;
@@ -22,7 +22,6 @@ describe('NavigationLayout', () => {
   it('checks workspace tabs option when navigationLayout=tabs', () => {
     const store = makeStore({
       navigationLayout: 'tabs',
-      isMenuBarEnabled: true,
     });
     render(
       <Provider store={store}>
@@ -37,7 +36,6 @@ describe('NavigationLayout', () => {
   it('checks workspace bar option when navigationLayout=sidebar', () => {
     const store = makeStore({
       navigationLayout: 'sidebar',
-      isMenuBarEnabled: true,
     });
     render(
       <Provider store={store}>
@@ -52,7 +50,6 @@ describe('NavigationLayout', () => {
   it('dispatches SETTINGS_SET_NAVIGATION_LAYOUT_CHANGED with "sidebar" when workspace bar is selected', () => {
     const store = makeStore({
       navigationLayout: 'tabs',
-      isMenuBarEnabled: true,
     });
     const dispatchSpy = jest.spyOn(store, 'dispatch');
 
@@ -73,7 +70,6 @@ describe('NavigationLayout', () => {
   it('dispatches SETTINGS_SET_NAVIGATION_LAYOUT_CHANGED with "tabs" when workspace tabs is selected', () => {
     const store = makeStore({
       navigationLayout: 'sidebar',
-      isMenuBarEnabled: true,
     });
     const dispatchSpy = jest.spyOn(store, 'dispatch');
 
@@ -91,50 +87,18 @@ describe('NavigationLayout', () => {
     });
   });
 
-  describe('on linux with the menu bar hidden', () => {
-    const originalPlatform = process.platform;
-
-    beforeAll(() => {
-      Object.defineProperty(process, 'platform', {
-        value: 'linux',
-        configurable: true,
-      });
+  it('keeps all workspace switcher options enabled regardless of menu bar state', () => {
+    const store = makeStore({
+      navigationLayout: 'sidebar',
     });
-
-    afterAll(() => {
-      Object.defineProperty(process, 'platform', {
-        value: originalPlatform,
-        configurable: true,
-      });
-    });
-
-    it('disables the workspace tabs option when navigationLayout=sidebar', () => {
-      const store = makeStore({
-        navigationLayout: 'sidebar',
-        isMenuBarEnabled: false,
-      });
-      render(
-        <Provider store={store}>
-          <NavigationLayout />
-        </Provider>
-      );
-      const [workspaceTabs, workspaceBar] = screen.getAllByRole('radio');
-      expect(workspaceTabs).toBeDisabled();
-      expect(workspaceBar).not.toBeDisabled();
-    });
-
-    it('keeps the workspace tabs option enabled when navigationLayout is already tabs', () => {
-      const store = makeStore({
-        navigationLayout: 'tabs',
-        isMenuBarEnabled: false,
-      });
-      render(
-        <Provider store={store}>
-          <NavigationLayout />
-        </Provider>
-      );
-      const [workspaceTabs] = screen.getAllByRole('radio');
-      expect(workspaceTabs).not.toBeDisabled();
-    });
+    render(
+      <Provider store={store}>
+        <NavigationLayout />
+      </Provider>
+    );
+    const radios = screen.getAllByRole('radio');
+    for (const radio of radios) {
+      expect(radio).not.toBeDisabled();
+    }
   });
 });

--- a/src/ui/components/SettingsView/features/NavigationLayout.tsx
+++ b/src/ui/components/SettingsView/features/NavigationLayout.tsx
@@ -25,9 +25,6 @@ export const NavigationLayout = (props: NavigationLayoutProps) => {
   const navigationLayout = useSelector(
     ({ navigationLayout }: RootState) => navigationLayout
   );
-  const isMenuBarEnabled = useSelector(
-    ({ isMenuBarEnabled }: RootState) => isMenuBarEnabled
-  );
   const dispatch = useDispatch<Dispatch<RootAction>>();
   const { t } = useTranslation();
 
@@ -49,27 +46,19 @@ export const NavigationLayout = (props: NavigationLayoutProps) => {
   const workspaceBarId = useId();
   const workspaceHiddenId = useId();
 
-  const isWorkspaceTabsDisabled =
-    process.platform === 'linux' &&
-    !isMenuBarEnabled &&
-    navigationLayout !== 'tabs';
-
   return (
     <Field className={props.className}>
       <FieldRow>
         <FieldLabel>{t('settings.options.navigation.title')}</FieldLabel>
       </FieldRow>
       <FieldDescription>
-        {isWorkspaceTabsDisabled
-          ? t('settings.options.navigation.disabledHint')
-          : t('settings.options.navigation.description')}
+        {t('settings.options.navigation.description')}
       </FieldDescription>
       <Box display='flex' flexDirection='column' mbs='x8'>
         <Box display='flex' alignItems='center' mbe='x8'>
           <RadioButton
             id={workspaceTabsId}
             checked={navigationLayout === 'tabs'}
-            disabled={isWorkspaceTabsDisabled}
             onChange={handleChange('tabs')}
           />
           <FieldLabel htmlFor={workspaceTabsId} mis='x8'>

--- a/src/ui/components/Shell/index.spec.tsx
+++ b/src/ui/components/Shell/index.spec.tsx
@@ -175,6 +175,15 @@ const buildState = (overrides: Record<string, unknown> = {}) =>
     userThemePreference: 'auto',
     isTransparentWindowEnabled: false,
     navigationLayout: 'sidebar',
+    rootWindowState: {
+      focused: true,
+      visible: true,
+      maximized: false,
+      minimized: false,
+      fullscreen: false,
+      normal: true,
+      bounds: { x: 0, y: 0, width: 1200, height: 800 },
+    },
     ...overrides,
   }) as any;
 
@@ -413,14 +422,27 @@ describe('Shell', () => {
     });
   });
 
-  describe('linux chrome', () => {
+  describe('linux chrome (Windows-parity client decorations)', () => {
     let restorePlatform: () => void;
 
     afterEach(() => {
       restorePlatform?.();
     });
 
-    it('mounts the TopBar with the downloads indicator, and no window controls, when navigationLayout is sidebar', () => {
+    it('mounts the meatball menu and window controls as TabBar slots when navigationLayout is tabs', () => {
+      restorePlatform = setPlatform('linux');
+
+      renderWithStore(<Shell />, {
+        preloadedState: buildState({ navigationLayout: 'tabs' }),
+      });
+
+      expect(screen.getByTestId('tab-bar')).toBeInTheDocument();
+      expect(screen.getByTestId('meatball-menu-button')).toBeInTheDocument();
+      expect(screen.getByTestId('window-controls')).toBeInTheDocument();
+      expect(screen.getByTestId('downloads-indicator')).toBeInTheDocument();
+    });
+
+    it('mounts the TopBar with window controls plus the vertical TabBar meatball when navigationLayout is sidebar', () => {
       restorePlatform = setPlatform('linux');
 
       renderWithStore(<Shell />, {
@@ -429,7 +451,7 @@ describe('Shell', () => {
 
       expect(screen.getByTestId('top-bar')).toBeInTheDocument();
       expect(screen.getByTestId('downloads-indicator')).toBeInTheDocument();
-      expect(screen.queryByTestId('window-controls')).not.toBeInTheDocument();
+      expect(screen.getByTestId('window-controls')).toBeInTheDocument();
       expect(screen.getByTestId('tab-bar')).toHaveAttribute(
         'data-orientation',
         'vertical'
@@ -437,7 +459,7 @@ describe('Shell', () => {
       expect(screen.getByTestId('meatball-menu-button')).toBeInTheDocument();
     });
 
-    it('mounts the TopBar with the downloads indicator and server switcher, and no window controls or TabBar, when navigationLayout is hidden', () => {
+    it('puts the meatball menu and window controls on the TopBar with no TabBar when navigationLayout is hidden', () => {
       restorePlatform = setPlatform('linux');
 
       renderWithStore(<Shell />, {
@@ -446,7 +468,8 @@ describe('Shell', () => {
 
       expect(screen.getByTestId('top-bar')).toBeInTheDocument();
       expect(screen.getByTestId('downloads-indicator')).toBeInTheDocument();
-      expect(screen.queryByTestId('window-controls')).not.toBeInTheDocument();
+      expect(screen.getByTestId('meatball-menu-button')).toBeInTheDocument();
+      expect(screen.getByTestId('window-controls')).toBeInTheDocument();
       expect(screen.queryByTestId('tab-bar')).not.toBeInTheDocument();
       expect(
         screen.getByRole('button', { name: 'tabBar.workspaces' })

--- a/src/ui/components/Shell/index.tsx
+++ b/src/ui/components/Shell/index.tsx
@@ -26,7 +26,13 @@ import { ServerSwitcher } from '../TopBar/ServerSwitcher';
 import { UpdateLabel } from '../TopBar/UpdateLabel';
 import { useShellTheme } from '../hooks/useShellTheme';
 import TooltipProvider from '../utils/TooltipProvider';
-import { GlobalStyles, WindowDragBar } from './styles';
+import {
+  CLIENT_CHROME_CORNER_RADIUS_PX,
+  GlobalStyles,
+  WindowDragBar,
+} from './styles';
+
+const usesLinuxClientChromeRounding = process.platform === 'linux';
 
 export const Shell = () => {
   const appPath = useSelector(({ appPath }: RootState) => appPath);
@@ -35,6 +41,10 @@ export const Shell = () => {
   );
   const navigationLayout = useSelector(
     ({ navigationLayout }: RootState) => navigationLayout
+  );
+  const isWindowExpanded = useSelector(
+    ({ rootWindowState }: RootState) =>
+      rootWindowState.maximized || rootWindowState.fullscreen
   );
 
   const shellTheme = useShellTheme();
@@ -69,22 +79,40 @@ export const Shell = () => {
         bg={isTransparentWindowEnabled ? 'transparent' : 'surface-neutral'}
         display='flex'
         flexWrap='wrap'
-        height='100vh'
+        height='100%'
         flexDirection='column'
+        style={
+          usesLinuxClientChromeRounding
+            ? {
+                // Soft outer corners on Linux only; drop when maximized.
+                borderRadius: isWindowExpanded
+                  ? 0
+                  : CLIENT_CHROME_CORNER_RADIUS_PX,
+                overflow: 'hidden',
+                // Hairline edge so the rounded silhouette reads on light wallpapers.
+                boxShadow: isWindowExpanded
+                  ? undefined
+                  : '0 0 0 1px rgba(0, 0, 0, 0.14)',
+              }
+            : undefined
+        }
       >
-        {navigationLayout === 'tabs' && process.platform === 'win32' && (
-          <TabBar
-            leadingSlot={
-              <>
-                <MeatballMenuButton />
-                <UpdateLabel />
-                <DownloadsIndicator />
-              </>
-            }
-            trailingSlot={<WindowControls />}
-          />
-        )}
-        {navigationLayout === 'tabs' && process.platform !== 'win32' && (
+        {/* Windows + Linux: client-side window chrome (min/max/close in-strip). */}
+        {navigationLayout === 'tabs' &&
+          (process.platform === 'win32' || process.platform === 'linux') && (
+            <TabBar
+              leadingSlot={
+                <>
+                  <MeatballMenuButton />
+                  <UpdateLabel />
+                  <DownloadsIndicator />
+                </>
+              }
+              trailingSlot={<WindowControls />}
+            />
+          )}
+        {/* macOS tabs: system traffic lights; meatball/downloads/update trail. */}
+        {navigationLayout === 'tabs' && process.platform === 'darwin' && (
           <TabBar
             trailingSlot={
               <>
@@ -95,36 +123,36 @@ export const Shell = () => {
             }
           />
         )}
-        {navigationLayout !== 'tabs' &&
-          ['darwin', 'linux'].includes(process.platform) && (
-            <TopBar
-              centerSlot={
-                navigationLayout === 'hidden' ? <ServerSwitcher /> : undefined
-              }
-              trailingSlot={
-                <>
-                  <UpdateLabel />
-                  <DownloadsIndicator compact />
-                </>
-              }
-            />
-          )}
-        {navigationLayout !== 'tabs' && process.platform === 'win32' && (
+        {navigationLayout !== 'tabs' && process.platform === 'darwin' && (
           <TopBar
-            leadingSlot={
+            centerSlot={
+              navigationLayout === 'hidden' ? <ServerSwitcher /> : undefined
+            }
+            trailingSlot={
               <>
-                {navigationLayout === 'hidden' && <MeatballMenuButton tiny />}
                 <UpdateLabel />
                 <DownloadsIndicator compact />
               </>
             }
-            centerSlot={
-              navigationLayout === 'hidden' ? <ServerSwitcher /> : undefined
-            }
-            trailingSlot={<WindowControls />}
-            textAlignment='left'
           />
         )}
+        {navigationLayout !== 'tabs' &&
+          (process.platform === 'win32' || process.platform === 'linux') && (
+            <TopBar
+              leadingSlot={
+                <>
+                  {navigationLayout === 'hidden' && <MeatballMenuButton tiny />}
+                  <UpdateLabel />
+                  <DownloadsIndicator compact />
+                </>
+              }
+              centerSlot={
+                navigationLayout === 'hidden' ? <ServerSwitcher /> : undefined
+              }
+              trailingSlot={<WindowControls />}
+              textAlignment='left'
+            />
+          )}
         <Box display='flex' flexDirection='row' flexGrow={1}>
           {navigationLayout === 'sidebar' && (
             <TabBar

--- a/src/ui/components/Shell/index.tsx
+++ b/src/ui/components/Shell/index.tsx
@@ -78,8 +78,10 @@ export const Shell = () => {
       <Box
         bg={isTransparentWindowEnabled ? 'transparent' : 'surface-neutral'}
         display='flex'
-        flexWrap='wrap'
+        flexWrap='nowrap'
         height='100%'
+        width='100%'
+        maxWidth='100%'
         flexDirection='column'
         style={
           usesLinuxClientChromeRounding
@@ -89,10 +91,12 @@ export const Shell = () => {
                   ? 0
                   : CLIENT_CHROME_CORNER_RADIUS_PX,
                 overflow: 'hidden',
-                // Hairline edge so the rounded silhouette reads on light wallpapers.
+                boxSizing: 'border-box',
+                // Inset hairline stays inside the box (outer box-shadow was
+                // adding ~1px and caused a horizontal scrollbar on Linux).
                 boxShadow: isWindowExpanded
                   ? undefined
-                  : '0 0 0 1px rgba(0, 0, 0, 0.14)',
+                  : 'inset 0 0 0 1px rgba(0, 0, 0, 0.14)',
               }
             : undefined
         }

--- a/src/ui/components/Shell/index.tsx
+++ b/src/ui/components/Shell/index.tsx
@@ -96,7 +96,7 @@ export const Shell = () => {
                 // adding ~1px and caused a horizontal scrollbar on Linux).
                 boxShadow: isWindowExpanded
                   ? undefined
-                  : 'inset 0 0 0 1px rgba(0, 0, 0, 0.14)',
+                  : 'inset 0 0 0 1px var(--rcx-color-shadow-elevation-border)',
               }
             : undefined
         }

--- a/src/ui/components/Shell/styles.tsx
+++ b/src/ui/components/Shell/styles.tsx
@@ -1,17 +1,20 @@
 import { Global, css } from '@emotion/react';
 import styled from '@emotion/styled';
 
-import { isDarwin } from '../../utils/platform';
+import { isDarwin, isLinux } from '../../utils/platform';
 
 type GlobalStylesProps = {
   isTransparentWindowEnabled: boolean;
 };
 
+/** Linux paints the outer window shape in CSS (DWM already rounds Windows). */
+const usesLinuxClientChromeRounding = isLinux;
+
 export const GlobalStyles = ({
   isTransparentWindowEnabled,
 }: GlobalStylesProps) => {
   const backgroundColor =
-    isDarwin && isTransparentWindowEnabled
+    (isDarwin && isTransparentWindowEnabled) || usesLinuxClientChromeRounding
       ? 'transparent'
       : 'var(--rcx-color-surface-sidebar, #2f343d)';
 
@@ -28,6 +31,12 @@ export const GlobalStyles = ({
           outline: 0 !important;
           outline-style: none;
           outline-color: transparent;
+        }
+
+        html,
+        body,
+        #root {
+          height: 100%;
         }
 
         body {
@@ -48,11 +57,15 @@ export const GlobalStyles = ({
           font-size: 0.875rem;
           line-height: 1rem;
           background-color: ${backgroundColor};
+          overflow: hidden;
         }
       `}
     />
   );
 };
+
+/** Outer shell radius for client-decorated windows (not maximized). */
+export const CLIENT_CHROME_CORNER_RADIUS_PX = 10;
 
 export const WindowDragBar = styled.div`
   position: fixed;

--- a/src/ui/components/Shell/styles.tsx
+++ b/src/ui/components/Shell/styles.tsx
@@ -36,12 +36,14 @@ export const GlobalStyles = ({
         html,
         body,
         #root {
+          width: 100%;
           height: 100%;
+          margin: 0;
+          overflow: hidden;
         }
 
         body {
           -webkit-font-smoothing: antialiased;
-          margin: 0;
           padding: 0;
           font-family:
             Inter,
@@ -57,7 +59,6 @@ export const GlobalStyles = ({
           font-size: 0.875rem;
           line-height: 1rem;
           background-color: ${backgroundColor};
-          overflow: hidden;
         }
       `}
     />

--- a/src/ui/components/TabBar/MeatballMenuButton.spec.tsx
+++ b/src/ui/components/TabBar/MeatballMenuButton.spec.tsx
@@ -55,38 +55,85 @@ describe('MeatballMenuButton', () => {
     expect(button).toHaveAttribute('aria-haspopup', 'menu');
   });
 
-  it('opens the menu on a solo Alt key press', () => {
-    renderWithStore(<MeatballMenuButton />);
+  describe('solo Alt key (macOS only — Windows/Linux use Alt for the native menu bar)', () => {
+    const originalPlatform = process.platform;
 
-    const button = screen.getByRole('button', { name: 'tabBar.meatballMenu' });
-    jest.spyOn(button, 'getBoundingClientRect').mockReturnValue({
-      left: 0,
-      bottom: 32,
-      top: 0,
-      right: 0,
-      width: 0,
-      height: 0,
-      x: 0,
-      y: 0,
-      toJSON: () => {},
+    afterEach(() => {
+      Object.defineProperty(process, 'platform', {
+        value: originalPlatform,
+        configurable: true,
+      });
     });
 
-    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Alt' }));
-    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Alt' }));
+    it('opens the menu on a solo Alt key press on darwin', () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'darwin',
+        configurable: true,
+      });
+      renderWithStore(<MeatballMenuButton />);
 
-    expect(mockDispatch).toHaveBeenCalledWith({
-      type: APP_MENU_TRIGGERED,
-      payload: { x: 0, y: 32 },
+      const button = screen.getByRole('button', {
+        name: 'tabBar.meatballMenu',
+      });
+      jest.spyOn(button, 'getBoundingClientRect').mockReturnValue({
+        left: 0,
+        bottom: 32,
+        top: 0,
+        right: 0,
+        width: 0,
+        height: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      });
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Alt' }));
+      window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Alt' }));
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: APP_MENU_TRIGGERED,
+        payload: { x: 0, y: 32 },
+      });
     });
-  });
 
-  it('does not open the menu when Alt is used as a modifier for another key', () => {
-    renderWithStore(<MeatballMenuButton />);
+    it('does not open the menu when Alt is used as a modifier for another key on darwin', () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'darwin',
+        configurable: true,
+      });
+      renderWithStore(<MeatballMenuButton />);
 
-    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Alt' }));
-    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
-    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Alt' }));
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Alt' }));
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+      window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Alt' }));
 
-    expect(mockDispatch).not.toHaveBeenCalled();
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
+
+    it('does not open the menu on a solo Alt key press on linux (native bar owns Alt)', () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'linux',
+        configurable: true,
+      });
+      renderWithStore(<MeatballMenuButton />);
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Alt' }));
+      window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Alt' }));
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
+
+    it('does not open the menu on a solo Alt key press on win32 (native bar owns Alt)', () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'win32',
+        configurable: true,
+      });
+      renderWithStore(<MeatballMenuButton />);
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Alt' }));
+      window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Alt' }));
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/ui/components/TabBar/MeatballMenuButton.tsx
+++ b/src/ui/components/TabBar/MeatballMenuButton.tsx
@@ -33,6 +33,13 @@ export const MeatballMenuButton = ({
   };
 
   useEffect(() => {
+    // On Windows/Linux a solo Alt reveals the native (auto-hidden) menu bar.
+    // Only macOS uses Alt as a meatball accelerator — there is no in-window
+    // native menu bar to toggle.
+    if (process.platform !== 'darwin') {
+      return;
+    }
+
     let isSoloAltPress = false;
 
     const handleKeyDown = (event: KeyboardEvent): void => {

--- a/src/ui/main/menuBar.ts
+++ b/src/ui/main/menuBar.ts
@@ -440,15 +440,13 @@ export const createViewMenu = createSelector(
           },
         },
       ]),
-      ...on(process.platform === 'linux', () => [
+      ...on(process.platform !== 'darwin', () => [
         {
           id: 'showMenuBar',
           label: t('menus.showMenuBar'),
           type: 'checkbox',
           checked: isMenuBarEnabled,
-          enabled: !isMenuBarEnabled || navigationLayout === 'sidebar',
-          accelerator:
-            process.platform === 'darwin' ? 'Shift+Command+M' : 'Ctrl+Shift+M',
+          accelerator: 'Ctrl+Shift+M',
           click: async ({ checked }) => {
             const browserWindow = await getRootWindow();
 
@@ -475,10 +473,6 @@ export const createViewMenu = createSelector(
         type: 'radio',
         checked: navigationLayout === 'tabs',
         accelerator: nextNavigationLayoutAccelerator(navigationLayout, 'tabs'),
-        enabled:
-          process.platform !== 'linux' ||
-          isMenuBarEnabled ||
-          navigationLayout === 'tabs',
         click: async () => {
           const browserWindow = await getRootWindow();
 
@@ -501,10 +495,6 @@ export const createViewMenu = createSelector(
           navigationLayout,
           'sidebar'
         ),
-        enabled:
-          process.platform !== 'linux' ||
-          isMenuBarEnabled ||
-          navigationLayout === 'sidebar',
         click: async () => {
           const browserWindow = await getRootWindow();
 
@@ -527,10 +517,6 @@ export const createViewMenu = createSelector(
           navigationLayout,
           'hidden'
         ),
-        enabled:
-          process.platform !== 'linux' ||
-          isMenuBarEnabled ||
-          navigationLayout === 'hidden',
         click: async () => {
           const browserWindow = await getRootWindow();
 
@@ -1280,18 +1266,20 @@ class MenuBarService extends Service {
         return;
       }
 
+      // Windows and Linux share the same model: keep the menu attached for
+      // accelerators, show it permanently when isMenuBarEnabled, otherwise
+      // auto-hide so a solo Alt press reveals it (classic desktop chrome).
+      // isMenuBarEnabled is already a view-menu dependency, so this watcher
+      // re-runs when the toggle flips and re-applies visibility here.
       const browserWindow = await getRootWindow();
-
-      if (process.platform === 'win32') {
-        Menu.setApplicationMenu(null);
-        browserWindow.setMenu(menu);
-        browserWindow.setMenuBarVisibility(false);
-        browserWindow.autoHideMenuBar = false;
-        return;
-      }
+      const isMenuBarEnabled = select(
+        ({ isMenuBarEnabled }) => isMenuBarEnabled
+      );
 
       Menu.setApplicationMenu(null);
       browserWindow.setMenu(menu);
+      browserWindow.autoHideMenuBar = !isMenuBarEnabled;
+      browserWindow.setMenuBarVisibility(isMenuBarEnabled);
     });
 
     this.listen(APP_MENU_TRIGGERED, async (action) => {

--- a/src/ui/main/rootWindow.ts
+++ b/src/ui/main/rootWindow.ts
@@ -77,12 +77,19 @@ export const getRootWindow = (): Promise<BrowserWindow> =>
     }, 300);
   });
 
+// Windows and Linux use client-side chrome (WindowControls in the shell).
+// macOS keeps a hidden title bar so traffic lights can sit in the tab strip.
 const platformTitleBarStyle =
-  process.platform === 'darwin' || process.platform === 'win32'
+  process.platform === 'darwin' ||
+  process.platform === 'win32' ||
+  process.platform === 'linux'
     ? 'hidden'
     : 'default';
 
 const isMac = process.platform === 'darwin';
+// Linux client chrome is a plain rectangle under most WMs. Transparent + CSS
+// radius paints soft outer corners. Windows already gets DWM rounding — leave it.
+const usesLinuxClientChromeRounding = process.platform === 'linux';
 
 export const createRootWindow = (): void => {
   _rootWindow = new BrowserWindow({
@@ -99,6 +106,13 @@ export const createRootWindow = (): void => {
           transparent: true,
           vibrancy: 'sidebar',
           visualEffectState: 'active',
+        }
+      : {}),
+    ...(usesLinuxClientChromeRounding
+      ? {
+          transparent: true,
+          backgroundColor: '#00000000',
+          hasShadow: true,
         }
       : {}),
   });
@@ -554,20 +568,7 @@ export const setupRootWindow = (): void => {
             browserWindow.setOverlayIcon(overlayIcon, overlayDescription);
           }
         }, 'Window icon update');
-      }),
-      ...(process.platform === 'linux'
-        ? [
-            watch(
-              ({ isMenuBarEnabled }) => isMenuBarEnabled,
-              async (isMenuBarEnabled) => {
-                await safeWindowOperation((browserWindow) => {
-                  browserWindow.autoHideMenuBar = !isMenuBarEnabled;
-                  browserWindow.setMenuBarVisibility(isMenuBarEnabled);
-                }, 'Menu bar visibility update');
-              }
-            ),
-          ]
-        : [])
+      })
     );
   }
 

--- a/src/ui/reducers/isMenuBarEnabled.spec.ts
+++ b/src/ui/reducers/isMenuBarEnabled.spec.ts
@@ -7,9 +7,10 @@ import {
 import { isMenuBarEnabled } from './isMenuBarEnabled';
 
 describe('isMenuBarEnabled reducer', () => {
-  it('should return initial state as true', () => {
+  it('defaults to on on macOS and off on Windows/Linux', () => {
+    const expected = process.platform === 'darwin';
     expect(isMenuBarEnabled(undefined, { type: 'UNKNOWN_ACTION' } as any)).toBe(
-      true
+      expected
     );
   });
 

--- a/src/ui/reducers/isMenuBarEnabled.ts
+++ b/src/ui/reducers/isMenuBarEnabled.ts
@@ -12,8 +12,13 @@ type IsMenuBarEnabledAction =
   | ActionOf<typeof SETTINGS_SET_IS_MENU_BAR_ENABLED_CHANGED>
   | ActionOf<typeof APP_SETTINGS_LOADED>;
 
+// macOS always uses the system menu bar (this flag is unused for visibility
+// there). Windows and Linux default to auto-hide: Alt reveals the bar; the
+// Settings / View → Menu bar toggle pins it permanently.
+const defaultIsMenuBarEnabled = process.platform === 'darwin';
+
 export const isMenuBarEnabled: Reducer<boolean, IsMenuBarEnabledAction> = (
-  state = true,
+  state = defaultIsMenuBarEnabled,
   action
 ) => {
   switch (action.type) {


### PR DESCRIPTION
## Summary

- **Menu bar (Windows + Linux):** hidden by default; press **Alt** to show temporarily; Settings → General → Menu bar (or View → Menu bar / `Ctrl+Shift+M`) pins it always visible. One-shot config revision migrates existing installs that stored `true` while the bar was forced hidden on Windows / always-on on Linux.
- **Linux client decorations:** same shell chrome as Windows — no DE title bar; min/max/close embedded in the tab strip / TopBar; meatball + update/downloads layout aligned with win32.
- **Linux outer corners:** soft 10px radius via transparent frame + CSS (skipped when maximized). Windows keeps DWM rounding.
- Removed obsolete “menu bar only toggles in sidebar / can’t use tabs without menu bar” coupling now that the meatball menu is always available.

## Test plan

- [ ] **Linux (Ubuntu/Manjaro/openSUSE):** no native DE title bar; window controls work (min/max/close); drag the strip to move the window
- [ ] **Linux:** outer corners slightly rounded; square when maximized
- [ ] **Linux/Windows:** menu bar off by default; **Alt** reveals it; Settings toggle pins it; choice survives restart
- [ ] **macOS:** unchanged (system menu bar + traffic lights)
- [ ] All navigation layouts (tabs / sidebar / hidden) still show meatball + downloads/update where expected
- [ ] Unit: `Shell/index.spec.tsx`, menu bar data/PersistableValues/reducer specs

Verified on lab VMs: Ubuntu 22.04 (GNOME X11), Manjaro (KDE Wayland/XWayland), openSUSE (KDE X11).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Menu bar visibility now defaults to enabled on macOS and disabled on Windows/Linux.
  - Windows and Linux users can temporarily show the menu bar with **Alt**.
  - Menu bar settings are available across supported desktop platforms.
  - Linux now includes Windows-style client-side window controls and rounded window chrome.

- **Improvements**
  - Workspace layout options remain available regardless of menu bar visibility.
  - Updated menu bar and navigation descriptions clarify platform behavior.
  - Windows/Linux window controls and menus now provide more consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->