### PR TITLE
fix: dedupe Windows notification quick replies (#3467)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,9 @@ yarn workspaces:build        # Build all workspaces
 - `release/X.Y.x` branches are patch lines for a shipped stable version.
   Fixes land on `dev` first and are cherry-picked onto the release branch.
   A hotfix authored directly on a release branch must be forward-ported to
-  `dev` immediately via a cherry-pick PR.
+  `dev` in the same change or immediately after (cherry-pick PR). Do not
+  ship a stable cut from `dev` that is missing a hotfix that already
+  shipped on a release line.
 - Never back-merge `master` or a `release/X.Y.x` branch into `dev`.
 - Tags are created only via `yarn release:tag` (channel-aware guard).
   Release builds trigger on semver tag pushes only and always produce a
@@ -134,6 +136,15 @@ yarn workspaces:build        # Build all workspaces
   color/animation tokens, read `docs/desktop-ui-guidelines.md` — token
   semantics and traps, Fuselage geometry/timing facts, the button-dimming and
   SVG transform-origin pitfalls, and layout rules learned in PRs #3441/#3443.
+
+## Desktop Notifications
+
+- Windows / Electron 42 can emit `reply` twice for one toast (WinRT + COM
+  activation paths). Guard `NOTIFICATIONS_NOTIFICATION_REPLIED` with a
+  per-notification `Set`; re-arm (delete the id) on `show`; never clear on
+  `close` — the duplicate can arrive after dismiss, and clearing there
+  reopens the race. If Windows replies are routed through
+  `Notification.handleActivation`, that path must use the same `Set`.
 
 ## Testing
 

--- a/src/notifications/main.ts
+++ b/src/notifications/main.ts
@@ -48,6 +48,7 @@ const resolveIcon = async (
 const notifications = new Map();
 const notificationTypes = new Map<string, 'voice' | 'text'>();
 const notificationCategories = new Map<string, 'DOWNLOADS' | 'SERVER'>();
+const repliedNotifications = new Set<string>();
 
 const createNotification = async (
   id: string,
@@ -79,6 +80,8 @@ const createNotification = async (
   });
 
   notification.addListener('show', () => {
+    repliedNotifications.delete(id);
+
     dispatchSingle({
       type: NOTIFICATIONS_NOTIFICATION_SHOWN,
       payload: { id },
@@ -126,6 +129,12 @@ const createNotification = async (
   });
 
   notification.addListener('reply', (_event, reply) => {
+    // Electron 42 on Windows can dispatch a single toast reply twice (WinRT+COM activation paths)
+    if (repliedNotifications.has(id)) {
+      return;
+    }
+    repliedNotifications.add(id);
+
     dispatchSingle({
       type: NOTIFICATIONS_NOTIFICATION_REPLIED,
       payload: { id, reply },

--- a/src/notifications/main/setup.main.spec.ts
+++ b/src/notifications/main/setup.main.spec.ts
@@ -233,4 +233,68 @@ describe('notifications/main setupNotifications', () => {
     expect(dispatch).not.toHaveBeenCalled();
     expect(notificationInstances).toHaveLength(0);
   });
+
+  const repliedCalls = () =>
+    dispatchSingle.mock.calls.filter(
+      ([action]) => action.type === NOTIFICATIONS_NOTIFICATION_REPLIED
+    );
+
+  it('dispatches REPLIED exactly once when the same reply event fires twice', async () => {
+    await create({
+      title: 'Hello',
+      body: 'World',
+      tag: 'dedup-1',
+      canReply: true,
+    });
+    const n = notificationInstances[0];
+
+    n.emit('reply', {}, 'hi there');
+    n.emit('reply', {}, 'hi there');
+
+    expect(repliedCalls()).toHaveLength(1);
+    expect(repliedCalls()[0][0].payload).toEqual({
+      id: 'dedup-1',
+      reply: 'hi there',
+    });
+  });
+
+  it('re-arms the guard after another show event, allowing a subsequent reply to dispatch', async () => {
+    await create({
+      title: 'Hello',
+      body: 'World',
+      tag: 'dedup-2',
+      canReply: true,
+    });
+    const n = notificationInstances[0];
+
+    n.emit('reply', {}, 'first reply');
+    n.emit('show');
+    n.emit('reply', {}, 'second reply');
+
+    expect(repliedCalls()).toHaveLength(2);
+    expect(repliedCalls()[1][0].payload).toEqual({
+      id: 'dedup-2',
+      reply: 'second reply',
+    });
+  });
+
+  it('does not re-arm the reply guard on close (duplicate can arrive after dismiss)', async () => {
+    await create({
+      title: 'Hello',
+      body: 'World',
+      tag: 'dedup-3',
+      canReply: true,
+    });
+    const n = notificationInstances[0];
+
+    n.emit('reply', {}, 'once');
+    n.emit('close');
+    n.emit('reply', {}, 'late duplicate');
+
+    expect(repliedCalls()).toHaveLength(1);
+    expect(repliedCalls()[0][0].payload).toEqual({
+      id: 'dedup-3',
+      reply: 'once',
+    });
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3467

## What

Windows notification quick-reply was sending the message twice on 4.16.0 / `dev`. This forward-ports the fix from #3420 (`b62b165` on `hotfix/4.15.6`) onto `dev` with the same semantics.

Thanks to **@Moku151** for reporting the 4.16.0 regression in #3467 and for opening #3468. That PR correctly identified the missing forward-port; this PR is Jean’s own port of #3420 rather than a merge of #3468 (third-party forward-port of the same code).

## Why

The 4.15.6 hotfix landed the `repliedNotifications` Set guard, but it was not forward-ported to `dev`, so 4.16.0 shipped without it. Electron 42 on Windows can emit `reply` twice for one toast (WinRT + COM activation paths).

## How

Same semantics as #3420:

- Guard `NOTIFICATIONS_NOTIFICATION_REPLIED` with a per-notification `repliedNotifications` Set
- Re-arm (delete the id) on `show`
- **Never** clear on `close` — the duplicate can arrive after dismiss; clearing there reopens the race (ignore CodeRabbit advice to clear on close)
- Regression specs in `src/notifications/main/setup.main.spec.ts`: duplicate reply dispatches once; later `show` then reply is accepted; `close` does not re-arm
- `AGENTS.md`: documents the reply-dedup constraint (and that a future `handleActivation` path must use the same Set) plus the hotfix → `dev` forward-port rule

Out of scope: CORE-2571, SUP-1097, and the broader Action Center / `handleActivation` work in #3464.

## Testing

```
yarn test --testPathPattern='src/notifications/main/setup.main.spec'
```

8 passed (including the three new reply-dedup cases).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de4ac723-d3ac-4fbd-ad8c-a763aa8fe485?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de4ac723-d3ac-4fbd-ad8c-a763aa8fe485&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate notification reply events from being processed.
  * Reply handling now resets when a notification is shown again, while closing a notification does not re-enable duplicate replies.

* **Tests**
  * Added coverage for repeated replies, notification re-display, and close behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->