### PR TITLE
chore: bump version to 4.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "Rocket.Chat",
   "name": "rocketchat",
   "description": "Official OSX, Windows, and Linux Desktop Clients for Rocket.Chat",
-  "version": "4.17.0-alpha.3",
+  "version": "4.17.0",
   "author": "Rocket.Chat Support <support@rocket.chat>",
   "copyright": "© 2016-2026, Rocket.Chat",
   "homepage": "https://rocket.chat",


### PR DESCRIPTION
Promotes 4.17.0-alpha.3 to stable 4.17.0 (drops the pre-release suffix, per docs/release-process.md).

Ships everything on dev since 4.16.0:

## Improvements
- Log viewer, downloads, settings and document viewer as separate windows on a shared native shell (#3444, #3446)
- SAML auth through deeplink (#3458)
- Workspace presence status in the tray icon and menu (#3466, #3472)

## Fixes
- Install macOS updates through electron-updater (#3431, closes #955)
- Check for updates on store builds — MAS, Microsoft Store, Snap, Flathub (#3460)
- Windows notification quick replies kept after toast dismissal (#3464) and deduplicated (#3468)

## Internal
- Release builds only on semver tags + PR checks for release lines (#3452, #3454)
- dev/master/release branching model docs (#3455, #3457)
- Test line coverage to 71.19% (#3429)

Excluded: #3433 (reverted in #3480, rework tracked in #3481).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Promoted the package from version 4.17.0-alpha.3 to the stable 4.17.0 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->