### PR TITLE
chore: bump version to 4.16.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,15 @@ yarn workspaces:build        # Build all workspaces
   2. Sign built packages using `jsign` with Google Cloud KMS.
 
   This prevents MSI build failures from KMS CNG provider conflicts.
+- `electron-builder.json`'s `mac.bundleVersion` (macOS `CFBundleVersion`) is
+  independent from `package.json`'s `version` and must be bumped on every
+  release that ships to the App Store / gets notarized — Apple requires each
+  submission's `CFBundleVersion` to strictly increase over the last one.
+  Format: `YYMM` + a single-digit build counter that resets to `0` at the
+  start of each month, e.g. the first build shipped in August 2026 is
+  `26080`, the second same-month build is `26081`. Check the current value
+  and the date of its last bump (`git log -p --follow -- electron-builder.json`)
+  before incrementing — do not guess an arbitrary increment.
 
 ## UI Work
 

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -18,7 +18,7 @@
     "category": "public.app-category.productivity",
     "target": ["dmg", "pkg", "zip", "mas"],
     "icon": "build/icon.icns",
-    "bundleVersion": "26060",
+    "bundleVersion": "26080",
     "helperBundleId": "chat.rocket.electron.helper",
     "type": "distribution",
     "artifactName": "rocketchat-${version}-${os}.${ext}",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "Rocket.Chat",
   "name": "rocketchat",
   "description": "Official OSX, Windows, and Linux Desktop Clients for Rocket.Chat",
-  "version": "4.16.0-alpha.4",
+  "version": "4.16.0",
   "author": "Rocket.Chat Support <support@rocket.chat>",
   "copyright": "© 2016-2026, Rocket.Chat",
   "homepage": "https://rocket.chat",


### PR DESCRIPTION
## Summary

Promotes `4.16.0-alpha.4` to stable `4.16.0`.

- Bump `package.json` version to `4.16.0`
- Bump `electron-builder.json` `mac.bundleVersion` to `26080` (first macOS build shipped in August 2026)
- Document the `bundleVersion` bump convention (`YYMM` + monthly build counter) in `AGENTS.md`

## What ships in 4.16.0

### 🐛 Fixes
- Render the TopBar correctly on Linux in sidebar and hidden navigation layouts (#3449)

### ✨ Improvements
- Unify Windows and Linux shell chrome and menu bar: the menu bar is hidden by default on Windows/Linux (press Alt to reveal it temporarily; Settings or `Ctrl+Shift+M` pins it visible), and Linux now gets the same client-side window chrome as Windows — embedded window controls, no native title bar, softly rounded corners (#3450)
- Rework the tab bar downloads indicator with a Chrome-style presentation (#3441, #3443)

### 🔧 Internal
- Update translations from Lingohub (#3447)
- Add desktop UI guidelines and a dev-app verification skill for contributors (#3445)
- Ignore local agent tooling state in git (#3448)

## Test plan
- [ ] `validate-pr` checks green on all 3 platforms
- [ ] Tag `4.16.0` after merge, confirm full asset matrix on the release build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the application version to 4.16.0.
  - Increased the macOS release build identifier for App Store and notarized releases.
- **Documentation**
  - Added guidance for maintaining macOS release build identifiers and tracking their required format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->