### PR TITLE
chore: bump version to 4.17.0-alpha.1

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -18,7 +18,7 @@
     "category": "public.app-category.productivity",
     "target": ["dmg", "pkg", "zip", "mas"],
     "icon": "build/icon.icns",
-    "bundleVersion": "26080",
+    "bundleVersion": "26081",
     "helperBundleId": "chat.rocket.electron.helper",
     "type": "distribution",
     "artifactName": "rocketchat-${version}-${os}.${ext}",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "Rocket.Chat",
   "name": "rocketchat",
   "description": "Official OSX, Windows, and Linux Desktop Clients for Rocket.Chat",
-  "version": "4.16.0",
+  "version": "4.17.0-alpha.1",
   "author": "Rocket.Chat Support <support@rocket.chat>",
   "copyright": "© 2016-2026, Rocket.Chat",
   "homepage": "https://rocket.chat",


### PR DESCRIPTION
First alpha of the 4.17.0 cycle, and the first release cut under the new branching model (alphas tagged on `dev`).

Ships since `4.16.0`:

- feat: log viewer, downloads, settings and document viewer as separate windows on a shared native shell (#3444)
- ci: build releases only on semver tags and run PR checks for release lines (#3454)
- fix(release): fail closed on unsafe release tags (#3452)
- docs: describe the dev/master/release branching model and wire it from README and AGENTS.md (#3455)

Also bumps `mac.bundleVersion` 26080 → 26081 (second build this month).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the macOS application build version.
  - Updated the application version to 4.17.0-alpha.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->