### PR TITLE
fix(navigation): intercept external markdown links and isolate subpath workspace navigation

### DIFF
--- a/src/ui/main/serverView/index.spec.ts
+++ b/src/ui/main/serverView/index.spec.ts
@@ -87,9 +87,7 @@ describe('serverView attachGuestWebContentsEvents will-navigate guard', () => {
     const webviewReadyCall = mockListen.mock.calls.find(
       ([actionType]) => actionType === WEBVIEW_READY
     );
-    webviewReadyCallback = webviewReadyCall?.[1] as (
-      action: unknown
-    ) => void;
+    webviewReadyCallback = webviewReadyCall?.[1] as (action: unknown) => void;
 
     const guestWebContents = {
       addListener: jest.fn(),
@@ -115,6 +113,9 @@ describe('serverView attachGuestWebContentsEvents will-navigate guard', () => {
     ({ preventDefault: jest.fn() }) as unknown as Event;
 
   it('allows same-origin http navigation', () => {
+    webviewReadyCallback({
+      payload: { webContentsId: 1, url: 'http://open.rocket.chat' },
+    });
     const event = createEvent();
     willNavigateHandler(event, 'http://open.rocket.chat/page');
     expect(event.preventDefault).not.toHaveBeenCalled();
@@ -208,7 +209,10 @@ describe('serverView attachGuestWebContentsEvents will-navigate guard', () => {
 
     it('allows navigation within the workspace subpath', () => {
       const event = createEvent();
-      willNavigateHandler(event, 'https://company.org/rocketchat/channel/general');
+      willNavigateHandler(
+        event,
+        'https://company.org/rocketchat/channel/general'
+      );
       expect(event.preventDefault).not.toHaveBeenCalled();
     });
 
@@ -225,6 +229,25 @@ describe('serverView attachGuestWebContentsEvents will-navigate guard', () => {
       );
       expect(mockOpenExternal).toHaveBeenCalledWith(
         'https://company.org/wiki/page'
+      );
+    });
+
+    it('intercepts and opens links when protocol does not match (http vs https)', async () => {
+      const event = createEvent();
+      willNavigateHandler(
+        event,
+        'http://company.org/rocketchat/channel/general'
+      );
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockIsProtocolAllowed).toHaveBeenCalledWith(
+        'http://company.org/rocketchat/channel/general'
+      );
+      expect(mockOpenExternal).toHaveBeenCalledWith(
+        'http://company.org/rocketchat/channel/general'
       );
     });
   });

--- a/src/ui/main/serverView/index.spec.ts
+++ b/src/ui/main/serverView/index.spec.ts
@@ -76,6 +76,7 @@ describe('serverView attachGuestWebContentsEvents will-navigate guard', () => {
   const mockListen = listen as unknown as jest.Mock;
 
   let willNavigateHandler: (event: Event, url: string) => void;
+  let webviewReadyCallback: (action: unknown) => void;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -86,7 +87,7 @@ describe('serverView attachGuestWebContentsEvents will-navigate guard', () => {
     const webviewReadyCall = mockListen.mock.calls.find(
       ([actionType]) => actionType === WEBVIEW_READY
     );
-    const webviewReadyCallback = webviewReadyCall?.[1] as (
+    webviewReadyCallback = webviewReadyCall?.[1] as (
       action: unknown
     ) => void;
 
@@ -113,28 +114,45 @@ describe('serverView attachGuestWebContentsEvents will-navigate guard', () => {
   const createEvent = (): Event =>
     ({ preventDefault: jest.fn() }) as unknown as Event;
 
-  it('allows http navigation', () => {
+  it('allows same-origin http navigation', () => {
     const event = createEvent();
     willNavigateHandler(event, 'http://open.rocket.chat/page');
     expect(event.preventDefault).not.toHaveBeenCalled();
   });
 
-  it('allows https navigation', () => {
+  it('allows same-origin https navigation', () => {
     const event = createEvent();
     willNavigateHandler(event, 'https://open.rocket.chat/page');
     expect(event.preventDefault).not.toHaveBeenCalled();
   });
 
-  it('denies file:// navigation', () => {
+  it('denies file:// navigation and does not open externally', async () => {
+    mockIsProtocolAllowed.mockResolvedValueOnce(false);
     const event = createEvent();
     willNavigateHandler(event, 'file:///etc/passwd');
     expect(event.preventDefault).toHaveBeenCalled();
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockIsProtocolAllowed).toHaveBeenCalledWith('file:///etc/passwd');
+    expect(mockOpenExternal).not.toHaveBeenCalled();
   });
 
-  it('denies navigation to an unknown/custom scheme', () => {
+  it('prevents in-app navigation and opens external markdown links externally when allowed', async () => {
     const event = createEvent();
-    willNavigateHandler(event, 'custom-scheme://payload');
+    willNavigateHandler(event, 'https://github.com/RocketChat');
+
     expect(event.preventDefault).toHaveBeenCalled();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockIsProtocolAllowed).toHaveBeenCalledWith(
+      'https://github.com/RocketChat'
+    );
+    expect(mockOpenExternal).toHaveBeenCalledWith(
+      'https://github.com/RocketChat'
+    );
   });
 
   it('still prevents and opens t.co links externally when allowed', async () => {
@@ -149,7 +167,7 @@ describe('serverView attachGuestWebContentsEvents will-navigate guard', () => {
     expect(mockOpenExternal).toHaveBeenCalledWith('https://t.co/abc123');
   });
 
-  it('does not open externally when protocol is not allowed for t.co links', async () => {
+  it('does not open externally when protocol is not allowed for external links', async () => {
     mockIsProtocolAllowed.mockResolvedValueOnce(false);
     const event = createEvent();
     willNavigateHandler(event, 'https://twitter.com/some/status');
@@ -159,6 +177,56 @@ describe('serverView attachGuestWebContentsEvents will-navigate guard', () => {
     await Promise.resolve();
 
     expect(mockOpenExternal).not.toHaveBeenCalled();
+  });
+
+  it('prevents navigation and opens allowed custom schemes externally (e.g. mailto:)', async () => {
+    const event = createEvent();
+    willNavigateHandler(event, 'mailto:support@rocket.chat');
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockIsProtocolAllowed).toHaveBeenCalledWith(
+      'mailto:support@rocket.chat'
+    );
+    expect(mockOpenExternal).toHaveBeenCalledWith('mailto:support@rocket.chat');
+  });
+
+  it('safely handles invalid URLs', () => {
+    const event = createEvent();
+    willNavigateHandler(event, 'not-a-valid-url');
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  describe('subpath-hosted workspace handling', () => {
+    beforeEach(() => {
+      webviewReadyCallback({
+        payload: { webContentsId: 1, url: 'https://company.org/rocketchat/' },
+      });
+    });
+
+    it('allows navigation within the workspace subpath', () => {
+      const event = createEvent();
+      willNavigateHandler(event, 'https://company.org/rocketchat/channel/general');
+      expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('intercepts and opens external same-domain paths outside the workspace subpath', async () => {
+      const event = createEvent();
+      willNavigateHandler(event, 'https://company.org/wiki/page');
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockIsProtocolAllowed).toHaveBeenCalledWith(
+        'https://company.org/wiki/page'
+      );
+      expect(mockOpenExternal).toHaveBeenCalledWith(
+        'https://company.org/wiki/page'
+      );
+    });
   });
 });
 

--- a/src/ui/main/serverView/index.ts
+++ b/src/ui/main/serverView/index.ts
@@ -587,6 +587,7 @@ export const attachGuestWebContentsEvents = async (): Promise<void> => {
         pathname.endsWith('/') ? pathname : `${pathname}/`;
 
       const isSameServer =
+        targetUrl.protocol === serverUrl.protocol &&
         targetUrl.hostname === serverUrl.hostname &&
         targetUrl.port === serverUrl.port &&
         normalizePath(targetUrl.pathname).startsWith(

--- a/src/ui/main/serverView/index.ts
+++ b/src/ui/main/serverView/index.ts
@@ -558,18 +558,42 @@ export const attachGuestWebContentsEvents = async (): Promise<void> => {
     // Download handling is now managed by electron-dl in main.ts
     // and integrated with our downloads system via setupDownloads()
 
-    // prevents the webview from navigating because of twitter preview links
+    // Intercept external links (e.g. Markdown links in topic or messages) and open them externally
     guestWebContents.on('will-navigate', (e, redirectUrl) => {
-      const { protocol, hostname } = new URL(redirectUrl);
+      let targetUrl: URL;
+      let serverUrl: URL;
 
-      if (protocol !== 'http:' && protocol !== 'https:') {
+      try {
+        targetUrl = new URL(redirectUrl);
+        serverUrl = new URL(action.payload.url);
+      } catch {
         e.preventDefault();
         return;
       }
 
-      const preventNavigateHosts = ['t.co', 'twitter.com'];
+      if (targetUrl.protocol !== 'http:' && targetUrl.protocol !== 'https:') {
+        e.preventDefault();
+        isProtocolAllowed(redirectUrl).then((allowed) => {
+          if (!allowed) {
+            return;
+          }
 
-      if (preventNavigateHosts.includes(hostname)) {
+          openExternal(redirectUrl);
+        });
+        return;
+      }
+
+      const normalizePath = (pathname: string): string =>
+        pathname.endsWith('/') ? pathname : `${pathname}/`;
+
+      const isSameServer =
+        targetUrl.hostname === serverUrl.hostname &&
+        targetUrl.port === serverUrl.port &&
+        normalizePath(targetUrl.pathname).startsWith(
+          normalizePath(serverUrl.pathname)
+        );
+
+      if (!isSameServer) {
         e.preventDefault();
         isProtocolAllowed(redirectUrl).then((allowed) => {
           if (!allowed) {


### PR DESCRIPTION
<!-- Inform the issue number that this PR closes, or remove the line below -->
Closes #2838

---

### 📋 Overview & Motivation

In the Rocket.Chat Desktop client, markdown links rendered inside channel/team topics (or message banners) render as regular anchor `<a>` tags without `target="_blank"`. When clicked, these links bypass Electron's `setWindowOpenHandler` and trigger the guest webview's `will-navigate` lifecycle event.

Previously, `will-navigate` in `src/ui/main/serverView/index.ts` only intercepted a hardcoded list of external hosts (`t.co` and `twitter.com`). Consequently:
1. **External Markdown Links Were Broken (#2838)**: Clicking any general external link (e.g. `https://github.com`, `https://google.com`, or `mailto:` links) in channel headers was completely unresponsive or failed to open in the user's default browser.
2. **Subpath Deployment Navigation Hijacking**: On instances deployed under a subpath (e.g. `https://company.org/rocketchat/`), links pointing to other paths on the same domain (e.g. `https://company.org/wiki` or `https://company.org/jira`) were treated as internal, navigating the server webview away from Rocket.Chat and trapping the user on the foreign page with no back navigation controls.

This PR establishes a robust, dynamic navigation interceptor in `will-navigate` that opens all external links in the default browser while preserving same-workspace routing.

---

### 🔍 Technical Root Cause Analysis

#### 1. Static Host Interception
In `src/ui/main/serverView/index.ts`, `will-navigate` previously checked:
```typescript
const preventNavigateHosts = ['t.co', 'twitter.com'];
if (preventNavigateHosts.includes(hostname)) {
  e.preventDefault();
  isProtocolAllowed(redirectUrl).then((allowed) => {
    if (allowed) openExternal(redirectUrl);
  });
}
```
Any URL outside `t.co` and `twitter.com` was ignored, neither launching in the external browser nor routed properly by the guest webview.

#### 2. Path Isolation on Subpath-Hosted Deployments
When checking whether a navigation belongs to the current server, checking only `hostname` and `port` allows external same-domain paths (such as `/wiki` or `/dashboard`) to navigate the internal webview, leaking origin permissions and causing `injected.ts` script failures.

---

### 🛠️ Key Changes & Implementation Details

1. **Dynamic Origin & Path Boundary Verification**:
   - Extracted `serverUrl` from the workspace definition (`action.payload.url`).
   - Compared `targetUrl.hostname`, `targetUrl.port`, and verified `normalizePath(targetUrl.pathname).startsWith(normalizePath(serverUrl.pathname))`.

2. **External Link Delegation**:
   - For all URLs outside the workspace boundary, calls `e.preventDefault()`.
   - Validates the target URL with `isProtocolAllowed(redirectUrl)` (supporting `http:`, `https:`, `mailto:`, and user-permitted protocols).
   - Spawns the system default browser via `openExternal(redirectUrl)`.

3. **Safe Malformed URL Handling**:
   - Wrapped URL parsing in a `try / catch` block to intercept and safely deny malformed navigation strings without throwing unhandled exceptions.

4. **Non-HTTP Protocol Forwarding**:
   - Handled non-HTTP schemes (e.g. `mailto:`, custom protocols) by verifying permissions and delegating to the OS handler.

---

### 📂 Modified Files

- `src/ui/main/serverView/index.ts`: Replaced static host filtering with origin and subpath boundary checking.
- `src/ui/main/serverView/index.spec.ts`: Added unit tests covering same-origin navigation, external link delegation, custom protocols, invalid URLs, and subpath-hosted workspaces.

---

### 🧪 Test Coverage & Verification

All 19 test cases in `src/ui/main/serverView/index.spec.ts` are passing:

```bash
PASS src/ui/main/serverView/index.spec.ts
  serverView attachGuestWebContentsEvents will-navigate guard
    ✓ allows same-origin http navigation (5 ms)
    ✓ allows same-origin https navigation (1 ms)
    ✓ denies file:// navigation and does not open externally (2 ms)
    ✓ prevents in-app navigation and opens external markdown links externally when allowed (1 ms)
    ✓ still prevents and opens t.co links externally when allowed (1 ms)
    ✓ does not open externally when protocol is not allowed for external links (1 ms)
    ✓ prevents navigation and opens allowed custom schemes externally (e.g. mailto:) (1 ms)
    ✓ safely handles invalid URLs (1 ms)
    subpath-hosted workspace handling
      ✓ allows navigation within the workspace subpath (1 ms)
      ✓ intercepts and opens external same-domain paths outside the workspace subpath (1 ms)
  serverView before-input-event fullscreen handling
    ✓ exits only the HTML5 fullscreen when Escape is pressed while a video is fullscreen (1 ms)
    ✓ swallows auto-repeated Escapes in HTML5 fullscreen without re-running the exit (1 ms)
    ✓ replays Escape into the guest instead of letting it reach the native window (84 ms)
    ✓ forwards the replayed Escape to the root window (1 ms)
    ✓ forwards Escape untouched when the window is not in fullscreen (1 ms)
    ✓ does not forward the Escape key up to the root window
    ✓ keeps forwarding both key down and key up of the shortcut key (1 ms)
    ✓ leaves HTML5 fullscreen to Chromium on other platforms (1 ms)
    ✓ leaves Escape alone on other platforms (1 ms)

Test Suites: 1 passed, 1 total
Tests:       19 passed, 19 total
```

---

### 🔬 How to Test Manually

1. **Channel Topic Markdown Link**:
   - Set a channel topic to `[GitHub](https://github.com/RocketChat)`.
   - Click the link in the channel header topic.
   - **Result**: The link opens in your system default browser.
2. **Subpath-Hosted Workspace**:
   - Connect to a subpath workspace (e.g. `https://example.com/rocketchat/`).
   - Click a link pointing to `https://example.com/wiki`.
   - **Result**: The link opens in your system default browser rather than replacing the Rocket.Chat view.
3. **Internal Navigation**:
   - Click internal channel/thread links.
   - **Result**: Navigates normally within the Rocket.Chat app.

---

### 🛡️ Security & Compatibility Considerations

- **No Breaking Changes**: Standard workspace interactions and internal router paths remain unchanged.
- **Protocol Safety**: Custom and non-HTTP protocols continue to pass through `isProtocolAllowed()` prompts to prevent protocol-handler injection.
- **Origin Isolation**: Webview sessions remain strictly isolated to the workspace's subpath boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved navigation handling within server-hosted workspaces.
  - Same-server links remain in the workspace, including links under configured subpaths.
  - Links attempting to leave the server or workspace are safely intercepted and opened externally when permitted.
  - Improved handling for mail links, approved custom protocols, file links, invalid URLs, and external markdown links.
  - Navigation is now blocked when links use a different protocol or do not match the workspace server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->