### PR TITLE
feat: SAML auth through deeplink

### DIFF
--- a/src/deepLinks/main.spec.ts
+++ b/src/deepLinks/main.spec.ts
@@ -788,6 +788,151 @@ describe('deepLinks/main.ts', () => {
       expect(mockWebContents.loadURL).not.toHaveBeenCalled();
     });
 
+    const runSamlDeepLink = async (deepLink: string): Promise<void> => {
+      const savedArgv = process.argv;
+      process.argv = ['electron', '.', deepLink];
+
+      await processDeepLinksInArgs();
+
+      process.argv = savedArgv;
+    };
+
+    it('redeems a SAML credentialToken on the target server view', async () => {
+      setupDeepLinks();
+
+      resolveServerUrlMock.mockResolvedValue([
+        'https://chat.example.com',
+        ServerUrlResolutionStatus.OK,
+        undefined,
+      ] as any);
+      selectMock.mockReturnValue([
+        { url: 'https://chat.example.com', title: 'Chat' },
+      ]);
+
+      await runSamlDeepLink(
+        'rocketchat://auth?type=saml&host=https://chat.example.com&credentialToken=saml-fresh-A'
+      );
+
+      expect(resolveServerUrlMock).toHaveBeenCalledWith(
+        'https://chat.example.com'
+      );
+      // The web client's own /saml/:token route redeems the token on this view's connection.
+      expect(mockWebContents.loadURL).toHaveBeenCalledWith(
+        'https://chat.example.com/saml/saml-fresh-A'
+      );
+      expect(mockWebContents.loadURL).not.toHaveBeenCalledWith(
+        expect.stringContaining('loginClient')
+      );
+    });
+
+    it('percent-encodes the SAML credentialToken into the path', async () => {
+      setupDeepLinks();
+
+      resolveServerUrlMock.mockResolvedValue([
+        'https://chat.example.com',
+        ServerUrlResolutionStatus.OK,
+        undefined,
+      ] as any);
+      selectMock.mockReturnValue([
+        { url: 'https://chat.example.com', title: 'Chat' },
+      ]);
+
+      await runSamlDeepLink(
+        'rocketchat://auth?type=saml&host=https://chat.example.com&credentialToken=saml%2Fescape%3FB'
+      );
+
+      // A token cannot break out of the /saml/ path segment and reach another route.
+      expect(mockWebContents.loadURL).toHaveBeenCalledWith(
+        'https://chat.example.com/saml/saml%2Fescape%3FB'
+      );
+    });
+
+    it('does nothing when the SAML deep link has no credentialToken', async () => {
+      setupDeepLinks();
+
+      await runSamlDeepLink(
+        'rocketchat://auth?type=saml&host=https://chat.example.com'
+      );
+
+      expect(resolveServerUrlMock).not.toHaveBeenCalled();
+      expect(mockWebContents.loadURL).not.toHaveBeenCalled();
+    });
+
+    it('redeems a different SAML credentialToken after one was consumed', async () => {
+      setupDeepLinks();
+
+      resolveServerUrlMock.mockResolvedValue([
+        'https://chat.example.com',
+        ServerUrlResolutionStatus.OK,
+        undefined,
+      ] as any);
+      selectMock.mockReturnValue([
+        { url: 'https://chat.example.com', title: 'Chat' },
+      ]);
+
+      await runSamlDeepLink(
+        'rocketchat://auth?type=saml&host=https://chat.example.com&credentialToken=saml-first-D'
+      );
+      await runSamlDeepLink(
+        'rocketchat://auth?type=saml&host=https://chat.example.com&credentialToken=saml-second-D'
+      );
+
+      expect(mockWebContents.loadURL).toHaveBeenCalledTimes(2);
+      expect(mockWebContents.loadURL).toHaveBeenLastCalledWith(
+        'https://chat.example.com/saml/saml-second-D'
+      );
+    });
+
+    it('asks to add an unknown server before redeeming a SAML credentialToken', async () => {
+      setupDeepLinks();
+
+      resolveServerUrlMock.mockResolvedValue([
+        'https://chat.example.com',
+        ServerUrlResolutionStatus.OK,
+        undefined,
+      ] as any);
+      askForServerAdditionMock.mockResolvedValue(true);
+      selectMock.mockImplementation((selector: any) =>
+        selector({ servers: [] })
+      );
+
+      await runSamlDeepLink(
+        'rocketchat://auth?type=saml&host=https://chat.example.com&credentialToken=saml-add-E'
+      );
+
+      expect(askForServerAdditionMock).toHaveBeenCalledWith(
+        'https://chat.example.com'
+      );
+      expect(dispatchMock).toHaveBeenCalledWith({
+        type: DEEP_LINKS_SERVER_ADDED,
+        payload: 'https://chat.example.com',
+      });
+      expect(mockWebContents.loadURL).toHaveBeenCalledWith(
+        'https://chat.example.com/saml/saml-add-E'
+      );
+    });
+
+    it('keeps using the resumeToken path for an unrecognized auth type', async () => {
+      setupDeepLinks();
+
+      resolveServerUrlMock.mockResolvedValue([
+        'https://chat.example.com',
+        ServerUrlResolutionStatus.OK,
+        undefined,
+      ] as any);
+      selectMock.mockReturnValue([
+        { url: 'https://chat.example.com', title: 'Chat' },
+      ]);
+
+      await runSamlDeepLink(
+        'rocketchat://auth?type=whatever&host=https://chat.example.com&token=abc&userId=123'
+      );
+
+      expect(mockWebContents.loadURL).toHaveBeenCalledWith(
+        'https://chat.example.com/home?resumeToken=abc&userId=123'
+      );
+    });
+
     it('processes rocketchat://room link when host and path are valid', async () => {
       setupDeepLinks();
 

--- a/src/deepLinks/main.ts
+++ b/src/deepLinks/main.ts
@@ -85,6 +85,11 @@ type AuthenticationParams = {
   userId: string;
 };
 
+type SamlAuthenticationParams = {
+  host: string;
+  credentialToken: string;
+};
+
 type OpenRoomParams = {
   host: string;
   path?: string;
@@ -177,6 +182,21 @@ const performAuthentication = async ({
     webContents.loadURL(url.href);
   });
 
+const performSamlAuthentication = async ({
+  host,
+  credentialToken,
+}: SamlAuthenticationParams): Promise<void> => {
+  return performOnServer(host, async (serverUrl) => {
+    const url = new URL(
+      `saml/${encodeURIComponent(credentialToken)}`,
+      serverUrl
+    );
+
+    const webContents = await getWebContents(serverUrl);
+    webContents.loadURL(url.href);
+  });
+};
+
 // https://developer.rocket.chat/rocket.chat/deeplink#channel-group-dm
 const performOpenRoom = async ({
   host,
@@ -219,6 +239,24 @@ const performConference = async ({ host, path }: InviteParams): Promise<void> =>
     webContents.loadURL(new URL(path, serverUrl).href);
   });
 
+const performAuthDeepLink = async (args: URLSearchParams): Promise<void> => {
+  const host = args.get('host') ?? undefined;
+
+  if (args.get('type') === 'saml') {
+    const credentialToken = args.get('credentialToken') ?? undefined;
+    if (host && credentialToken) {
+      await performSamlAuthentication({ host, credentialToken });
+    }
+    return;
+  }
+
+  const token = args.get('token') ?? undefined;
+  const userId = args.get('userId') ?? undefined;
+  if (host && token && userId) {
+    await performAuthentication({ host, token, userId });
+  }
+};
+
 const processDeepLink = async (deepLink: string): Promise<void> => {
   const telephonyLink = parseTelephonyLink(deepLink);
   if (telephonyLink) {
@@ -242,12 +280,7 @@ const processDeepLink = async (deepLink: string): Promise<void> => {
 
   switch (action) {
     case 'auth': {
-      const host = args.get('host') ?? undefined;
-      const token = args.get('token') ?? undefined;
-      const userId = args.get('userId') ?? undefined;
-      if (host && token && userId) {
-        await performAuthentication({ host, token, userId });
-      }
+      await performAuthDeepLink(args);
       break;
     }
 


### PR DESCRIPTION
<!--
INSTRUCTION: Your Pull Request name should start with one of the following
prefixes:

- "feat:" for new features;
- "fix:" for bug fixes.

INSTRUCTION: Target the `dev` branch, unless this PR is backporting a fix
to a `release/X.Y.x` patch line.
-->

Implements deeplink auth for SAML.

The web client passes the saml credential token in form of deeplink. The electron app parses the credential token and navigates the required host to `saml/token` path where web client is set to redeem the saml credential token.

<!-- Tell us more about your PR with screen shots if you can -->
[CORE-2598](https://rocketchat.atlassian.net/browse/CORE-2598)


[CORE-2598]: https://rocketchat.atlassian.net/browse/CORE-2598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for SAML authentication through deep links.
  * Credential tokens can now be securely encoded in SAML links and redeemed automatically.
  * Added support for multiple authentication tokens and unknown server addresses.
  * Existing authentication links continue to use the standard resume flow when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->