### PR TITLE
fix: calculate download speed and ETA during active downloads

### DIFF
--- a/src/ui/components/DownloadsManagerView/DownloadItem.spec.tsx
+++ b/src/ui/components/DownloadsManagerView/DownloadItem.spec.tsx
@@ -95,6 +95,24 @@ describe('DownloadItem', () => {
 
       expect(invokeMock).toHaveBeenCalledWith('downloads/copy-link', 42);
     });
+
+    it('calculates and renders progressSpeed and estimatedTimeLeft when endTime is undefined', () => {
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1000);
+      try {
+        renderItem({
+          state: 'progressing',
+          receivedBytes: 500,
+          totalBytes: 1000,
+          startTime: 0,
+          endTime: undefined,
+        });
+
+        expect(screen.getByText('byteSpeed:500')).toBeInTheDocument();
+        expect(screen.getByText('duration:1')).toBeInTheDocument();
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
   });
 
   describe('paused state', () => {

--- a/src/ui/components/DownloadsManagerView/DownloadItem.spec.tsx
+++ b/src/ui/components/DownloadsManagerView/DownloadItem.spec.tsx
@@ -97,13 +97,13 @@ describe('DownloadItem', () => {
     });
 
     it('calculates and renders progressSpeed and estimatedTimeLeft when endTime is undefined', () => {
-      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1000);
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(2000);
       try {
         renderItem({
           state: 'progressing',
           receivedBytes: 500,
           totalBytes: 1000,
-          startTime: 0,
+          startTime: 1000,
           endTime: undefined,
         });
 

--- a/src/ui/components/DownloadsManagerView/DownloadItem.tsx
+++ b/src/ui/components/DownloadsManagerView/DownloadItem.tsx
@@ -50,14 +50,18 @@ const DownloadItem = ({
       !receivedBytes ||
       !totalBytes ||
       !startTime ||
-      !endTime ||
       state !== 'progressing'
     ) {
       return undefined;
     }
 
+    const elapsed = (endTime ?? Date.now()) - startTime;
+    if (elapsed <= 0) {
+      return undefined;
+    }
+
     return i18n.format(
-      (receivedBytes / (endTime - startTime)) * 1000,
+      (receivedBytes / elapsed) * 1000,
       'byteSpeed'
     );
   }, [endTime, i18n, receivedBytes, startTime, state, totalBytes]);
@@ -67,14 +71,22 @@ const DownloadItem = ({
       !receivedBytes ||
       !totalBytes ||
       !startTime ||
-      !endTime ||
       state !== 'progressing'
     ) {
       return undefined;
     }
 
+    const elapsed = (endTime ?? Date.now()) - startTime;
+    if (elapsed <= 0) {
+      return undefined;
+    }
+
     const remainingBytes = totalBytes - receivedBytes;
-    const speed = receivedBytes / (endTime - startTime);
+    const speed = receivedBytes / elapsed;
+    if (speed <= 0) {
+      return undefined;
+    }
+
     return i18n.format(remainingBytes / speed, 'duration');
   }, [endTime, i18n, receivedBytes, startTime, state, totalBytes]);
 

--- a/src/ui/components/DownloadsManagerView/DownloadItem.tsx
+++ b/src/ui/components/DownloadsManagerView/DownloadItem.tsx
@@ -60,10 +60,7 @@ const DownloadItem = ({
       return undefined;
     }
 
-    return i18n.format(
-      (receivedBytes / elapsed) * 1000,
-      'byteSpeed'
-    );
+    return i18n.format((receivedBytes / elapsed) * 1000, 'byteSpeed');
   }, [endTime, i18n, receivedBytes, startTime, state, totalBytes]);
 
   const estimatedTimeLeft = useMemo(() => {


### PR DESCRIPTION
## Proposed changes
Fixes an issue in `DownloadItem.tsx` where download speed and estimated time remaining were never calculated or displayed in the Downloads Manager during active downloads.

### Problem
Previously, both `progressSpeed` and `estimatedTimeLeft` hooks in `DownloadItem.tsx` required `!endTime` to be false (i.e. `endTime` defined) alongside `state === 'progressing'`. However, in Electron's download lifecycle, `endTime` is `undefined` until the download finishes or terminates. This created an impossible condition:
- While downloading (`state === 'progressing'`), `endTime` is `undefined`, so `!endTime` is `true` -> returns `undefined`.
- When completed (`state === 'completed'`), `endTime` is set, but `state !== 'progressing'` is `true` -> returns `undefined`.

As a result, download speed and remaining time were never displayed in the UI.

### Solution
- Calculate elapsed time dynamically using `(endTime ?? Date.now()) - startTime` during active progressing downloads.
- Added guard for `elapsed <= 0` to prevent division by zero.
- Added unit test in `DownloadItem.spec.tsx` verifying that `progressSpeed` and `estimatedTimeLeft` render when `endTime` is `undefined`.

Closes #3477

## Issue(s)
Closes #3477

## How to test or reproduce
1. Open the Downloads Manager.
2. Start downloading a file.
3. Observe that download speed (e.g. `1.2 MB/s`) and remaining duration (e.g. `15s`) now render live in the progress row next to the transferred byte size.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Download progress now displays transfer speed and estimated time remaining while a download is still in progress.
  * Improved progress calculations by using the current elapsed time when a download has not yet completed.
  * Prevented invalid speed and time-remaining estimates when no measurable time has elapsed.
  * Download progress information now remains accurate throughout active transfers, including early-progress states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->