### PR TITLE
chore(deps): patch the vulnerable dependencies we control

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,9 +65,9 @@
     "@rocket.chat/fuselage-polyfills": "~0.31.25",
     "@rocket.chat/icons": "0.37.0",
     "archiver": "~7.0.1",
-    "axios": "~1.13.6",
+    "axios": "~1.18.0",
     "detect-browsers": "~6.1.0",
-    "dompurify": "~3.3.3",
+    "dompurify": "~3.4.13",
     "electron-dl": "4.0.0",
     "electron-log": "~5.4.3",
     "electron-store": "~8.1.0",
@@ -148,13 +148,13 @@
     "patch-package": "~8.0.0",
     "prettier": "~3.2.5",
     "puppeteer": "23.1.1",
-    "rollup": "~4.32.0",
+    "rollup": "~4.62.4",
     "rollup-plugin-copy": "~3.5.0",
     "ts-jest": "~29.1.4",
     "ts-node": "~10.9.2",
     "typescript": "~5.7.3",
     "xvfb-maybe": "~0.2.1",
-    "yaml": "^1.10.2"
+    "yaml": "^1.10.3"
   },
   "optionalDependencies": {
     "fsevents": "2.3.3"
@@ -174,11 +174,11 @@
     "@ewsjs/xhr@npm:^2.0.2": "patch:@ewsjs/xhr@npm%3A2.0.2#~/.yarn/patches/@ewsjs-xhr-npm-2.0.2-77506b0a6c.patch",
     "cross-spawn": "7.0.6",
     "braces": "3.0.3",
-    "ws": "8.18.0",
-    "axios": "1.13.6",
-    "follow-redirects": "1.15.9",
-    "form-data": "4.0.5",
-    "tar-fs": "3.0.8",
+    "ws": "8.21.3",
+    "axios": "1.18.0",
+    "follow-redirects": "1.16.0",
+    "form-data": "4.0.6",
+    "tar-fs": "3.1.3",
     "undici": "5.28.5"
   },
   "volta": {

--- a/src/outlookCalendar/__tests__/ipc.main.spec.ts
+++ b/src/outlookCalendar/__tests__/ipc.main.spec.ts
@@ -1,0 +1,461 @@
+/**
+ * Coverage for the axios contract in `src/outlookCalendar/ipc.ts`, added
+ * alongside the axios `~1.13.6` -> `~1.18.0` bump. The five axios call sites
+ * (`listEventsFromRocketChatServer` GET, `createEventOnRocketChatServer`,
+ * `updateEventOnRocketChatServer` and `deleteEventOnRocketChatServer` POSTs)
+ * are all module-internal and only reachable through the exported
+ * `syncEventsWithRocketChatServer` / IPC handlers, so tests drive the real
+ * exported surface and assert on the mocked `axios` calls it makes.
+ *
+ * Location note: this file lives in the module's existing
+ * `src/outlookCalendar/__tests__/` convention (see `getOutlookEvents.spec.ts`,
+ * `errorClassification.spec.ts`, `logger.spec.ts`), and is named
+ * `ipc.main.spec.ts` because `ipc.ts` is main-process code (uses `handle` /
+ * electron's `ipcMain`). Verified discovered by exactly the main-process
+ * ('node' testEnvironment) project via `yarn test --listTests`.
+ *
+ * `../logger` is mocked (mirrors `getOutlookEvents.spec.ts`) so no
+ * console.warn/error output leaks into the test run.
+ */
+jest.mock('../logger', () => ({
+  outlookLog: jest.fn(),
+  outlookError: jest.fn(),
+  outlookWarn: jest.fn(),
+  outlookEventDetail: jest.fn(),
+}));
+
+jest.mock('../getOutlookEvents', () => ({
+  getOutlookEvents: jest.fn(),
+}));
+
+jest.mock('axios');
+
+const selectMock = jest.fn();
+const dispatchMock = jest.fn();
+const watchMock = jest.fn();
+const requestMock = jest.fn();
+jest.mock('../../store', () => ({
+  select: (...args: any[]) => selectMock(...args),
+  dispatch: (...args: any[]) => dispatchMock(...args),
+  watch: (...args: any[]) => watchMock(...args),
+  request: (...args: any[]) => requestMock(...args),
+}));
+
+const handleRegistry = new Map<string, (...args: any[]) => any>();
+jest.mock('../../ipc/main', () => ({
+  handle: jest.fn((channel: string, cb: (...args: any[]) => any) => {
+    handleRegistry.set(channel, cb);
+    return () => handleRegistry.delete(channel);
+  }),
+}));
+
+const isEncryptionAvailableMock = jest.fn(() => false);
+jest.mock('electron', () => ({
+  safeStorage: {
+    isEncryptionAvailable: () => isEncryptionAvailableMock(),
+    encryptString: jest.fn((s: string) => Buffer.from(s)),
+    decryptString: jest.fn((b: Buffer) => b.toString()),
+  },
+  webContents: {
+    fromId: jest.fn(() => undefined),
+  },
+}));
+
+// eslint-disable-next-line import/first
+import axios from 'axios';
+
+// eslint-disable-next-line import/first
+import { getOutlookEvents } from '../getOutlookEvents';
+// eslint-disable-next-line import/first
+import type * as OutlookIpcModule from '../ipc';
+// eslint-disable-next-line import/first
+import type {
+  AppointmentData,
+  OutlookCredentials,
+  RocketChatCalendarEvent,
+  RocketChatEventsResponse,
+} from '../type';
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+const mockedGetOutlookEvents = getOutlookEvents as jest.Mock;
+
+const credentials: OutlookCredentials = {
+  userId: 'user-1',
+  serverUrl: 'https://mail.example.com',
+  login: 'user@example.com',
+  password: 'secret',
+};
+
+const serverUrl = 'https://rc.example.com/';
+const token = 'rc-token';
+
+const makeAppointment = (
+  overrides: Partial<AppointmentData> = {}
+): AppointmentData => ({
+  id: 'appt-1',
+  subject: 'Standup',
+  startTime: '2024-01-15T09:00:00.000Z',
+  endTime: '2024-01-15T09:30:00.000Z',
+  description: 'Daily sync',
+  isAllDay: false,
+  isCanceled: false,
+  busy: true,
+  ...overrides,
+});
+
+const makeRcEvent = (
+  overrides: Partial<RocketChatCalendarEvent> = {}
+): RocketChatCalendarEvent => ({
+  _id: 'rc-1',
+  externalId: 'appt-1',
+  subject: 'Standup',
+  startTime: '2024-01-15T09:00:00.000Z',
+  ...overrides,
+});
+
+const emptyRcResponse: RocketChatEventsResponse = { success: true, data: [] };
+
+/** Builds a rejection value that satisfies `axios.isAxiosError` narrowing. */
+const makeAxiosError = (overrides: Record<string, any> = {}) => ({
+  isAxiosError: true,
+  message: 'Request failed with status code 500',
+  name: 'AxiosError',
+  response: {
+    status: 500,
+    statusText: 'Internal Server Error',
+    data: { error: 'boom' },
+  },
+  ...overrides,
+});
+
+describe('outlookCalendar/ipc — axios contract', () => {
+  let syncEventsWithRocketChatServer: typeof OutlookIpcModule.syncEventsWithRocketChatServer;
+  let stopOutlookCalendarSync: typeof OutlookIpcModule.stopOutlookCalendarSync;
+
+  beforeAll(async () => {
+    ({ syncEventsWithRocketChatServer, stopOutlookCalendarSync } = await import(
+      '../ipc'
+    ));
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    handleRegistry.clear();
+    // Clear any recurring-sync timers/state left over by a previous test so
+    // sync state does not leak across `it`s (module is imported once).
+    stopOutlookCalendarSync();
+
+    isEncryptionAvailableMock.mockReturnValue(false);
+    selectMock.mockReturnValue({ servers: [] });
+    mockedAxios.isAxiosError.mockImplementation(
+      (error: unknown): error is any =>
+        !!error &&
+        typeof error === 'object' &&
+        (error as any).isAxiosError === true
+    );
+    mockedGetOutlookEvents.mockResolvedValue([]);
+  });
+
+  describe('listEventsFromRocketChatServer (axios.get, L174)', () => {
+    it('sends the auth headers and timeout, and feeds the response into the sync', async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        status: 200,
+        data: emptyRcResponse,
+      });
+
+      await syncEventsWithRocketChatServer(serverUrl, credentials, token);
+
+      expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+      const [url, config] = mockedAxios.get.mock.calls[0];
+      expect(url).toBe(`${serverUrl}api/v1/calendar-events.list`);
+      expect(config).toMatchObject({
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Auth-Token': token,
+          'X-User-Id': credentials.userId,
+        },
+        timeout: 10_000,
+      });
+    });
+
+    it('classifies an AxiosError (status/statusText/data) and aborts the sync without throwing the raw error', async () => {
+      mockedAxios.get.mockRejectedValueOnce(
+        makeAxiosError({
+          response: { status: 401, statusText: 'Unauthorized', data: 'nope' },
+        })
+      );
+
+      // listEventsFromRocketChatServer returns null on failure, and
+      // performSync converts that into a generic "sync cannot proceed" error
+      // (the classified status/statusText/data are consumed internally by
+      // createClassifiedError/outlookError, which are mocked away here).
+      await expect(
+        syncEventsWithRocketChatServer(serverUrl, credentials, token)
+      ).rejects.toThrow(/Sync failed during event fetching/);
+    });
+
+    it('takes the non-axios branch for a plain Error and still aborts the sync', async () => {
+      mockedAxios.get.mockRejectedValueOnce(new Error('plain network error'));
+      mockedAxios.isAxiosError.mockReturnValue(false);
+
+      await expect(
+        syncEventsWithRocketChatServer(serverUrl, credentials, token)
+      ).rejects.toThrow(/Sync failed during event fetching/);
+    });
+  });
+
+  describe('createEventOnRocketChatServer (axios.post, L256)', () => {
+    it('POSTs a new event with auth headers/timeout when the Outlook event is not yet on the RC server', async () => {
+      mockedGetOutlookEvents.mockResolvedValueOnce([
+        makeAppointment({ id: 'new-appt' }),
+      ]);
+      mockedAxios.get.mockResolvedValueOnce({
+        status: 200,
+        data: emptyRcResponse,
+      });
+      mockedAxios.post.mockResolvedValueOnce({ status: 200, data: {} });
+
+      await syncEventsWithRocketChatServer(serverUrl, credentials, token);
+
+      expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+      const [url, payload, config] = mockedAxios.post.mock.calls[0];
+      expect(url).toBe(`${serverUrl}api/v1/calendar-events.import`);
+      expect(payload).toMatchObject({ externalId: 'new-appt' });
+      expect(config).toMatchObject({
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Auth-Token': token,
+          'X-User-Id': credentials.userId,
+        },
+        timeout: 10_000,
+      });
+    });
+
+    it('classifies an AxiosError on create but lets the sync loop continue (individual failures do not abort the sync)', async () => {
+      mockedGetOutlookEvents.mockResolvedValueOnce([
+        makeAppointment({ id: 'new-appt' }),
+      ]);
+      mockedAxios.get.mockResolvedValueOnce({
+        status: 200,
+        data: emptyRcResponse,
+      });
+      mockedAxios.post.mockRejectedValueOnce(
+        makeAxiosError({
+          response: { status: 403, statusText: 'Forbidden', data: 'denied' },
+        })
+      );
+
+      await expect(
+        syncEventsWithRocketChatServer(serverUrl, credentials, token)
+      ).resolves.toBeUndefined();
+      expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+    });
+
+    it('takes the non-axios branch for a plain Error on create', async () => {
+      mockedGetOutlookEvents.mockResolvedValueOnce([
+        makeAppointment({ id: 'new-appt' }),
+      ]);
+      mockedAxios.get.mockResolvedValueOnce({
+        status: 200,
+        data: emptyRcResponse,
+      });
+      mockedAxios.post.mockRejectedValueOnce(new Error('plain create error'));
+      mockedAxios.isAxiosError.mockReturnValue(false);
+
+      await expect(
+        syncEventsWithRocketChatServer(serverUrl, credentials, token)
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('updateEventOnRocketChatServer (axios.post, L343)', () => {
+    it('POSTs an update with auth headers/timeout when a matching RC event has changed', async () => {
+      const outlookAppointment = makeAppointment({
+        id: 'appt-1',
+        subject: 'Updated subject',
+      });
+      mockedGetOutlookEvents.mockResolvedValueOnce([outlookAppointment]);
+      mockedAxios.get.mockResolvedValueOnce({
+        status: 200,
+        data: {
+          success: true,
+          data: [makeRcEvent({ subject: 'Old subject' })],
+        },
+      });
+      mockedAxios.post.mockResolvedValueOnce({ status: 200, data: {} });
+
+      await syncEventsWithRocketChatServer(serverUrl, credentials, token);
+
+      expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+      const [url, payload, config] = mockedAxios.post.mock.calls[0];
+      expect(url).toBe(`${serverUrl}api/v1/calendar-events.update`);
+      expect(payload).toMatchObject({
+        eventId: 'rc-1',
+        subject: 'Updated subject',
+      });
+      expect(config).toMatchObject({
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Auth-Token': token,
+          'X-User-Id': credentials.userId,
+        },
+        timeout: 10_000,
+      });
+    });
+
+    it('classifies an AxiosError on update without aborting the overall sync', async () => {
+      mockedGetOutlookEvents.mockResolvedValueOnce([
+        makeAppointment({ id: 'appt-1', subject: 'Updated subject' }),
+      ]);
+      mockedAxios.get.mockResolvedValueOnce({
+        status: 200,
+        data: {
+          success: true,
+          data: [makeRcEvent({ subject: 'Old subject' })],
+        },
+      });
+      mockedAxios.post.mockRejectedValueOnce(
+        makeAxiosError({
+          response: { status: 500, statusText: 'Server Error', data: 'x' },
+        })
+      );
+
+      await expect(
+        syncEventsWithRocketChatServer(serverUrl, credentials, token)
+      ).resolves.toBeUndefined();
+    });
+
+    it('takes the non-axios branch for a plain Error on update', async () => {
+      mockedGetOutlookEvents.mockResolvedValueOnce([
+        makeAppointment({ id: 'appt-1', subject: 'Updated subject' }),
+      ]);
+      mockedAxios.get.mockResolvedValueOnce({
+        status: 200,
+        data: {
+          success: true,
+          data: [makeRcEvent({ subject: 'Old subject' })],
+        },
+      });
+      mockedAxios.post.mockRejectedValueOnce(new Error('plain update error'));
+      mockedAxios.isAxiosError.mockReturnValue(false);
+
+      await expect(
+        syncEventsWithRocketChatServer(serverUrl, credentials, token)
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('deleteEventOnRocketChatServer (axios.post, L407)', () => {
+    it('POSTs a delete with auth headers/timeout for RC events no longer on Outlook', async () => {
+      mockedGetOutlookEvents.mockResolvedValueOnce([]);
+      mockedAxios.get.mockResolvedValueOnce({
+        status: 200,
+        data: { success: true, data: [makeRcEvent({ _id: 'to-delete' })] },
+      });
+      mockedAxios.post.mockResolvedValueOnce({ status: 200, data: {} });
+
+      await syncEventsWithRocketChatServer(serverUrl, credentials, token);
+
+      expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+      const [url, payload, config] = mockedAxios.post.mock.calls[0];
+      expect(url).toBe(`${serverUrl}api/v1/calendar-events.delete`);
+      expect(payload).toMatchObject({ eventId: 'to-delete' });
+      expect(config).toMatchObject({
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Auth-Token': token,
+          'X-User-Id': credentials.userId,
+        },
+        timeout: 10_000,
+      });
+    });
+
+    it('classifies an AxiosError on delete without aborting the overall sync', async () => {
+      mockedGetOutlookEvents.mockResolvedValueOnce([]);
+      mockedAxios.get.mockResolvedValueOnce({
+        status: 200,
+        data: { success: true, data: [makeRcEvent({ _id: 'to-delete' })] },
+      });
+      mockedAxios.post.mockRejectedValueOnce(
+        makeAxiosError({
+          response: { status: 404, statusText: 'Not Found', data: 'gone' },
+        })
+      );
+
+      await expect(
+        syncEventsWithRocketChatServer(serverUrl, credentials, token)
+      ).resolves.toBeUndefined();
+    });
+
+    it('takes the non-axios branch for a plain Error on delete', async () => {
+      mockedGetOutlookEvents.mockResolvedValueOnce([]);
+      mockedAxios.get.mockResolvedValueOnce({
+        status: 200,
+        data: { success: true, data: [makeRcEvent({ _id: 'to-delete' })] },
+      });
+      mockedAxios.post.mockRejectedValueOnce(new Error('plain delete error'));
+      mockedAxios.isAxiosError.mockReturnValue(false);
+
+      await expect(
+        syncEventsWithRocketChatServer(serverUrl, credentials, token)
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('syncEventsWithRocketChatServer', () => {
+    it('rejects immediately when no token is provided', async () => {
+      await expect(
+        syncEventsWithRocketChatServer(serverUrl, credentials, '' as any)
+      ).rejects.toThrow(/Authentication required/);
+      expect(mockedAxios.get).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op (no axios calls) when credentials are incomplete', async () => {
+      await syncEventsWithRocketChatServer(
+        serverUrl,
+        { ...credentials, login: '' },
+        token
+      );
+
+      expect(mockedAxios.get).not.toHaveBeenCalled();
+      expect(mockedAxios.post).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('startOutlookCalendarUrlHandler / stopOutlookCalendarSync (exported IPC surface)', () => {
+    it('registers the has-credentials handler and reports true for complete credentials', async () => {
+      const { startOutlookCalendarUrlHandler } = await import('../ipc');
+      startOutlookCalendarUrlHandler();
+
+      selectMock.mockReturnValue({
+        servers: [
+          {
+            url: serverUrl,
+            webContentsId: 1,
+            outlookCredentials: credentials,
+          },
+        ],
+      });
+
+      const handler = handleRegistry.get('outlook-calendar/has-credentials');
+      expect(handler).toBeDefined();
+
+      const result = await handler!({ id: 1 });
+      expect(result).toBe(true);
+    });
+
+    it('registers the has-credentials handler and reports false when no server matches', async () => {
+      const { startOutlookCalendarUrlHandler } = await import('../ipc');
+      startOutlookCalendarUrlHandler();
+      selectMock.mockReturnValue({ servers: [] });
+
+      const handler = handleRegistry.get('outlook-calendar/has-credentials');
+      const result = await handler!({ id: 999 });
+      expect(result).toBe(false);
+    });
+
+    it('stopOutlookCalendarSync clears tracked server state without throwing', () => {
+      expect(() => stopOutlookCalendarSync()).not.toThrow();
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3030,6 +3030,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@napi-rs/lzma-linux-x64-gnu@npm:1.5.1":
+  version: 1.5.1
+  resolution: "@napi-rs/lzma-linux-x64-gnu@npm:1.5.1"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@nicolo-ribaudo/eslint-scope-5-internals@npm:5.1.1-v1":
   version: 5.1.1-v1
   resolution: "@nicolo-ribaudo/eslint-scope-5-internals@npm:5.1.1-v1"
@@ -4384,135 +4391,177 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-android-arm-eabi@npm:4.32.1":
-  version: 4.32.1
-  resolution: "@rollup/rollup-android-arm-eabi@npm:4.32.1"
+"@rollup/rollup-android-arm-eabi@npm:4.62.4":
+  version: 4.62.4
+  resolution: "@rollup/rollup-android-arm-eabi@npm:4.62.4"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@rollup/rollup-android-arm64@npm:4.32.1":
-  version: 4.32.1
-  resolution: "@rollup/rollup-android-arm64@npm:4.32.1"
+"@rollup/rollup-android-arm64@npm:4.62.4":
+  version: 4.62.4
+  resolution: "@rollup/rollup-android-arm64@npm:4.62.4"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-darwin-arm64@npm:4.32.1":
-  version: 4.32.1
-  resolution: "@rollup/rollup-darwin-arm64@npm:4.32.1"
+"@rollup/rollup-darwin-arm64@npm:4.62.4":
+  version: 4.62.4
+  resolution: "@rollup/rollup-darwin-arm64@npm:4.62.4"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-darwin-x64@npm:4.32.1":
-  version: 4.32.1
-  resolution: "@rollup/rollup-darwin-x64@npm:4.32.1"
+"@rollup/rollup-darwin-x64@npm:4.62.4":
+  version: 4.62.4
+  resolution: "@rollup/rollup-darwin-x64@npm:4.62.4"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-freebsd-arm64@npm:4.32.1":
-  version: 4.32.1
-  resolution: "@rollup/rollup-freebsd-arm64@npm:4.32.1"
+"@rollup/rollup-freebsd-arm64@npm:4.62.4":
+  version: 4.62.4
+  resolution: "@rollup/rollup-freebsd-arm64@npm:4.62.4"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-freebsd-x64@npm:4.32.1":
-  version: 4.32.1
-  resolution: "@rollup/rollup-freebsd-x64@npm:4.32.1"
+"@rollup/rollup-freebsd-x64@npm:4.62.4":
+  version: 4.62.4
+  resolution: "@rollup/rollup-freebsd-x64@npm:4.62.4"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm-gnueabihf@npm:4.32.1":
-  version: 4.32.1
-  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.32.1"
+"@rollup/rollup-linux-arm-gnueabihf@npm:4.62.4":
+  version: 4.62.4
+  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.62.4"
   conditions: os=linux & cpu=arm & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm-musleabihf@npm:4.32.1":
-  version: 4.32.1
-  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.32.1"
+"@rollup/rollup-linux-arm-musleabihf@npm:4.62.4":
+  version: 4.62.4
+  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.62.4"
   conditions: os=linux & cpu=arm & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm64-gnu@npm:4.32.1":
-  version: 4.32.1
-  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.32.1"
+"@rollup/rollup-linux-arm64-gnu@npm:4.62.4":
+  version: 4.62.4
+  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.62.4"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm64-musl@npm:4.32.1":
-  version: 4.32.1
-  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.32.1"
+"@rollup/rollup-linux-arm64-musl@npm:4.62.4":
+  version: 4.62.4
+  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.62.4"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-loongarch64-gnu@npm:4.32.1":
-  version: 4.32.1
-  resolution: "@rollup/rollup-linux-loongarch64-gnu@npm:4.32.1"
+"@rollup/rollup-linux-loong64-gnu@npm:4.62.4":
+  version: 4.62.4
+  resolution: "@rollup/rollup-linux-loong64-gnu@npm:4.62.4"
   conditions: os=linux & cpu=loong64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-powerpc64le-gnu@npm:4.32.1":
-  version: 4.32.1
-  resolution: "@rollup/rollup-linux-powerpc64le-gnu@npm:4.32.1"
+"@rollup/rollup-linux-loong64-musl@npm:4.62.4":
+  version: 4.62.4
+  resolution: "@rollup/rollup-linux-loong64-musl@npm:4.62.4"
+  conditions: os=linux & cpu=loong64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-ppc64-gnu@npm:4.62.4":
+  version: 4.62.4
+  resolution: "@rollup/rollup-linux-ppc64-gnu@npm:4.62.4"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-riscv64-gnu@npm:4.32.1":
-  version: 4.32.1
-  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.32.1"
+"@rollup/rollup-linux-ppc64-musl@npm:4.62.4":
+  version: 4.62.4
+  resolution: "@rollup/rollup-linux-ppc64-musl@npm:4.62.4"
+  conditions: os=linux & cpu=ppc64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-riscv64-gnu@npm:4.62.4":
+  version: 4.62.4
+  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.62.4"
   conditions: os=linux & cpu=riscv64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-s390x-gnu@npm:4.32.1":
-  version: 4.32.1
-  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.32.1"
+"@rollup/rollup-linux-riscv64-musl@npm:4.62.4":
+  version: 4.62.4
+  resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.62.4"
+  conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-s390x-gnu@npm:4.62.4":
+  version: 4.62.4
+  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.62.4"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-x64-gnu@npm:4.32.1":
-  version: 4.32.1
-  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.32.1"
+"@rollup/rollup-linux-x64-gnu@npm:4.62.4":
+  version: 4.62.4
+  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.62.4"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-x64-musl@npm:4.32.1":
-  version: 4.32.1
-  resolution: "@rollup/rollup-linux-x64-musl@npm:4.32.1"
+"@rollup/rollup-linux-x64-musl@npm:4.62.4":
+  version: 4.62.4
+  resolution: "@rollup/rollup-linux-x64-musl@npm:4.62.4"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-arm64-msvc@npm:4.32.1":
-  version: 4.32.1
-  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.32.1"
+"@rollup/rollup-openbsd-x64@npm:4.62.4":
+  version: 4.62.4
+  resolution: "@rollup/rollup-openbsd-x64@npm:4.62.4"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-openharmony-arm64@npm:4.62.4":
+  version: 4.62.4
+  resolution: "@rollup/rollup-openharmony-arm64@npm:4.62.4"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-arm64-msvc@npm:4.62.4":
+  version: 4.62.4
+  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.62.4"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-ia32-msvc@npm:4.32.1":
-  version: 4.32.1
-  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.32.1"
+"@rollup/rollup-win32-ia32-msvc@npm:4.62.4":
+  version: 4.62.4
+  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.62.4"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-x64-msvc@npm:4.32.1":
-  version: 4.32.1
-  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.32.1"
+"@rollup/rollup-win32-x64-gnu@npm:4.62.4":
+  version: 4.62.4
+  resolution: "@rollup/rollup-win32-x64-gnu@npm:4.62.4"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-x64-msvc@npm:4.62.4":
+  version: 4.62.4
+  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.62.4"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -4786,10 +4835,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:1.0.6":
-  version: 1.0.6
-  resolution: "@types/estree@npm:1.0.6"
-  checksum: 10/9d35d475095199c23e05b431bcdd1f6fec7380612aed068b14b2a08aa70494de8a9026765a5a91b1073f636fb0368f6d8973f518a31391d519e20c59388ed88d
+"@types/estree@npm:1.0.9":
+  version: 1.0.9
+  resolution: "@types/estree@npm:1.0.9"
+  checksum: 10/16aabfa703b5bdac83f719b07ce92a11b2d3c9b8628eacc92889d8af46cab2d78fc45c7b5378de383d0500585cea5c2f79125eeddfe5fbc6bd6a27eb0c8ccee5
   languageName: node
   linkType: hard
 
@@ -6079,14 +6128,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.13.6":
-  version: 1.13.6
-  resolution: "axios@npm:1.13.6"
+"axios@npm:1.18.0":
+  version: 1.18.0
+  resolution: "axios@npm:1.18.0"
   dependencies:
-    follow-redirects: "npm:^1.15.11"
+    follow-redirects: "npm:^1.16.0"
     form-data: "npm:^4.0.5"
-    proxy-from-env: "npm:^1.1.0"
-  checksum: 10/a7ed83c2af3ef21d64609df0f85e76893a915a864c5934df69241001d0578082d6521a0c730bf37518ee458821b5695957cb10db9fc705f2a8996c8686ea7a89
+    https-proxy-agent: "npm:^5.0.1"
+    proxy-from-env: "npm:^2.1.0"
+  checksum: 10/586a1a9534531c6ec4ee8fbab07a536ecaa8d29bd16b40ab0f9fce361fcd24da1538a54aadde0562f08f30b55bf80f9b7ededf1987e6506f722e1fb338b09d5d
   languageName: node
   linkType: hard
 
@@ -7962,7 +8012,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:*, dompurify@npm:~3.3.3":
+"dompurify@npm:*":
   version: 3.3.3
   resolution: "dompurify@npm:3.3.3"
   dependencies:
@@ -7971,6 +8021,18 @@ __metadata:
     "@types/trusted-types":
       optional: true
   checksum: 10/4cc9c539ed7136d46c6577613b8e20871c2b6165db01dfbd2a3c11c75f9e339c496ac6519a1c3190115def8cadae3720bef0417fc43fa28802c7407bab174da9
+  languageName: node
+  linkType: hard
+
+"dompurify@npm:~3.4.13":
+  version: 3.4.13
+  resolution: "dompurify@npm:3.4.13"
+  dependencies:
+    "@types/trusted-types": "npm:^2.0.7"
+  dependenciesMeta:
+    "@types/trusted-types":
+      optional: true
+  checksum: 10/0db0a309a868a38aca042f606b37446977c35ee4501850a8c1bf2781337d79871daf1f4344bbf5b545f2a8c62e4d4e192c8fd6f1ff49ecec7c865c55a0aefee3
   languageName: node
   linkType: hard
 
@@ -9354,13 +9416,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:1.15.9":
-  version: 1.15.9
-  resolution: "follow-redirects@npm:1.15.9"
+"follow-redirects@npm:1.16.0":
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 10/e3ab42d1097e90d28b913903841e6779eb969b62a64706a3eb983e894a5db000fbd89296f45f08885a0e54cd558ef62e81be1165da9be25a6c44920da10f424c
+  checksum: 10/3fbe3d80b3b544c22705d837aa5d4a0d07a740d913534a2620b0a004c610af4148e3b58723536dd099aaa1c9d3a155964bde9665d6e5cb331460809a1fc572fd
   languageName: node
   linkType: hard
 
@@ -9383,16 +9445,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:4.0.5":
-  version: 4.0.5
-  resolution: "form-data@npm:4.0.5"
+"form-data@npm:4.0.6":
+  version: 4.0.6
+  resolution: "form-data@npm:4.0.6"
   dependencies:
     asynckit: "npm:^0.4.0"
     combined-stream: "npm:^1.0.8"
     es-set-tostringtag: "npm:^2.1.0"
-    hasown: "npm:^2.0.2"
-    mime-types: "npm:^2.1.12"
-  checksum: 10/52ecd6e927c8c4e215e68a7ad5e0f7c1031397439672fd9741654b4a94722c4182e74cc815b225dcb5be3f4180f36428f67c6dd39eaa98af0dcfdd26c00c19cd
+    hasown: "npm:^2.0.4"
+    mime-types: "npm:^2.1.35"
+  checksum: 10/de6614c8537c92fa5fa3ee7e827758f98f5a9c033f348b7de81855ef36e5cb867e75d9f405d9483ab8d724a4a20d4e79926a299fa8dbba38f530eb659f0884e4
   languageName: node
   linkType: hard
 
@@ -9990,6 +10052,15 @@ __metadata:
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 10/7898a9c1788b2862cf0f9c345a6bec77ba4a0c0983c7f19d610c382343d4f98fa260686b225dfb1f88393a66679d2ec58ee310c1d6868c081eda7918f32cc70a
+  languageName: node
+  linkType: hard
+
+"hasown@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "hasown@npm:2.0.4"
+  dependencies:
+    function-bind: "npm:^1.1.2"
+  checksum: 10/13823863ae48161068b4c51606a3128451c66f14545a5169d667fe9fca168dcd38c27570c7a299e32ef844b8da3d55def7fe88602f8970d4311fb543ee88001a
   languageName: node
   linkType: hard
 
@@ -12286,7 +12357,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.12":
+"mime-types@npm:^2.1.35":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
@@ -13759,6 +13830,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"proxy-from-env@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "proxy-from-env@npm:2.1.0"
+  checksum: 10/fbbaf4dab2a6231dc9e394903a5f66f20475e36b734335790b46feb9da07c37d6b32e2c02e3e2ea4d4b23774c53d8562e5b7cc73282cb43f4a597b7eacaee2ee
+  languageName: node
+  linkType: hard
+
 "psl@npm:^1.1.33":
   version: 1.15.0
   resolution: "psl@npm:1.15.0"
@@ -14671,13 +14749,13 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:~6.17.0"
     "@typescript-eslint/parser": "npm:~6.17.0"
     archiver: "npm:~7.0.1"
-    axios: "npm:~1.13.6"
+    axios: "npm:~1.18.0"
     builtin-modules: "npm:~3.3.0"
     chokidar: "npm:~3.5.3"
     conventional-changelog-cli: "npm:~4.1.0"
     convert-svg-to-png: "npm:~0.6.4"
     detect-browsers: "npm:~6.1.0"
-    dompurify: "npm:~3.3.3"
+    dompurify: "npm:~3.4.13"
     electron: "npm:42.5.0"
     electron-builder: "npm:26.0.3"
     electron-devtools-installer: "npm:^3.2.0"
@@ -14720,14 +14798,14 @@ __metadata:
     redux: "npm:~5.0.1"
     reselect: "npm:~5.0.1"
     rimraf: "npm:~5.0.7"
-    rollup: "npm:~4.32.0"
+    rollup: "npm:~4.62.4"
     rollup-plugin-copy: "npm:~3.5.0"
     semver: "npm:~7.5.4"
     ts-jest: "npm:~29.1.4"
     ts-node: "npm:~10.9.2"
     typescript: "npm:~5.7.3"
     xvfb-maybe: "npm:~0.2.1"
-    yaml: "npm:^1.10.2"
+    yaml: "npm:^1.10.3"
   dependenciesMeta:
     fsevents:
       optional: true
@@ -14747,32 +14825,41 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup@npm:~4.32.0":
-  version: 4.32.1
-  resolution: "rollup@npm:4.32.1"
+"rollup@npm:~4.62.4":
+  version: 4.62.4
+  resolution: "rollup@npm:4.62.4"
   dependencies:
-    "@rollup/rollup-android-arm-eabi": "npm:4.32.1"
-    "@rollup/rollup-android-arm64": "npm:4.32.1"
-    "@rollup/rollup-darwin-arm64": "npm:4.32.1"
-    "@rollup/rollup-darwin-x64": "npm:4.32.1"
-    "@rollup/rollup-freebsd-arm64": "npm:4.32.1"
-    "@rollup/rollup-freebsd-x64": "npm:4.32.1"
-    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.32.1"
-    "@rollup/rollup-linux-arm-musleabihf": "npm:4.32.1"
-    "@rollup/rollup-linux-arm64-gnu": "npm:4.32.1"
-    "@rollup/rollup-linux-arm64-musl": "npm:4.32.1"
-    "@rollup/rollup-linux-loongarch64-gnu": "npm:4.32.1"
-    "@rollup/rollup-linux-powerpc64le-gnu": "npm:4.32.1"
-    "@rollup/rollup-linux-riscv64-gnu": "npm:4.32.1"
-    "@rollup/rollup-linux-s390x-gnu": "npm:4.32.1"
-    "@rollup/rollup-linux-x64-gnu": "npm:4.32.1"
-    "@rollup/rollup-linux-x64-musl": "npm:4.32.1"
-    "@rollup/rollup-win32-arm64-msvc": "npm:4.32.1"
-    "@rollup/rollup-win32-ia32-msvc": "npm:4.32.1"
-    "@rollup/rollup-win32-x64-msvc": "npm:4.32.1"
-    "@types/estree": "npm:1.0.6"
+    "@napi-rs/lzma-linux-x64-gnu": "npm:1.5.1"
+    "@rollup/rollup-android-arm-eabi": "npm:4.62.4"
+    "@rollup/rollup-android-arm64": "npm:4.62.4"
+    "@rollup/rollup-darwin-arm64": "npm:4.62.4"
+    "@rollup/rollup-darwin-x64": "npm:4.62.4"
+    "@rollup/rollup-freebsd-arm64": "npm:4.62.4"
+    "@rollup/rollup-freebsd-x64": "npm:4.62.4"
+    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.62.4"
+    "@rollup/rollup-linux-arm-musleabihf": "npm:4.62.4"
+    "@rollup/rollup-linux-arm64-gnu": "npm:4.62.4"
+    "@rollup/rollup-linux-arm64-musl": "npm:4.62.4"
+    "@rollup/rollup-linux-loong64-gnu": "npm:4.62.4"
+    "@rollup/rollup-linux-loong64-musl": "npm:4.62.4"
+    "@rollup/rollup-linux-ppc64-gnu": "npm:4.62.4"
+    "@rollup/rollup-linux-ppc64-musl": "npm:4.62.4"
+    "@rollup/rollup-linux-riscv64-gnu": "npm:4.62.4"
+    "@rollup/rollup-linux-riscv64-musl": "npm:4.62.4"
+    "@rollup/rollup-linux-s390x-gnu": "npm:4.62.4"
+    "@rollup/rollup-linux-x64-gnu": "npm:4.62.4"
+    "@rollup/rollup-linux-x64-musl": "npm:4.62.4"
+    "@rollup/rollup-openbsd-x64": "npm:4.62.4"
+    "@rollup/rollup-openharmony-arm64": "npm:4.62.4"
+    "@rollup/rollup-win32-arm64-msvc": "npm:4.62.4"
+    "@rollup/rollup-win32-ia32-msvc": "npm:4.62.4"
+    "@rollup/rollup-win32-x64-gnu": "npm:4.62.4"
+    "@rollup/rollup-win32-x64-msvc": "npm:4.62.4"
+    "@types/estree": "npm:1.0.9"
     fsevents: "npm:~2.3.2"
   dependenciesMeta:
+    "@napi-rs/lzma-linux-x64-gnu":
+      optional: true
     "@rollup/rollup-android-arm-eabi":
       optional: true
     "@rollup/rollup-android-arm64":
@@ -14793,11 +14880,17 @@ __metadata:
       optional: true
     "@rollup/rollup-linux-arm64-musl":
       optional: true
-    "@rollup/rollup-linux-loongarch64-gnu":
+    "@rollup/rollup-linux-loong64-gnu":
       optional: true
-    "@rollup/rollup-linux-powerpc64le-gnu":
+    "@rollup/rollup-linux-loong64-musl":
+      optional: true
+    "@rollup/rollup-linux-ppc64-gnu":
+      optional: true
+    "@rollup/rollup-linux-ppc64-musl":
       optional: true
     "@rollup/rollup-linux-riscv64-gnu":
+      optional: true
+    "@rollup/rollup-linux-riscv64-musl":
       optional: true
     "@rollup/rollup-linux-s390x-gnu":
       optional: true
@@ -14805,9 +14898,15 @@ __metadata:
       optional: true
     "@rollup/rollup-linux-x64-musl":
       optional: true
+    "@rollup/rollup-openbsd-x64":
+      optional: true
+    "@rollup/rollup-openharmony-arm64":
+      optional: true
     "@rollup/rollup-win32-arm64-msvc":
       optional: true
     "@rollup/rollup-win32-ia32-msvc":
+      optional: true
+    "@rollup/rollup-win32-x64-gnu":
       optional: true
     "@rollup/rollup-win32-x64-msvc":
       optional: true
@@ -14815,7 +14914,7 @@ __metadata:
       optional: true
   bin:
     rollup: dist/bin/rollup
-  checksum: 10/5a64860df9d0c1b88d142b8502cb2e858e8314025ed35c605c70dc5c7c099fcecc9340cac269412c9a8b53705b911f1454b01164d23400c7d84cafb241be255f
+  checksum: 10/2392665d3f6177ff58ee6675c75a379d191748d51559ed447b2ee3c5b00855146d67cdea7d816986b1294bb173e557c83ef00a027f549b7d49591c959288a306
   languageName: node
   linkType: hard
 
@@ -15727,9 +15826,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar-fs@npm:3.0.8":
-  version: 3.0.8
-  resolution: "tar-fs@npm:3.0.8"
+"tar-fs@npm:3.1.3":
+  version: 3.1.3
+  resolution: "tar-fs@npm:3.1.3"
   dependencies:
     bare-fs: "npm:^4.0.1"
     bare-path: "npm:^3.0.0"
@@ -15740,7 +15839,7 @@ __metadata:
       optional: true
     bare-path:
       optional: true
-  checksum: 10/fdcd1c66dc5e2cad5544ffe7eab9a470b419290b22300c344688df51bf06127963da07a1e3ae23cae80851cd9f60149e80b38e56485dd7a14aea701241ac2f81
+  checksum: 10/858176af2e7c41a302026c6f21940160d50045f567e4276950c921c501e8ddb42edbf5b5437298092fe60d42c7b999a599279d94c3f369b9adb1cfc5b57486fe
   languageName: node
   linkType: hard
 
@@ -16892,9 +16991,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:8.18.0":
-  version: 8.18.0
-  resolution: "ws@npm:8.18.0"
+"ws@npm:8.21.3":
+  version: 8.21.3
+  resolution: "ws@npm:8.21.3"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -16903,7 +17002,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10/70dfe53f23ff4368d46e4c0b1d4ca734db2c4149c6f68bc62cb16fc21f753c47b35fcc6e582f3bdfba0eaeb1c488cddab3c2255755a5c3eecb251431e42b3ff6
+  checksum: 10/8856922c26fd2d106931c16310d9a0bc2d6d37ed8771352bfa0d2a36df0ab5cb1f6528c6db8213f3333cf4ce93925e56f13604df0454cb0d4289fef922bebcdd
   languageName: node
   linkType: hard
 
@@ -17025,7 +17124,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^1.10.2":
+"yaml@npm:^1.10.3":
   version: 1.10.3
   resolution: "yaml@npm:1.10.3"
   checksum: 10/e2ef2feb92c708138f016c69777a0f1e45f6d3c5e7cbcda30807a98a37eda2e008bd4fa57352b043c65245a4c799d0c99d1f9b3425de40e70929e26d2ea38215


### PR DESCRIPTION
## What

Bumps the vulnerable packages whose versions are ours to choose — direct dependencies and the existing security `resolutions` pins. Nothing here reaches into electron-builder's dependency tree.

| Package | From | To |
|---|---|---|
| axios | `~1.13.6` | `~1.18.0` |
| ws | 8.18.0 | 8.21.3 |
| follow-redirects | 1.15.9 | 1.16.0 |
| form-data | 4.0.5 | 4.0.6 |
| tar-fs | 3.0.8 | 3.1.3 |
| dompurify | `~3.3.3` | `~3.4.13` |
| rollup | `~4.32.0` | `~4.62.4` |
| yaml | `^1.10.2` | `^1.10.3` |

Clears **34 open Dependabot alerts** (14 high, 19 medium, 1 low). axios alone accounts for 10 highs, and it was pinned twice — as a dependency and as a resolution — so both had to move for the bump to take effect.

## Deliberately not included

- **undici** (needs 5.x → 6.x) and **@babel/core** (7 → 8) are major bumps.
- **sharp** is pinned to 0.29.3 specifically for `@fiahfy/{icns,ico}-convert`; moving it risks the icon build.
- The remaining alerts are **transitive under electron-builder** (`tar`, `handlebars`, `shell-quote`, `basic-ftp`, `minimatch`, …). Fixing those means new `resolutions` on the code that packages and signs installers, so it needs a real per-platform packaging test — its own change, not this one.

Separately, 31 electron alerts were dismissed as false positives: every advisory range caps at `< 39.8.x` and this project ships 42.5.0.

## Tests added

`src/outlookCalendar/ipc.ts` is 1317 lines with five axios call sites and had **no spec**, so nothing would have caught a behavioural regression from the axios bump. Adds `src/outlookCalendar/__tests__/ipc.main.spec.ts` — 17 tests covering every call site's success path, `isAxiosError` branch, and non-axios `Error` branch, driven through the exported `syncEventsWithRocketChatServer`.

## Verification

- 217/217 pre-existing axios-dependent tests pass on 1.18.0 (`supportedVersions` ×2, `outlookCalendar` ×2)
- new spec discovered by jest and passing 17/17
- `yarn lint` and `npx tsc --noEmit` clean
- `yarn build` succeeds on rollup 4.62.4 — 29 chunks, externals check passed (unit tests alone would not prove a rollup bump)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for Outlook calendar synchronization and IPC interactions.
  * Verified event creation, updates, deletions, authentication handling, error recovery, and cleanup behavior.

* **Chores**
  * Updated application runtime and development dependencies.
  * Refreshed selected dependency versions and security-related resolutions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->