### PR TITLE
chore: bump version to 4.17.0-alpha.2

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -18,7 +18,7 @@
     "category": "public.app-category.productivity",
     "target": ["dmg", "pkg", "zip", "mas"],
     "icon": "build/icon.icns",
-    "bundleVersion": "26081",
+    "bundleVersion": "26082",
     "helperBundleId": "chat.rocket.electron.helper",
     "type": "distribution",
     "artifactName": "rocketchat-${version}-${os}.${ext}",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "Rocket.Chat",
   "name": "rocketchat",
   "description": "Official OSX, Windows, and Linux Desktop Clients for Rocket.Chat",
-  "version": "4.17.0-alpha.1",
+  "version": "4.17.0-alpha.2",
   "author": "Rocket.Chat Support <support@rocket.chat>",
   "copyright": "© 2016-2026, Rocket.Chat",
   "homepage": "https://rocket.chat",


### PR DESCRIPTION
## Shipped since 4.17.0-alpha.1

- feat(tray): show workspace presence status in the tray icon and menu (#3466)
- fix: dedupe Windows notification quick replies (#3468)
- fix: Windows notification quick replies lost after toast dismissal (#3464)
- fix(tray): hide presence status when the active server failed to load (#3472)

## Version bump

- `package.json`: 4.17.0-alpha.1 → 4.17.0-alpha.2
- `electron-builder.json` `mac.bundleVersion`: 26081 → 26082

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s macOS build version.
  * Incremented the package version to the next alpha release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->