### PR TITLE
fix: stop overriding the web client's presence detection on servers >= 7.10

### DIFF
--- a/src/injected.ts
+++ b/src/injected.ts
@@ -968,6 +968,18 @@ const start = async () => {
       setupFlags.gitCommitHash = true;
     }
 
+    // Since Rocket.Chat 7.10.0 the web client registers the idle detector itself
+    // (apps/meteor/client/lib/userPresence.ts). The preload keeps a single
+    // registration, so registering again here replaces the web client's callback:
+    // it never learns the user is idle and cannot re-assert `away` after a
+    // websocket reconnection.
+    if (
+      !setupFlags.userPresence &&
+      versionIsGreaterOrEqualsTo(serverInfo.version, '7.10.0')
+    ) {
+      setupFlags.userPresence = true;
+    }
+
     if (Tracker && Meteor && getUserPreference && !setupFlags.userPresence) {
       Tracker.autorun(() => {
         const uid = Meteor.userId();

--- a/src/injected.ts
+++ b/src/injected.ts
@@ -301,12 +301,22 @@ const start = async () => {
   loadModule(settingsModulePath, 'Settings', (value) => {
     settings = value.settings;
   });
-  loadModule(utilsModulePath, 'Utils', (value) => {
-    getUserPreference = value.getUserPreference;
-  });
-  loadModule(userPresenceModulePath, 'UserPresence', (value) => {
-    UserPresence = value.UserPresence;
-  });
+  // Since Rocket.Chat 7.10.0 the web client registers the idle detector itself
+  // (apps/meteor/client/lib/userPresence.ts) and the meteor-user-presence
+  // package no longer exists, so these modules are only needed for the legacy
+  // presence block below.
+  const usesLegacyPresenceDetection = !versionIsGreaterOrEqualsTo(
+    serverInfo.version,
+    '7.10.0'
+  );
+  if (usesLegacyPresenceDetection) {
+    loadModule(utilsModulePath, 'Utils', (value) => {
+      getUserPreference = value.getUserPreference;
+    });
+    loadModule(userPresenceModulePath, 'UserPresence', (value) => {
+      UserPresence = value.UserPresence;
+    });
+  }
 
   tryRequireFirstOf(presenceModulePaths)
     .then((module) => {
@@ -968,19 +978,17 @@ const start = async () => {
       setupFlags.gitCommitHash = true;
     }
 
-    // Since Rocket.Chat 7.10.0 the web client registers the idle detector itself
-    // (apps/meteor/client/lib/userPresence.ts). The preload keeps a single
-    // registration, so registering again here replaces the web client's callback:
-    // it never learns the user is idle and cannot re-assert `away` after a
-    // websocket reconnection.
+    // Only for servers < 7.10.0. Newer web clients register the idle detector
+    // themselves; the preload keeps a single registration, so registering again
+    // here would replace the web client's callback: it would never learn the
+    // user is idle and could not re-assert `away` after a websocket reconnection.
     if (
-      !setupFlags.userPresence &&
-      versionIsGreaterOrEqualsTo(serverInfo.version, '7.10.0')
+      usesLegacyPresenceDetection &&
+      Tracker &&
+      Meteor &&
+      getUserPreference &&
+      !setupFlags.userPresence
     ) {
-      setupFlags.userPresence = true;
-    }
-
-    if (Tracker && Meteor && getUserPreference && !setupFlags.userPresence) {
       Tracker.autorun(() => {
         const uid = Meteor.userId();
         if (!uid) return;

--- a/src/injected.ts
+++ b/src/injected.ts
@@ -553,6 +553,7 @@ const start = async () => {
     themeAppearance: false,
     userPresence: false,
     userPresenceStatus: false,
+    userPresenceReassert: false,
   };
 
   // Per-subscription unread state, accumulated from the
@@ -976,6 +977,27 @@ const start = async () => {
         window.RocketChatDesktop.setGitCommitHash(gitCommitHash);
       });
       setupFlags.gitCommitHash = true;
+    }
+
+    // After a websocket reconnection the server writes `online` for the new
+    // session. The desktop poller only reports OS idle transitions, so a user
+    // who stayed idle across the drop would remain `online` until the next
+    // transition. Once the connection and login settle, ask the preload to
+    // report the current idle state unconditionally. Web clients >= 8.8.0 also
+    // re-assert on their own; the duplicate is idempotent.
+    if (Tracker && Meteor && !setupFlags.userPresenceReassert) {
+      let wasSettled = false;
+      Tracker.autorun(() => {
+        const settled =
+          Boolean(Meteor.status()?.connected) &&
+          Boolean(Meteor.userId()) &&
+          !Meteor.loggingIn?.();
+        if (settled && !wasSettled) {
+          window.RocketChatDesktop.reassertUserPresenceDetection();
+        }
+        wasSettled = settled;
+      });
+      setupFlags.userPresenceReassert = true;
     }
 
     // Only for servers < 7.10.0. Newer web clients register the idle detector

--- a/src/servers/preload/__tests__/api.spec.ts
+++ b/src/servers/preload/__tests__/api.spec.ts
@@ -26,6 +26,7 @@ jest.mock('../../../telephony/preload', () => ({
 
 jest.mock('../../../userPresence/preload', () => ({
   setUserPresenceDetection: jest.fn(),
+  reassertUserPresenceDetection: jest.fn(),
 }));
 
 jest.mock('../badge', () => ({ setBadge: jest.fn() }));

--- a/src/servers/preload/api.ts
+++ b/src/servers/preload/api.ts
@@ -15,7 +15,10 @@ import {
   setUserToken,
 } from '../../outlookCalendar/preload';
 import { onTelephonyCallRequested } from '../../telephony/preload';
-import { setUserPresenceDetection } from '../../userPresence/preload';
+import {
+  reassertUserPresenceDetection,
+  setUserPresenceDetection,
+} from '../../userPresence/preload';
 import type { Server } from '../common';
 import { setBadge } from './badge';
 import { writeTextToClipboard } from './clipboard';
@@ -66,6 +69,7 @@ type ExtendedIRocketChatDesktop = IRocketChatDesktop & {
   supportedDocumentViewerFormats: () => string[];
   onNavigateToRoute: (callback: (path: string) => void) => void;
   setUserRoles: (roles: string[]) => void;
+  reassertUserPresenceDetection: () => void;
   setUserPresence: (payload: {
     presence: Server['presence'];
     presenceStatusText: Server['presenceStatusText'];
@@ -106,6 +110,7 @@ export const RocketChatDesktop: Window['RocketChatDesktop'] = {
   setBackground,
   setTitle,
   setUserPresenceDetection,
+  reassertUserPresenceDetection,
   setUserLoggedIn,
   setUserRoles,
   setUserPresence,

--- a/src/userPresence/__tests__/preload.spec.ts
+++ b/src/userPresence/__tests__/preload.spec.ts
@@ -1,0 +1,152 @@
+const invoke = jest.fn();
+
+jest.mock('../../ipc/renderer', () => ({
+  invoke: (...args: unknown[]) => invoke(...args),
+}));
+
+jest.mock('../../store', () => ({
+  listen: jest.fn(() => jest.fn()),
+}));
+
+describe('userPresence/preload', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('reports a transition once and does not repeat unchanged state', async () => {
+    const { setUserPresenceDetection } = await import('../preload');
+    const setUserOnline = jest.fn();
+
+    invoke.mockResolvedValueOnce('active');
+    invoke.mockResolvedValueOnce('idle');
+    invoke.mockResolvedValueOnce('idle');
+
+    setUserPresenceDetection({
+      isAutoAwayEnabled: true,
+      idleThreshold: 60000,
+      setUserOnline,
+    });
+
+    // Initial poll.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(setUserOnline).toHaveBeenCalledTimes(1);
+    expect(setUserOnline).toHaveBeenNthCalledWith(1, true);
+
+    // Second poll (transition to idle).
+    await jest.advanceTimersByTimeAsync(2000);
+
+    expect(setUserOnline).toHaveBeenCalledTimes(2);
+    expect(setUserOnline).toHaveBeenNthCalledWith(2, false);
+
+    // Third poll (still idle, no transition).
+    await jest.advanceTimersByTimeAsync(2000);
+
+    expect(setUserOnline).toHaveBeenCalledTimes(2);
+  });
+
+  it('reassertUserPresenceDetection reports unconditionally even without a transition', async () => {
+    const { setUserPresenceDetection, reassertUserPresenceDetection } =
+      await import('../preload');
+    const setUserOnline = jest.fn();
+
+    invoke.mockResolvedValueOnce('idle');
+
+    setUserPresenceDetection({
+      isAutoAwayEnabled: true,
+      idleThreshold: 60000,
+      setUserOnline,
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(setUserOnline).toHaveBeenCalledTimes(1);
+    expect(setUserOnline).toHaveBeenNthCalledWith(1, false);
+
+    invoke.mockResolvedValueOnce('idle');
+
+    reassertUserPresenceDetection();
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(setUserOnline).toHaveBeenCalledTimes(2);
+    expect(setUserOnline).toHaveBeenNthCalledWith(2, false);
+  });
+
+  it('is a no-op when auto-away is disabled', async () => {
+    const { setUserPresenceDetection, reassertUserPresenceDetection } =
+      await import('../preload');
+    const setUserOnline = jest.fn();
+
+    setUserPresenceDetection({
+      isAutoAwayEnabled: false,
+      idleThreshold: 60000,
+      setUserOnline,
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    reassertUserPresenceDetection();
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(invoke).not.toHaveBeenCalled();
+    expect(setUserOnline).not.toHaveBeenCalled();
+  });
+
+  it('reassert routes through the newest setUserOnline after re-registration', async () => {
+    const { setUserPresenceDetection, reassertUserPresenceDetection } =
+      await import('../preload');
+    const oldSetUserOnline = jest.fn();
+    const newSetUserOnline = jest.fn();
+
+    invoke.mockResolvedValueOnce('active');
+
+    setUserPresenceDetection({
+      isAutoAwayEnabled: true,
+      idleThreshold: 60000,
+      setUserOnline: oldSetUserOnline,
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(oldSetUserOnline).toHaveBeenCalledTimes(1);
+
+    invoke.mockResolvedValueOnce('active');
+
+    setUserPresenceDetection({
+      isAutoAwayEnabled: true,
+      idleThreshold: 60000,
+      setUserOnline: newSetUserOnline,
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    oldSetUserOnline.mockClear();
+    newSetUserOnline.mockClear();
+
+    invoke.mockResolvedValueOnce('active');
+
+    reassertUserPresenceDetection();
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(oldSetUserOnline).not.toHaveBeenCalled();
+    expect(newSetUserOnline).toHaveBeenCalledTimes(1);
+    expect(newSetUserOnline).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/userPresence/preload.ts
+++ b/src/userPresence/preload.ts
@@ -5,6 +5,7 @@ import { SYSTEM_SUSPENDING, SYSTEM_LOCKING_SCREEN } from './actions';
 import type { SystemIdleState } from './common';
 
 let detachCallbacks: () => void;
+let reassert: () => void = () => undefined;
 
 const attachCallbacks = ({
   isAutoAwayEnabled,
@@ -28,7 +29,26 @@ const attachCallbacks = ({
   );
 
   let pollingTimer: ReturnType<typeof setTimeout>;
-  let prevState: SystemIdleState;
+  let prevState: SystemIdleState | undefined;
+
+  const reportSystemIdleState = async (force: boolean): Promise<void> => {
+    if (!isAutoAwayEnabled || !idleThreshold) {
+      return;
+    }
+
+    const state = await invoke(
+      'power-monitor/get-system-idle-state',
+      idleThreshold
+    );
+
+    if (!force && prevState === state) {
+      return;
+    }
+
+    prevState = state;
+    setUserOnline(state === 'active' || state === 'unknown');
+  };
+
   const pollSystemIdleState = async (): Promise<void> => {
     if (!isAutoAwayEnabled || !idleThreshold) {
       return;
@@ -36,26 +56,24 @@ const attachCallbacks = ({
 
     pollingTimer = setTimeout(pollSystemIdleState, 2000);
 
-    const state = await invoke(
-      'power-monitor/get-system-idle-state',
-      idleThreshold
-    );
-
-    if (prevState === state) {
-      return;
-    }
-
-    const isOnline = state === 'active' || state === 'unknown';
-    setUserOnline(isOnline);
-
-    prevState = state;
+    await reportSystemIdleState(false);
   };
 
   pollSystemIdleState();
 
+  // After a websocket reconnection the server writes `online` for the new
+  // session. The poller only reports OS idle transitions, so a user who
+  // stayed idle across the drop would remain `online` until the next
+  // transition. This lets the page ask for an unconditional report once the
+  // connection and login have settled.
+  reassert = (): void => {
+    void reportSystemIdleState(true);
+  };
+
   return (): void => {
     unsubscribeFromPowerMonitorEvents();
     clearTimeout(pollingTimer);
+    reassert = () => undefined;
   };
 };
 
@@ -66,4 +84,8 @@ export const setUserPresenceDetection = (options: {
 }): void => {
   detachCallbacks?.();
   detachCallbacks = attachCallbacks(options);
+};
+
+export const reassertUserPresenceDetection = (): void => {
+  reassert();
 };


### PR DESCRIPTION
Jira: [CORE-2684](https://rocketchat.atlassian.net/browse/CORE-2684) · Support ticket #115962

## Problem

On the desktop app, a user who went idle (`away`) comes back as `online` after any websocket reconnection and stays `online` until the OS reports a new idle transition. On deployments that recycle websockets on a schedule (OpenShift router `timeout tunnel`, LB idle timeouts) every desktop user flips to `online` on that cadence, and everyone is green in the morning. The web client is not affected.

## Cause

Since Rocket.Chat 7.10.0 (RocketChat/Rocket.Chat#36704) the web client registers the desktop idle detector itself through `RocketChatDesktop.setUserPresenceDetection`, and since 8.8.0 (RocketChat/Rocket.Chat#41585) it also re-sends `UserPresence:away` right after a websocket reconnection when the user is still idle.

`injected.ts` still carries the pre-7.10 presence block, which calls `setUserPresenceDetection` again about a second after the web client does. The preload keeps a single registration, so that second call replaces the web client's callback: the web client never learns the user is idle, and after a reconnection nobody re-sends `away` (the injected poller only reacts to OS-state changes, and the user is still idle). The server keeps the `online` it writes for the new session.

## Change

Skip the legacy block when the server is ≥ 7.10.0, leaving the web client as the only registrant. Servers older than 7.10 keep the block; they have no other idle detection. Nothing else in the desktop uses the block: the tray presence status (#3466) reads the web client's presence store and does not touch the detector.

## Verification

Against Rocket.Chat 8.8.1 with the built `app/injected.js`:

- idle → `UserPresence:away` sent by the web client, status `away`;
- `Meteor.disconnect()` / `reconnect()` → `UserPresence:away` re-sent right after `login`, status stays `away`.

Without this change the same run ends `online` with no `UserPresence:away` frame after the reconnection. Reproduced first with the packaged 4.13.0 app and the same procedure.

## Follow-up in this PR: re-assert after reconnection on every server version

Leaving the web client as the only registrant fixes the reconnection symptom on servers ≥ 8.8.0, because that web client re-sends `UserPresence:away` on its own once the connection settles. Web clients 7.10.0–8.7.x own the registration but have no re-assert logic, and servers < 7.10.0 use the legacy injected block; on both the symptom described above persisted, because the desktop poller only reports OS idle *transitions* and a user who stayed idle across the drop produces none.

The desktop now closes that gap itself:

- `injected.ts` watches `Meteor.status().connected`, `Meteor.userId()` and `Meteor.loggingIn()` in a `Tracker.autorun`. When the three settle into "connected, logged in, not logging in" it calls `RocketChatDesktop.reassertUserPresenceDetection()`. Waiting for login to finish matters because the server writes `online` during the login resume.
- `userPresence/preload.ts` exposes `reassertUserPresenceDetection`, which reports the current OS idle state unconditionally through whichever `setUserOnline` callback is registered, instead of only on a transition.
- On ≥ 8.8.0 the callback maps to the web client's own `setAway`/`registerActivity`, so the duplicate re-assert is idempotent. On 7.10.0–8.7.x it maps straight to `UserPresence:away`/`online`. On < 7.10.0 the legacy block's callback does the same method calls.

Also gated the `Utils` and `UserPresence` module loads on `< 7.10.0`, since nothing consumes them on newer servers and the failed loads spent the full retry chain and logged `Failed to load … module`.

Unit coverage: `src/userPresence/__tests__/preload.spec.ts` (transition-only polling, unconditional re-assert, no-op when auto-away is disabled, re-assert routes through the latest registration). Runtime verification against live 8.7.0 and 8.8.1 servers (idle forced through the main-process `powerMonitor.getSystemIdleState`, `Meteor.disconnect()` / `reconnect()`, DDP frames and `users.info` polled): with this change the reconnection frames are `connect`, `login`, `UserPresence:away` and the status stays `away` on both versions; with the re-assert autorun removed from `injected.ts` (control) 8.7.0 ends `online` with no `UserPresence:away` frame. Details in the PR comments.

## Note for 8.9+

RocketChat/Rocket.Chat#41994 moved `app/utils/client/index.ts`, so on those servers the block already fails to load `getUserPreference` and never runs (`Failed to load Utils module` in the webview console). That is accidental; this change makes it explicit and covers 8.8.x, where the file still exists.


[CORE-2684]: https://rocketchat.atlassian.net/browse/CORE-2684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user-presence compatibility with Rocket.Chat servers version 7.10.0 and newer.
  * Prevented legacy presence handling from running on newer server versions.
  * Restored accurate presence reporting after websocket reconnections.
  * Preserved existing preference-based presence behavior for older server versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
