### PR TITLE
ci: build releases only on semver tags and run PR checks for release lines

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -3,11 +3,9 @@ name: Build release
 
 on:
   push:
-    branches:
-      - master
-      - dev
     tags:
-      - '*'
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-*'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/powershell-lint.yml
+++ b/.github/workflows/powershell-lint.yml
@@ -13,6 +13,7 @@ on:
     branches:
       - master
       - dev
+      - 'release/**'
     paths:
       - '**.ps1'
       - '**.psm1'

--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - master
       - dev
+      - 'release/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - dev
+      - 'release/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}


### PR DESCRIPTION
Part of the branching-model migration (dev = development branch, master = releases only, release/X.Y.x = patch lines).

## What changed

- `build-release.yml` no longer triggers on branch pushes (`master`/`dev`). Release builds now run **only on semver tag pushes** (`X.Y.Z` and `X.Y.Z-*`). This removes the rolling Development/Snapshot draft builds and makes non-semver tags (archive tags, typos) build-inert.
- `validate-pr.yml` and `pull-request-build.yml` now also run for PRs targeting `release/**` branches — previously patch-release PRs would get no CI at all.
- `powershell-lint.yml` push trigger extended with `release/**` for consistency.

## Why

Under the new model, alphas are tagged on `dev`, stables on `master` (via dev→master release merges), and patches on `release/X.Y.x` lines. The tag-triggered release path in `desktop-release-action` is already branch-agnostic, so no action changes are needed — its per-push dev/snapshot code paths simply become unreachable (left in place deliberately to avoid rebuilding the committed `dist/` bundle).

Validated with actionlint (only pre-existing, unrelated warnings reported).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release automation now runs only for semantic version tags, including prereleases.
  * Code quality checks and pull request validation now support release branches.
  * Pull request builds now run when targeting release branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->