### PR TITLE
fix(video-call): open conference http(s) popups as sandboxed child windows (SUP-1108)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -340,6 +340,12 @@ git worktree add ../Rocket.Chat.Electron-worktrees/feature-name -b new-branch de
   Only include numbers from actual logs, error messages, or documented
   sources.
 - PR descriptions: straightforward language, focus on what changed and why.
+- PR descriptions and commit bodies are public. Do not include internal
+  references (Jira or Zoho Desk links and ticket text, customer names,
+  support conversations) or local developer tooling notes (GitNexus,
+  agent workflow, ledgers). A bare Jira key in the title or subject is
+  the accepted convention; everything else about the ticket stays
+  internal.
 
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence

--- a/docs/video-call-window-management.md
+++ b/docs/video-call-window-management.md
@@ -376,12 +376,15 @@ one used by the video call window's own host page) with the following policy:
 - **Everything else** (`javascript:`, `data:`, `file:`, `smb:`, etc.) is
   denied.
 
-Any popup spawned this way gets the same policy applied recursively via
-`did-create-window`. Both page-initiated navigations (`will-navigate`) and
-server-side redirects (`will-redirect`) go through the same protocol check,
-so a nested popup or an in-popup navigation/redirect can't escape the
-sandbox. The video call window's own host page is unaffected by this change
-and keeps routing all `http(s)` popups to the system browser.
+Any popup spawned this way gets the same policy re-applied to every
+descendant popup (a popup opened from a popup, and so on) via each window's
+own `did-create-window` registration. Both page-initiated navigations
+(`will-navigate`) and server-side redirects (`will-redirect`) go through the
+same protocol check: navigations/redirects to `http:`, `https:`, `file:`,
+`data:`, `about:`, or `blob:` proceed in place, and any other scheme is
+cancelled and, if the app's external-protocol check allows it, handed to the
+system browser. The video call window's own host page is unaffected by this
+change and keeps routing all `http(s)` popups to the system browser.
 
 ### Deferred React Import
 ```typescript

--- a/docs/video-call-window-management.md
+++ b/docs/video-call-window-management.md
@@ -355,6 +355,32 @@ webview.setAttribute('partition', 'persist:video-call-session'); // Generic part
 webview.src = url; // Set last - triggers loading
 ```
 
