### PR TITLE
fix(tray): hide presence status when the active server failed to load

### DIFF
--- a/src/ui/__tests__/selectors.spec.ts
+++ b/src/ui/__tests__/selectors.spec.ts
@@ -81,4 +81,19 @@ describe('ui/selectors', () => {
 
     expect(selectActiveServerPresence(rootState).connection).toBe('connected');
   });
+
+  it('passes through the failed flag from the active server', () => {
+    const rootState = {
+      servers: [
+        {
+          url: 'https://server.test',
+          title: 'Server',
+          failed: true,
+        },
+      ],
+      currentView: { url: 'https://server.test' },
+    } as unknown as RootState;
+
+    expect(selectActiveServerPresence(rootState).failed).toBe(true);
+  });
 });

--- a/src/ui/__tests__/selectors.spec.ts
+++ b/src/ui/__tests__/selectors.spec.ts
@@ -96,4 +96,23 @@ describe('ui/selectors', () => {
 
     expect(selectActiveServerPresence(rootState).failed).toBe(true);
   });
+
+  it('flags isAddingServer when the current view is the add-workspace screen, even with existing servers', () => {
+    const rootState = {
+      servers: [{ url: 'https://server.test', title: 'Server' }],
+      currentView: 'add-new-server',
+    } as unknown as RootState;
+
+    expect(selectActiveServerPresence(rootState).isAddingServer).toBe(true);
+    expect(selectActiveServerPresence(rootState).hasServers).toBe(true);
+  });
+
+  it('does not flag isAddingServer when a server is selected', () => {
+    const rootState = {
+      servers: [{ url: 'https://server.test', title: 'Server' }],
+      currentView: { url: 'https://server.test' },
+    } as unknown as RootState;
+
+    expect(selectActiveServerPresence(rootState).isAddingServer).toBe(false);
+  });
 });

--- a/src/ui/main/trayIcon.ts
+++ b/src/ui/main/trayIcon.ts
@@ -75,6 +75,7 @@ const buildPresenceMenuItems = (
     connection,
     supported,
     loggedIn,
+    failed,
     hasServers,
   } = activeServerPresence;
 
@@ -106,7 +107,7 @@ const buildPresenceMenuItems = (
     ];
   }
 
