### PR TITLE
chore: bump version to 4.17.0-alpha.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "Rocket.Chat",
   "name": "rocketchat",
   "description": "Official OSX, Windows, and Linux Desktop Clients for Rocket.Chat",
-  "version": "4.17.0-alpha.2",
+  "version": "4.17.0-alpha.3",
   "author": "Rocket.Chat Support <support@rocket.chat>",
   "copyright": "© 2016-2026, Rocket.Chat",
   "homepage": "https://rocket.chat",


### PR DESCRIPTION
Alpha release 4.17.0-alpha.3 from dev.

## Changes since 4.17.0-alpha.2

### 🐛 Fixes
- fix(updates): install macOS updates through electron-updater (#955) (#3431)
- fix(updates): make Check for updates work on store builds (Mac App Store, Microsoft Store, Snap, Flathub) (#3460)
- fix: keep macOS native fullscreen when pressing ESC (#3433)

### ✨ Improvements
- feat(logViewer): correctness, performance, and UX improvements (#3446)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package to version `4.17.0-alpha.3`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->