### PR TITLE
fix: dedupe Windows notification quick replies (#3467)

### DIFF
--- a/src/notifications/main.ts
+++ b/src/notifications/main.ts
@@ -48,6 +48,7 @@ const resolveIcon = async (
 const notifications = new Map();
 const notificationTypes = new Map<string, 'voice' | 'text'>();
 const notificationCategories = new Map<string, 'DOWNLOADS' | 'SERVER'>();
+const repliedNotifications = new Set<string>();
 
 const createNotification = async (
   id: string,
@@ -79,6 +80,8 @@ const createNotification = async (
   });
 
   notification.addListener('show', () => {
+    repliedNotifications.delete(id);
+
     dispatchSingle({
       type: NOTIFICATIONS_NOTIFICATION_SHOWN,
       payload: { id },
@@ -126,6 +129,11 @@ const createNotification = async (
   });
 
   notification.addListener('reply', (_event, reply) => {
+    if (repliedNotifications.has(id)) {
+      return;
+    }
+    repliedNotifications.add(id);
+
     dispatchSingle({
       type: NOTIFICATIONS_NOTIFICATION_REPLIED,
       payload: { id, reply },

--- a/src/notifications/main/setup.main.spec.ts
+++ b/src/notifications/main/setup.main.spec.ts
@@ -121,6 +121,11 @@ describe('notifications/main setupNotifications', () => {
     });
   };
 
+  const repliedCalls = () =>
+    dispatchSingle.mock.calls.filter(
+      ([action]) => action.type === NOTIFICATIONS_NOTIFICATION_REPLIED
+    );
+
   it('creates a notification and wires show/click/close/reply/action', async () => {
     await create({
       title: 'Hello',
@@ -179,6 +184,35 @@ describe('notifications/main setupNotifications', () => {
     expect(dispatchSingle).toHaveBeenCalledWith(
       expect.objectContaining({ type: NOTIFICATIONS_NOTIFICATION_CLOSED })
     );
+  });
+
+  it('dispatches a duplicated reply event exactly once', async () => {
+    await create({ title: 'Hello', tag: 'reply-once' });
+
+    const notification = notificationInstances[0];
+    notification.emit('reply', {}, 'hi there');
+    notification.emit('reply', {}, 'hi there');
+
+    expect(repliedCalls()).toHaveLength(1);
+    expect(repliedCalls()[0][0].payload).toEqual({
+      id: 'reply-once',
+      reply: 'hi there',
+    });
+  });
+
+  it('accepts another reply after the notification is shown again', async () => {
+    await create({ title: 'Hello', tag: 'reply-again' });
+
+    const notification = notificationInstances[0];
+    notification.emit('reply', {}, 'first reply');
+    notification.emit('show');
+    notification.emit('reply', {}, 'second reply');
+
+    expect(repliedCalls()).toHaveLength(2);
+    expect(repliedCalls()[1][0].payload).toEqual({
+      id: 'reply-again',
+      reply: 'second reply',
+    });
   });
 
   it('draws attention for voice notifications', async () => {


### PR DESCRIPTION
Closes #3467

## Summary

This restores the notification reply deduplication introduced in #3420, which was included in 4.15.6 but was not forward-ported to `dev` and is therefore missing from 4.16.0.

On Windows, Electron can emit the `reply` event twice for a single notification quick reply, causing the message to be sent twice.

This PR:

- dispatches only the first reply event for a notification;
- resets the deduplication state when the notification is shown again;
- adds regression tests for duplicated reply events and subsequent valid replies.

## Screenshots

Not applicable; this change affects notification event handling only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate notification replies from being processed more than once.
  * Replies are accepted again when a notification is shown anew.

* **Tests**
  * Added coverage for duplicate reply handling and valid replies after a notification reappears.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
[SUP-1107]

[SUP-1107]: https://rocketchat.atlassian.net/browse/SUP-1107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