-  if (supported === false) {
+  if (supported === false || failed) {
     return [];
   }
 

--- a/src/ui/main/trayIcon.ts
+++ b/src/ui/main/trayIcon.ts
@@ -77,9 +77,10 @@ const buildPresenceMenuItems = (
     loggedIn,
     failed,
     hasServers,
+    isAddingServer,
   } = activeServerPresence;
 
-  if (!hasServers) {
+  if (!hasServers || isAddingServer) {
     return [
       {
         label: t('tray.presence.addWorkspace'),

--- a/src/ui/main/trayIconMenu.main.spec.ts
+++ b/src/ui/main/trayIconMenu.main.spec.ts
@@ -60,6 +60,7 @@ type ActiveServerPresence = {
   loggedIn?: boolean;
   failed?: boolean;
   hasServers: boolean;
+  isAddingServer?: boolean;
 };
 
 const baseState = (
@@ -294,6 +295,24 @@ describe('ui/main/trayIcon buildMenuTemplate', () => {
 
   it('shows an Add workspace item and no radios when there are no servers', () => {
     const template = buildMenuTemplate(baseState({ hasServers: false }));
+
+    const radios = template.filter((item) => item.type === 'radio');
+    expect(radios).toHaveLength(0);
+    expect(findItem(template, 'tray.presence.addWorkspace')).toBeDefined();
+  });
+
+  it('shows an Add workspace item and no radios when on the add-workspace screen with existing servers', () => {
+    const template = buildMenuTemplate(
+      baseState({
+        hasServers: true,
+        isAddingServer: true,
+        url: 'https://server.test',
+        presence: 'online',
+        connection: 'connected',
+        loggedIn: true,
+        supported: true,
+      })
+    );
 
     const radios = template.filter((item) => item.type === 'radio');
     expect(radios).toHaveLength(0);

--- a/src/ui/main/trayIconMenu.main.spec.ts
+++ b/src/ui/main/trayIconMenu.main.spec.ts
@@ -58,6 +58,7 @@ type ActiveServerPresence = {
   connection?: 'connected' | 'connecting' | 'disconnected';
   supported?: boolean;
   loggedIn?: boolean;
+  failed?: boolean;
   hasServers: boolean;
 };
 
@@ -309,6 +310,29 @@ describe('ui/main/trayIcon buildMenuTemplate', () => {
         connection: 'connected',
         loggedIn: true,
         supported: false,
+      })
+    );
+
+    const radios = template.filter((item) => item.type === 'radio');
+    expect(radios).toHaveLength(0);
+    expect(template.some((item) => item.label === 'Some status')).toBe(false);
+    expect(findItem(template, 'tray.presence.signIn')).toBeUndefined();
+    expect(findItem(template, 'tray.presence.addWorkspace')).toBeUndefined();
+    expect(findItem(template, 'tray.menu.hide')).toBeDefined();
+    expect(findItem(template, 'tray.menu.quit')).toBeDefined();
+  });
+
+  it('hides presence items entirely when the active server failed to load', () => {
+    const template = buildMenuTemplate(
+      baseState({
+        hasServers: true,
+        url: 'https://server.test',
+        presence: 'online',
+        statusText: 'Some status',
+        connection: 'connected',
+        loggedIn: true,
+        supported: true,
+        failed: true,
       })
     );
 

--- a/src/ui/main/trayIconMenu.main.spec.ts
+++ b/src/ui/main/trayIconMenu.main.spec.ts
@@ -355,6 +355,7 @@ describe('ui/main/trayIcon buildMenuTemplate', () => {
       })
     );
 
+    expect(findPresenceRootItem(template)).toBeUndefined();
     const radios = template.filter((item) => item.type === 'radio');
     expect(radios).toHaveLength(0);
     expect(template.some((item) => item.label === 'Some status')).toBe(false);

--- a/src/ui/selectors.ts
+++ b/src/ui/selectors.ts
@@ -52,6 +52,7 @@ export type ActiveServerPresence = {
   connection?: 'connected' | 'connecting' | 'disconnected';
   supported?: boolean;
   loggedIn?: boolean;
+  failed?: boolean;
   hasServers: boolean;
 };
 
@@ -98,6 +99,7 @@ export const selectActiveServerPresence = createSelector(
         : activeServer.presenceConnection,
       supported: activeServer.presenceSupported,
       loggedIn: activeServer.userLoggedIn,
+      failed: activeServer.failed,
       hasServers,
     };
   }

--- a/src/ui/selectors.ts
+++ b/src/ui/selectors.ts
@@ -54,6 +54,7 @@ export type ActiveServerPresence = {
   loggedIn?: boolean;
   failed?: boolean;
   hasServers: boolean;
+  isAddingServer: boolean;
 };
 
 const toHref = (url: string): string => {
@@ -75,9 +76,10 @@ export const selectActiveServerPresence = createSelector(
     isPresenceDisconnectionSimulated
   ): ActiveServerPresence => {
     const hasServers = servers.length > 0;
+    const isAddingServer = currentView === 'add-new-server';
 
     if (typeof currentView !== 'object' || !currentView.url) {
-      return { hasServers };
+      return { hasServers, isAddingServer };
     }
 
     const currentViewHref = toHref(currentView.url);
@@ -86,7 +88,7 @@ export const selectActiveServerPresence = createSelector(
     );
 
     if (!activeServer) {
-      return { hasServers };
+      return { hasServers, isAddingServer };
     }
 
     return {
@@ -101,6 +103,7 @@ export const selectActiveServerPresence = createSelector(
       loggedIn: activeServer.userLoggedIn,
       failed: activeServer.failed,
       hasServers,
+      isAddingServer,
     };
   }
 );


### PR DESCRIPTION
## Summary
- The tray Status submenu (Online/Away/Busy/Offline) stayed fully visible and clickable even after the active server hit a navigation failure (`server.failed`), so selecting a status silently no-oped against a broken workspace. `selectActiveServerPresence` now passes `failed` through, and `buildPresenceMenuItems` hides the Status item on `failed`, matching the existing unsupported-version behavior.
- The tray only offered "Add workspace" when there were zero servers configured, so it showed nothing while the user was actively on the add-workspace screen with existing workspaces (e.g. after removing the active server, or clicking "+ Add workspace"). `isAddingServer` is now threaded through the same selector, and the tray shows "Add workspace" in that case too.

Reported by Ivan Netto (QA on CORE-2525): a workspace stuck on a broken/invalid page still showed the presence Status menu as available, unlike a workspace where the user is simply logged out (which correctly shows "Sign in to...").

Ref: [CORE-2525](https://rocketchat.atlassian.net/browse/CORE-2525)

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on changed files
- [x] `yarn test --runTestsByPath src/ui/main/trayIconMenu.main.spec.ts src/ui/__tests__/selectors.spec.ts` — 26/26 passing, including 5 new cases covering the `failed` and `isAddingServer` guards

[CORE-2525]: https://rocketchat.atlassian.net/browse/CORE-2525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Presence options are now hidden in the tray menu when the active workspace fails to load or is unsupported.
  * The tray menu shows only the Add workspace option while adding a workspace.
  * Essential tray actions, including Show/Hide and Quit, remain available during workspace loading failures.

* **Tests**
  * Added coverage for failed workspaces, add-workspace mode, and tray menu behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->