### PR TITLE
docs: correct update-channel metadata claims and note admin merges in ship-release

### DIFF
--- a/.claude/skills/ship-release/SKILL.md
+++ b/.claude/skills/ship-release/SKILL.md
@@ -106,7 +106,10 @@ push, release publish) is gated on explicit user approval.
 4. Commit `chore: bump version to <version>`, push, open a PR to **`dev`**.
 5. Wait for `validate-pr` checks. **GATE: show PR URL + checks status. STOP
    until the user says merge.**
-6. Squash-merge: `gh pr merge <PR> --squash`.
+6. Squash-merge: `gh pr merge <PR> --squash`. Branch protection requires 1
+   approving review, so this typically needs `--admin` (the release manager
+   has bypass) — otherwise `gh pr merge` refuses with "requirements have not
+   been met".
 
 ### Stable (promotion)
 
@@ -114,7 +117,8 @@ push, release publish) is gated on explicit user approval.
 2. Bump `"version"` in `package.json` to the bare version (drop the
    pre-release suffix, e.g. `4.17.0-alpha.6` → `4.17.0`).
 3. **GATE**, commit, push, open a bump PR to **`dev`**. Wait for checks.
-   **GATE: STOP until the user says merge.** Squash-merge.
+   **GATE: STOP until the user says merge.** Squash-merge (branch protection
+   requires 1 approving review, so this typically needs `--admin`).
 4. `git -C "$RELEASE_WT" fetch origin dev` and confirm the merge commit is
    HEAD of `origin/dev` with `package.json` at TARGET.
 5. Open the **release PR**: `dev` → `master`
@@ -142,7 +146,8 @@ push, release publish) is gated on explicit user approval.
    pushing.
 3. Bump `"version"` in `package.json` to `X.Y.Z`, commit, push a bump PR
    targeting **`release/<X.Y.x>`**. Wait for checks. **GATE: STOP until the
-   user says merge.** Squash-merge.
+   user says merge.** Squash-merge (branch protection requires 1 approving
+   review, so this typically needs `--admin`).
 
 ## Phase 3 — Merge & tag
 
@@ -169,6 +174,9 @@ or stay `cd`'d in) — never in the user's own checkout.
    ```sh
    gh pr merge <RELEASE_PR> --merge
    ```
+   Branch protection requires 1 approving review, so this typically needs
+   `--admin` (the release manager has bypass) — otherwise `gh pr merge`
+   refuses with "requirements have not been met".
 2. `git -C "$RELEASE_WT" fetch origin master` and confirm the merge commit
    is HEAD of `origin/master` and its `package.json` has TARGET.
 3. **GATE: confirm with the user before pushing the tag.**

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -23,11 +23,21 @@ Alpha work stays on `dev`; it never gets its own long-lived branch.
 
 ## How channels work
 
-| Channel | Version Format | Who Gets It | Update File |
-|---------|---------------|-------------|-------------|
-| Stable | `4.12.0` | All users (default) | `latest.yml` |
-| Beta | `4.12.0-beta.1` | Beta opt-in users | `beta.yml` |
-| Alpha | `4.12.0-alpha.1` | Alpha opt-in users | `alpha.yml` |
+| Channel | Version Format | Who Gets It |
+|---------|---------------|-------------|
+| Stable | `4.12.0` | All users (default) |
+| Beta | `4.12.0-beta.1` | Beta opt-in users |
+| Alpha | `4.12.0-alpha.1` | Alpha opt-in users |
+
+Every release — stable, beta, or alpha — uploads the same update metadata
+(`latest.yml`, `latest-mac.yml`, `latest-linux.yml`); there is no
+per-channel `.yml` filename. Channel separation instead comes from two
+things: whether the GitHub release is marked **Pre-release** (true for
+alpha/beta, false for stable), and whether the client has opted into
+prereleases (electron-updater's `allowPrerelease` is enabled for the
+alpha/beta channel settings, disabled for stable). A stable client's
+updater ignores prerelease-flagged releases even though they share the
+same `latest*.yml` file names.
 
 **Channel hierarchy**: Alpha users receive alpha, beta, AND stable updates.
 Beta users receive beta AND stable. Stable users only receive stable.
@@ -98,9 +108,10 @@ Alphas are cut directly from `dev` — no dedicated branch.
 
 4. CI builds automatically: pushing a semver tag is the **only** trigger for
    release builds (`build-release.yml` no longer runs on branch pushes). The
-   workflow builds for all platforms, generates `alpha.yml`,
-   `alpha-mac.yml`, `alpha-linux.yml` metadata, and creates a **draft**
-   GitHub release marked as Pre-release.
+   workflow builds for all platforms, generates `latest.yml`,
+   `latest-mac.yml`, `latest-linux.yml` metadata, and creates a **draft**
+   GitHub release marked as Pre-release — that Pre-release flag, not the
+   metadata file name, is what keeps the build away from stable clients.
 
 5. Publish the release: open the draft on GitHub Releases, review the notes,
    click "Publish release". Nothing is visible to any client until a human
@@ -269,9 +280,9 @@ Typical release progression:
 ### Update not showing after channel switch
 
 1. Verify the release is published (not draft) on GitHub.
-2. Check that the corresponding `.yml` file exists in the release assets:
-   - Alpha: `alpha.yml`, `alpha-mac.yml`, `alpha-linux.yml`
-   - Beta: `beta.yml`, `beta-mac.yml`, `beta-linux.yml`
+2. Check that `latest.yml`, `latest-mac.yml`, and `latest-linux.yml` exist
+   in the release assets, and that the release's Pre-release flag matches
+   the intended channel (checked for alpha/beta, unchecked for stable).
 3. Click "Check for Updates" in the About dialog.
 4. Restart the app and try again.
 


### PR DESCRIPTION
Follow-up from running the 4.17.0-alpha.1 release through the new flow end to end.

- `docs/release-process.md` claimed alpha/beta releases ship per-channel `alpha*.yml`/`beta*.yml` metadata. Verified against 4.17.0-alpha.1, 4.16.0-alpha.3, and 4.15.6: every release uploads only `latest*.yml`; channel separation comes from the GitHub Pre-release flag plus the client's prerelease opt-in (`allowPrerelease` for alpha/beta channels). The channel table, the alpha CI step, and the troubleshooting checklist now describe that.
- `.claude/skills/ship-release/SKILL.md`: at each merge gate, note that branch protection requires 1 approving review, so `gh pr merge` typically needs `--admin` — observed live, the command refuses otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified release-channel metadata and how pre-release settings determine channel separation.
  * Updated alpha release output and troubleshooting guidance to reference shared metadata files.
  * Documented approval and merge requirements for release pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->