+### Conference Webview Popup Policy
+
+`allowpopups` alone is not enough to control what a conference page can spawn
+via `window.open` / `target="_blank"` — `src/videoCallWindow/ipc.ts` installs
+a `setWindowOpenHandler` on the attached conference webview (separate from the
+one used by the video call window's own host page) with the following policy:
+
+- **Tab-target links** (`disposition` `foreground-tab` / `background-tab`,
+  e.g. middle-click or ctrl-click) are sent to the system browser and the
+  Electron popup is denied.
+- **Plain `http(s)` popups** (default disposition) are allowed as sandboxed
+  Electron child windows (`nodeIntegration: false`, `contextIsolation: true`,
+  `sandbox: true`, no preload, hidden until `ready-to-show`). This is required
+  for identity-provider SSO login flows (e.g. Pexip's IdP popup), which rely
+  on `window.opener` to hand the result back to the conference page — routing
+  these to the system browser breaks that relationship.
+- **In-app popup schemes** (`about:`, `blob:`) are allowed as before, for
+  device pickers and transient blob/PDF exports.
+- **Everything else** (`javascript:`, `data:`, `file:`, `smb:`, etc.) is
+  denied.
+
+Any popup spawned this way gets the same policy applied recursively via
+`did-create-window`, so a nested popup or an in-popup navigation can't escape
+the sandbox. The video call window's own host page is unaffected by this
+change and keeps routing all `http(s)` popups to the system browser.
+
 ### Deferred React Import
 ```typescript
 let screenPickerModule: typeof import('./screenSharePickerMount') | null = null;

--- a/docs/video-call-window-management.md
+++ b/docs/video-call-window-management.md
@@ -377,9 +377,11 @@ one used by the video call window's own host page) with the following policy:
   denied.
 
 Any popup spawned this way gets the same policy applied recursively via
-`did-create-window`, so a nested popup or an in-popup navigation can't escape
-the sandbox. The video call window's own host page is unaffected by this
-change and keeps routing all `http(s)` popups to the system browser.
+`did-create-window`. Both page-initiated navigations (`will-navigate`) and
+server-side redirects (`will-redirect`) go through the same protocol check,
+so a nested popup or an in-popup navigation/redirect can't escape the
+sandbox. The video call window's own host page is unaffected by this change
+and keeps routing all `http(s)` popups to the system browser.
 
 ### Deferred React Import
 ```typescript

--- a/src/videoCallWindow/ipc.ts
+++ b/src/videoCallWindow/ipc.ts
@@ -322,6 +322,83 @@ const handleVideoCallWindowOpen = ({
   return { action: 'deny' };
 };
 
+// Window-open policy for the conference (guest) webview only. Unlike the host
+// page above, an http(s) popup here isn't always a plain external link — SSO
+// providers (e.g. Pexip's IdP login flow) rely on `window.open` handing
+// control back to the opener via `window.opener`, which only works if the
+// popup is a real (sandboxed) Electron child window. Tab-target links
+// (middle-click / ctrl-click) still go to the system browser; dangerous
+// schemes are still denied.
+type WindowOpenDetails = {
+  url: string;
+  disposition: string;
+};
+const handleConferenceWebviewWindowOpen = ({
+  url,
+  disposition,
+}: WindowOpenDetails):
+  | { action: 'deny' }
+  | {
+      action: 'allow';
+      overrideBrowserWindowOptions?: Electron.BrowserWindowConstructorOptions;
+    } => {
+  if (disposition === 'foreground-tab' || disposition === 'background-tab') {
+    isProtocolAllowed(url).then((allowed) => {
+      if (allowed) {
+        openExternal(url);
+      }
+    });
+    return { action: 'deny' };
+  }
+
+  if (url.startsWith('http://') || url.startsWith('https://')) {
+    return {
+      action: 'allow',
+      overrideBrowserWindowOptions: {
+        show: false,
+        autoHideMenuBar: true,
+        webPreferences: {
+          nodeIntegration: false,
+          contextIsolation: true,
+          sandbox: true,
+          webviewTag: false,
+        },
+      },
+    };
+  }
+
+  const lower = url.toLowerCase();
+  if (ALLOWED_POPUP_SCHEMES.some((scheme) => lower.startsWith(scheme))) {
+    return { action: 'allow' };
+  }
+  return { action: 'deny' };
+};
+
+// Shared by the conference webview's own `will-navigate` and any popup child
+// window it spawns: send external-protocol target="_self" navigations
+// (mailto:, tel:, custom schemes) to the browser; http(s)/file/data/about/blob
+// self-navigations stay in place so auth redirects and the conference's own
+// flows keep working.
+const handleConferenceWillNavigate = (event: Event, navUrl: string): void => {
+  try {
+    const { protocol } = new URL(navUrl);
+    if (
+      !['http:', 'https:', 'file:', 'data:', 'about:', 'blob:'].includes(
+        protocol
+      )
+    ) {
+      event.preventDefault();
+      isProtocolAllowed(navUrl).then((allowed) => {
+        if (allowed) {
+          openExternal(navUrl);
+        }
+      });
+    }
+  } catch {
+    // Ignore unparseable URLs.
+  }
+};
+
 const setupWebviewHandlers = (webContents: WebContents) => {
   // Track attached webviews that need handler setup
   const pendingWebviews: WebContents[] = [];
@@ -400,31 +477,29 @@ const setupWebviewHandlers = (webContents: WebContents) => {
     webviewWebContents: WebContents
   ): void => {
     // Route external links opened from the conference (target="_blank" /
-    // window.open) to the system browser instead of spawning a new Electron
-    // window, mirroring the main app window.
-    webviewWebContents.setWindowOpenHandler(handleVideoCallWindowOpen);
+    // window.open) to a sandboxed Electron popup window for plain http(s)
+    // (needed for SSO/IdP login flows such as Pexip, which rely on
+    // window.opener), and to the system browser for tab-target links and
+    // in-app popup schemes otherwise. See handleConferenceWebviewWindowOpen.
+    webviewWebContents.setWindowOpenHandler(handleConferenceWebviewWindowOpen);
 
     // Send external-protocol target="_self" navigations (mailto:, tel:, custom
     // schemes) to the browser too; http(s) self-navigations stay in the webview
     // so the conference's own flows (auth redirects, etc.) keep working.
-    webviewWebContents.on('will-navigate', (event: Event, navUrl: string) => {
-      try {
-        const { protocol } = new URL(navUrl);
-        if (
-          !['http:', 'https:', 'file:', 'data:', 'about:', 'blob:'].includes(
-            protocol
-          )
-        ) {
-          event.preventDefault();
-          isProtocolAllowed(navUrl).then((allowed) => {
-            if (allowed) {
-              openExternal(navUrl);
-            }
-          });
-        }
-      } catch {
-        // Ignore unparseable URLs.
-      }
+    webviewWebContents.on('will-navigate', handleConferenceWillNavigate);
+
+    // A guest-webview popup (e.g. an SSO/IdP login window) is created hidden
+    // to avoid a white flash, and its own popups/navigations must follow the
+    // same guest policy so a nested popup (or a redirect inside the popup)
+    // can't escape the sandbox.
+    webviewWebContents.on('did-create-window', (childWindow) => {
+      childWindow.once('ready-to-show', () => {
+        childWindow.show();
+      });
+      childWindow.webContents.setWindowOpenHandler(
+        handleConferenceWebviewWindowOpen
+      );
+      childWindow.webContents.on('will-navigate', handleConferenceWillNavigate);
     });
 
     // Media (mic/cam) permission requests from the conference originate in the

--- a/src/videoCallWindow/ipc.ts
+++ b/src/videoCallWindow/ipc.ts
@@ -374,11 +374,12 @@ const handleConferenceWebviewWindowOpen = ({
   return { action: 'deny' };
 };
 
-// Shared by the conference webview's own `will-navigate` and any popup child
-// window it spawns: send external-protocol target="_self" navigations
-// (mailto:, tel:, custom schemes) to the browser; http(s)/file/data/about/blob
-// self-navigations stay in place so auth redirects and the conference's own
-// flows keep working.
+// Shared by the conference webview's own `will-navigate`/`will-redirect` and
+// any popup child window it spawns: send external-protocol target="_self"
+// navigations (mailto:, tel:, custom schemes) — whether page-initiated
+// (`will-navigate`) or a server-side redirect (`will-redirect`) — to the
+// browser; http(s)/file/data/about/blob navigations stay in place so auth
+// redirects and the conference's own flows keep working.
 const handleConferenceWillNavigate = (event: Event, navUrl: string): void => {
   try {
     const { protocol } = new URL(navUrl);
@@ -487,6 +488,7 @@ const setupWebviewHandlers = (webContents: WebContents) => {
     // schemes) to the browser too; http(s) self-navigations stay in the webview
     // so the conference's own flows (auth redirects, etc.) keep working.
     webviewWebContents.on('will-navigate', handleConferenceWillNavigate);
+    webviewWebContents.on('will-redirect', handleConferenceWillNavigate);
 
     // A guest-webview popup (e.g. an SSO/IdP login window) is created hidden
     // to avoid a white flash, and its own popups/navigations must follow the
@@ -500,6 +502,7 @@ const setupWebviewHandlers = (webContents: WebContents) => {
         handleConferenceWebviewWindowOpen
       );
       childWindow.webContents.on('will-navigate', handleConferenceWillNavigate);
+      childWindow.webContents.on('will-redirect', handleConferenceWillNavigate);
     });
 
     // Media (mic/cam) permission requests from the conference originate in the

--- a/src/videoCallWindow/ipc.ts
+++ b/src/videoCallWindow/ipc.ts
@@ -400,6 +400,23 @@ const handleConferenceWillNavigate = (event: Event, navUrl: string): void => {
   }
 };
 
+// Applies the conference guest's popup policy (window-open handler,
+// will-navigate/will-redirect guards) to a popup window, and recurses via
+// `did-create-window` so every descendant popup (a popup opened from a
+// popup, and so on) gets the same wiring — a grandchild can't slip through
+// unpoliced just because it wasn't opened directly from the webview.
+const attachConferencePopupPolicy = (childWindow: BrowserWindow): void => {
+  childWindow.once('ready-to-show', () => {
+    childWindow.show();
+  });
+  childWindow.webContents.setWindowOpenHandler(
+    handleConferenceWebviewWindowOpen
+  );
+  childWindow.webContents.on('will-navigate', handleConferenceWillNavigate);
+  childWindow.webContents.on('will-redirect', handleConferenceWillNavigate);
+  childWindow.webContents.on('did-create-window', attachConferencePopupPolicy);
+};
+
 const setupWebviewHandlers = (webContents: WebContents) => {
   // Track attached webviews that need handler setup
   const pendingWebviews: WebContents[] = [];
@@ -491,19 +508,10 @@ const setupWebviewHandlers = (webContents: WebContents) => {
     webviewWebContents.on('will-redirect', handleConferenceWillNavigate);
 
     // A guest-webview popup (e.g. an SSO/IdP login window) is created hidden
-    // to avoid a white flash, and its own popups/navigations must follow the
-    // same guest policy so a nested popup (or a redirect inside the popup)
-    // can't escape the sandbox.
-    webviewWebContents.on('did-create-window', (childWindow) => {
-      childWindow.once('ready-to-show', () => {
-        childWindow.show();
-      });
-      childWindow.webContents.setWindowOpenHandler(
-        handleConferenceWebviewWindowOpen
-      );
-      childWindow.webContents.on('will-navigate', handleConferenceWillNavigate);
-      childWindow.webContents.on('will-redirect', handleConferenceWillNavigate);
-    });
+    // to avoid a white flash, and the same policy is applied to every
+    // descendant popup (a popup opened from this popup, and so on) via
+    // attachConferencePopupPolicy's own did-create-window registration.
+    webviewWebContents.on('did-create-window', attachConferencePopupPolicy);
 
     // Media (mic/cam) permission requests from the conference originate in the
     // webview's session, NOT the host window's, so the handler must live on the

--- a/src/videoCallWindow/main/ipc.main.spec.ts
+++ b/src/videoCallWindow/main/ipc.main.spec.ts
@@ -1040,12 +1040,37 @@ describe('videoCallWindow/ipc — PR #3359 hardening', () => {
       ).toEqual({ action: 'deny' });
     });
 
-    it('registers a will-navigate handler on the guest webview', async () => {
+    it('registers will-navigate and will-redirect handlers on the guest webview', async () => {
       const guest = await attachGuest();
       expect(guest.on).toHaveBeenCalledWith(
         'will-navigate',
         expect.any(Function)
       );
+      expect(guest.on).toHaveBeenCalledWith(
+        'will-redirect',
+        expect.any(Function)
+      );
+    });
+
+    it('will-redirect: denies a redirect to a dangerous scheme and sends it to the system browser, but leaves http(s) alone', async () => {
+      const guest = await attachGuest();
+      const willRedirectHandler = guest.on.mock.calls.find(
+        ([event]: [string]) => event === 'will-redirect'
+      )[1];
+
+      const { openExternal } = (await import(
+        '../../utils/browserLauncher'
+      )) as any;
+
+      const dangerousEvent = { preventDefault: jest.fn() };
+      willRedirectHandler(dangerousEvent, 'smb://share/path');
+      expect(dangerousEvent.preventDefault).toHaveBeenCalledTimes(1);
+      await flushPromises();
+      expect(openExternal).toHaveBeenCalledWith('smb://share/path');
+
+      const httpEvent = { preventDefault: jest.fn() };
+      willRedirectHandler(httpEvent, 'https://example.com/page');
+      expect(httpEvent.preventDefault).not.toHaveBeenCalled();
     });
 
     it('registers a did-create-window handler that wires the popup child window with the guest policy', async () => {
@@ -1074,6 +1099,10 @@ describe('videoCallWindow/ipc — PR #3359 hardening', () => {
       ).toHaveBeenCalledTimes(1);
       expect(childWindow.webContents.on).toHaveBeenCalledWith(
         'will-navigate',
+        expect.any(Function)
+      );
+      expect(childWindow.webContents.on).toHaveBeenCalledWith(
+        'will-redirect',
         expect.any(Function)
       );
 

--- a/src/videoCallWindow/main/ipc.main.spec.ts
+++ b/src/videoCallWindow/main/ipc.main.spec.ts
@@ -1073,7 +1073,7 @@ describe('videoCallWindow/ipc — PR #3359 hardening', () => {
       expect(httpEvent.preventDefault).not.toHaveBeenCalled();
     });
 
-    it('registers a did-create-window handler that wires the popup child window with the guest policy', async () => {
+    it('registers a did-create-window handler that wires the popup child window with the guest policy, recursively for descendant popups', async () => {
       const guest = await attachGuest();
       expect(guest.on).toHaveBeenCalledWith(
         'did-create-window',
@@ -1083,14 +1083,16 @@ describe('videoCallWindow/ipc — PR #3359 hardening', () => {
         ([event]: [string]) => event === 'did-create-window'
       )[1];
 
-      const childWindow = {
+      const makeFakeChild = () => ({
         once: jest.fn(),
         show: jest.fn(),
         webContents: {
           setWindowOpenHandler: jest.fn(),
           on: jest.fn(),
         },
-      };
+      });
+
+      const childWindow = makeFakeChild();
 
       didCreateWindowHandler(childWindow, { url: 'https://idp.example/sso' });
 
@@ -1105,6 +1107,10 @@ describe('videoCallWindow/ipc — PR #3359 hardening', () => {
         'will-redirect',
         expect.any(Function)
       );
+      expect(childWindow.webContents.on).toHaveBeenCalledWith(
+        'did-create-window',
+        expect.any(Function)
+      );
 
       expect(childWindow.once).toHaveBeenCalledWith(
         'ready-to-show',
@@ -1116,6 +1122,47 @@ describe('videoCallWindow/ipc — PR #3359 hardening', () => {
       expect(childWindow.show).not.toHaveBeenCalled();
       readyToShowCallback();
       expect(childWindow.show).toHaveBeenCalledTimes(1);
+
+      // A popup opened FROM the child (a grandchild) must get the same
+      // wiring — the recursive did-create-window registration above is what
+      // makes that happen.
+      const childDidCreateWindowHandler =
+        childWindow.webContents.on.mock.calls.find(
+          ([event]: [string]) => event === 'did-create-window'
+        )[1];
+
+      const grandchildWindow = makeFakeChild();
+      childDidCreateWindowHandler(grandchildWindow, {
+        url: 'https://idp.example/sso/nested',
+      });
+
+      expect(
+        grandchildWindow.webContents.setWindowOpenHandler
+      ).toHaveBeenCalledTimes(1);
+      expect(grandchildWindow.webContents.on).toHaveBeenCalledWith(
+        'will-navigate',
+        expect.any(Function)
+      );
+      expect(grandchildWindow.webContents.on).toHaveBeenCalledWith(
+        'will-redirect',
+        expect.any(Function)
+      );
+      expect(grandchildWindow.webContents.on).toHaveBeenCalledWith(
+        'did-create-window',
+        expect.any(Function)
+      );
+
+      expect(grandchildWindow.once).toHaveBeenCalledWith(
+        'ready-to-show',
+        expect.any(Function)
+      );
+      const grandchildReadyToShowCallback =
+        grandchildWindow.once.mock.calls.find(
+          ([event]: [string]) => event === 'ready-to-show'
+        )[1];
+      expect(grandchildWindow.show).not.toHaveBeenCalled();
+      grandchildReadyToShowCallback();
+      expect(grandchildWindow.show).toHaveBeenCalledTimes(1);
     });
 
     it('leaves the host window popup policy unchanged: http(s) still denied + sent to the system browser', async () => {

--- a/src/videoCallWindow/main/ipc.main.spec.ts
+++ b/src/videoCallWindow/main/ipc.main.spec.ts
@@ -955,17 +955,44 @@ describe('videoCallWindow/ipc — PR #3359 hardening', () => {
       return guest;
     };
 
-    it('routes http(s) popups to the system browser and denies the Electron window', async () => {
+    it('allows http(s) popups as sandboxed Electron child windows (SSO/IdP flow)', async () => {
       const guest = await attachGuest();
       expect(guest.setWindowOpenHandler).toHaveBeenCalledTimes(1);
       const handler = guest.setWindowOpenHandler.mock.calls[0][0];
 
-      expect(handler({ url: 'https://example.com/page' })).toEqual({
+      const result = handler({
+        url: 'https://example.com/page',
+        disposition: 'new-window',
+      });
+      expect(result.action).toBe('allow');
+      expect(result.overrideBrowserWindowOptions.webPreferences).toMatchObject({
+        nodeIntegration: false,
+        contextIsolation: true,
+        sandbox: true,
+      });
+
+      const { openExternal } = (await import(
+        '../../utils/browserLauncher'
+      )) as any;
+      expect(openExternal).not.toHaveBeenCalled();
+    });
+
+    it('routes tab-disposition http(s) popups to the system browser and denies the Electron window', async () => {
+      const guest = await attachGuest();
+      const handler = guest.setWindowOpenHandler.mock.calls[0][0];
+
+      expect(
+        handler({
+          url: 'https://example.com/page',
+          disposition: 'foreground-tab',
+        })
+      ).toEqual({
         action: 'deny',
       });
       const { openExternal } = (await import(
         '../../utils/browserLauncher'
       )) as any;
+      await flushPromises();
       expect(openExternal).toHaveBeenCalledWith('https://example.com/page');
     });
 
@@ -973,8 +1000,15 @@ describe('videoCallWindow/ipc — PR #3359 hardening', () => {
       const guest = await attachGuest();
       const handler = guest.setWindowOpenHandler.mock.calls[0][0];
 
-      expect(handler({ url: 'about:blank' })).toEqual({ action: 'allow' });
-      expect(handler({ url: 'blob:https://meet.example/abc' })).toEqual({
+      expect(
+        handler({ url: 'about:blank', disposition: 'new-window' })
+      ).toEqual({ action: 'allow' });
+      expect(
+        handler({
+          url: 'blob:https://meet.example/abc',
+          disposition: 'new-window',
+        })
+      ).toEqual({
         action: 'allow',
       });
     });
@@ -983,16 +1017,27 @@ describe('videoCallWindow/ipc — PR #3359 hardening', () => {
       const guest = await attachGuest();
       const handler = guest.setWindowOpenHandler.mock.calls[0][0];
 
-      expect(handler({ url: 'javascript:alert(1)' })).toEqual({
+      expect(
+        handler({ url: 'javascript:alert(1)', disposition: 'new-window' })
+      ).toEqual({
         action: 'deny',
       });
-      expect(handler({ url: 'file:///etc/passwd' })).toEqual({
+      expect(
+        handler({ url: 'file:///etc/passwd', disposition: 'new-window' })
+      ).toEqual({
         action: 'deny',
       });
-      expect(handler({ url: 'data:text/html,<script>1</script>' })).toEqual({
+      expect(
+        handler({
+          url: 'data:text/html,<script>1</script>',
+          disposition: 'new-window',
+        })
+      ).toEqual({
         action: 'deny',
       });
-      expect(handler({ url: 'smb://share/path' })).toEqual({ action: 'deny' });
+      expect(
+        handler({ url: 'smb://share/path', disposition: 'new-window' })
+      ).toEqual({ action: 'deny' });
     });
 
     it('registers a will-navigate handler on the guest webview', async () => {
@@ -1001,6 +1046,73 @@ describe('videoCallWindow/ipc — PR #3359 hardening', () => {
         'will-navigate',
         expect.any(Function)
       );
+    });
+
+    it('registers a did-create-window handler that wires the popup child window with the guest policy', async () => {
+      const guest = await attachGuest();
+      expect(guest.on).toHaveBeenCalledWith(
+        'did-create-window',
+        expect.any(Function)
+      );
+      const didCreateWindowHandler = guest.on.mock.calls.find(
+        ([event]: [string]) => event === 'did-create-window'
+      )[1];
+
+      const childWindow = {
+        once: jest.fn(),
+        show: jest.fn(),
+        webContents: {
+          setWindowOpenHandler: jest.fn(),
+          on: jest.fn(),
+        },
+      };
+
+      didCreateWindowHandler(childWindow, { url: 'https://idp.example/sso' });
+
+      expect(
+        childWindow.webContents.setWindowOpenHandler
+      ).toHaveBeenCalledTimes(1);
+      expect(childWindow.webContents.on).toHaveBeenCalledWith(
+        'will-navigate',
+        expect.any(Function)
+      );
+
+      expect(childWindow.once).toHaveBeenCalledWith(
+        'ready-to-show',
+        expect.any(Function)
+      );
+      const readyToShowCallback = childWindow.once.mock.calls.find(
+        ([event]: [string]) => event === 'ready-to-show'
+      )[1];
+      expect(childWindow.show).not.toHaveBeenCalled();
+      readyToShowCallback();
+      expect(childWindow.show).toHaveBeenCalledTimes(1);
+    });
+
+    it('leaves the host window popup policy unchanged: http(s) still denied + sent to the system browser', async () => {
+      await attachGuest();
+
+      // The host window's webContents (createdWindows[0].webContents) has its
+      // window-open handler registered twice (an smb-only guard, then the
+      // shared handleVideoCallWindowOpen wrapper) — the last registration is
+      // the one Electron actually uses.
+      const hostSetWindowOpenHandler =
+        createdWindows[0].webContents.setWindowOpenHandler;
+      expect(hostSetWindowOpenHandler.mock.calls.length).toBeGreaterThanOrEqual(
+        2
+      );
+      const hostHandler =
+        hostSetWindowOpenHandler.mock.calls[
+          hostSetWindowOpenHandler.mock.calls.length - 1
+        ][0];
+
+      expect(hostHandler({ url: 'https://example.com/page' })).toEqual({
+        action: 'deny',
+      });
+      const { openExternal } = (await import(
+        '../../utils/browserLauncher'
+      )) as any;
+      expect(openExternal).toHaveBeenCalledWith('https://example.com/page');
     });
 
     it('installs a media permission handler on the fallback (isolated) webview session', async () => {


### PR DESCRIPTION
## Problem

Since 4.16.0, SSO login through an identity-provider popup fails inside the internal video call window. This affects Pexip, whose web client performs the login in a popup by default ([Pexip docs](https://docs.pexip.com/admin/idps.htm)) and hands the result back through `window.opener`.

#3370 registered a window-open handler on the conference webview that returns `deny` for every http(s) URL and opens it in the system browser. A popup in the system browser has no opener relationship with the webview, so the login never completes. 4.15.0 had no handler on the guest webview, so the popup opened as an Electron child window and the flow worked.

## Change

`src/videoCallWindow/ipc.ts`

- New `handleConferenceWebviewWindowOpen`, used only for the conference (guest) webview:
  - `foreground-tab` / `background-tab` dispositions (middle-click, ctrl-click): system browser + `deny`, as before.
  - Plain http(s) popups: `allow` as a sandboxed Electron child window (`nodeIntegration: false`, `contextIsolation: true`, `sandbox: true`, `webviewTag: false`, no preload, created hidden and shown on `ready-to-show`).
  - `about:` / `blob:`: `allow`, as before.
  - Everything else (`javascript:`, `data:`, `file:`, `smb:`, ...): `deny`, as before.
- `did-create-window` on the guest webview re-applies the same window-open policy and the shared `will-navigate` policy to the child window, so a nested popup or an in-popup redirect cannot escape it.
- The existing inline `will-navigate` body is extracted into `handleConferenceWillNavigate` so both call sites share it.
- The video call window's own host page keeps `handleVideoCallWindowOpen` unchanged (http(s) still goes to the system browser).

`src/videoCallWindow/main/ipc.main.spec.ts`: tests for the new guest policy (allow with sandboxed prefs, tab dispositions external, dangerous schemes denied, `did-create-window` wiring) plus a test proving the host page policy is unchanged.

`docs/video-call-window-management.md`: "Conference Webview Popup Policy" section.

## Verification

- `yarn jest src/videoCallWindow`: 4 suites, 54 tests passed.
- `npx tsc --noEmit`: clean.
- `yarn lint`: 0 errors (37 pre-existing warnings in unrelated files).
- Runtime, dev app from this branch: a local server mimicking a popup SSO flow (conference page calls `window.open('/idp')`, `/idp` 302s to `/callback`, `/callback` posts to `window.opener` and closes), opened through `window.RocketChatDesktop.openInternalVideoChatWindow(url, { providerName: 'pexip' })` on the server webview. Observed via the main-process inspector: the popup was created as an Electron window with `nodeIntegration: false`, `contextIsolation: true`, `sandbox: true`, no preload; the callback page had `window.opener`; the conference page received the posted result; the popup closed itself.

Not yet verified against a live Pexip deployment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved conference webview popups so HTTP(S)-based SSO and login flows open correctly in sandboxed in-app windows.
  - Preserved external-browser behavior for tab-target links and the host window.
  - Applied consistent navigation safeguards to popup windows, redirects, and nested popups.
  - Blocked unsupported or potentially unsafe protocols while allowing approved in-app links.
- **Documentation**
  - Documented conference popup and navigation behavior, including nested popup handling and supported protocols.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->