### PR TITLE
CORE-2640 Add find in page (Cmd+F) for workspace webviews

### DIFF
--- a/src/i18n/de-DE.i18n.json
+++ b/src/i18n/de-DE.i18n.json
@@ -312,6 +312,7 @@
     "settings": "Einstellungen",
     "editMenu": "&Bearbeiten",
     "fileMenu": "&Datei",
+    "findInPage": "&Find…",
     "forward": "&Nach vorne",
     "helpMenu": "&Hilfe",
     "hide": "Ausblenden {{- appName}}",
@@ -341,6 +342,14 @@
     "zoomIn": "Vergrößern",
     "zoomOut": "Verkleinern",
     "simulateDisconnected": "Verbindungsabbruch simulieren"
+  },
+  "findInPage": {
+    "placeholder": "Find in page",
+    "matchCount": "{{current}} of {{total}}",
+    "noMatches": "No matches",
+    "previous": "Previous match",
+    "next": "Next match",
+    "close": "Close"
   },
   "loadingError": {
     "title": "Server konnte nicht geladen werden",

--- a/src/i18n/en.i18n.json
+++ b/src/i18n/en.i18n.json
@@ -500,6 +500,7 @@
     "checkForUpdates": "Check for updates",
     "editMenu": "&Edit",
     "fileMenu": "&File",
+    "findInPage": "&Find…",
     "forward": "&Forward",
     "helpMenu": "&Help",
     "hide": "Hide {{- appName}}",
@@ -542,6 +543,14 @@
     "windowMenu": "&Window",
     "zoomIn": "Zoom in",
     "zoomOut": "Zoom out"
+  },
+  "findInPage": {
+    "placeholder": "Find in page",
+    "matchCount": "{{current}} of {{total}}",
+    "noMatches": "No matches",
+    "previous": "Previous match",
+    "next": "Next match",
+    "close": "Close"
   },
   "loadingError": {
     "title": "Server Failed to Load",

--- a/src/i18n/es.i18n.json
+++ b/src/i18n/es.i18n.json
@@ -335,6 +335,7 @@
     "settings": "Configuración",
     "editMenu": "&Editar",
     "fileMenu": "&Archivo",
+    "findInPage": "&Find…",
     "forward": "&Avanzar",
     "helpMenu": "&Ayuda",
     "hide": "Ocultar {{- appName}}",
@@ -365,6 +366,14 @@
     "zoomIn": "Acercar",
     "zoomOut": "Alejar",
     "simulateDisconnected": "Simular desconexión"
+  },
+  "findInPage": {
+    "placeholder": "Find in page",
+    "matchCount": "{{current}} of {{total}}",
+    "noMatches": "No matches",
+    "previous": "Previous match",
+    "next": "Next match",
+    "close": "Close"
   },
   "loadingError": {
     "title": "Fallo al cargar el servidor",

--- a/src/i18n/fi.i18n.json
+++ b/src/i18n/fi.i18n.json
@@ -309,6 +309,7 @@
     "settings": "Asetukset",
     "editMenu": "M&uokkaa",
     "fileMenu": "Tie&dosto",
+    "findInPage": "&Find…",
     "forward": "V&älitä",
     "helpMenu": "&Ohje",
     "hide": "Piilota {{- appName}}",
@@ -339,6 +340,14 @@
     "zoomIn": "Lähennä",
     "zoomOut": "Loitonna",
     "simulateDisconnected": "Simuloi yhteyden katkeamista"
+  },
+  "findInPage": {
+    "placeholder": "Find in page",
+    "matchCount": "{{current}} of {{total}}",
+    "noMatches": "No matches",
+    "previous": "Previous match",
+    "next": "Next match",
+    "close": "Close"
   },
   "loadingError": {
     "title": "Palvelimen lataus epäonnistui",

--- a/src/i18n/fr.i18n.json
+++ b/src/i18n/fr.i18n.json
@@ -310,6 +310,7 @@
     "settings": "Paramètres",
     "editMenu": "&Éditer",
     "fileMenu": "&Fichier",
+    "findInPage": "&Find…",
     "forward": "&Suivant",
     "helpMenu": "&Aide",
     "hide": "Masquer {{- appName}}",
@@ -340,6 +341,14 @@
     "zoomIn": "Zoomer",
     "zoomOut": "Zoom arrière",
     "simulateDisconnected": "Simuler une déconnexion"
+  },
+  "findInPage": {
+    "placeholder": "Find in page",
+    "matchCount": "{{current}} of {{total}}",
+    "noMatches": "No matches",
+    "previous": "Previous match",
+    "next": "Next match",
+    "close": "Close"
   },
   "loadingError": {
     "title": "Echec du chargement du serveur",

--- a/src/i18n/hu.i18n.json
+++ b/src/i18n/hu.i18n.json
@@ -352,6 +352,7 @@
     "settings": "Beállítások",
     "editMenu": "S&zerkesztés",
     "fileMenu": "&Fájl",
+    "findInPage": "&Find…",
     "forward": "&Előre",
     "helpMenu": "&Súgó",
     "hide": "A {{- appName}} elrejtése",
@@ -388,6 +389,14 @@
     "zoomIn": "Nagyítás",
     "zoomOut": "Kicsinyítés",
     "simulateDisconnected": "Kapcsolat megszakadásának szimulálása"
+  },
+  "findInPage": {
+    "placeholder": "Find in page",
+    "matchCount": "{{current}} of {{total}}",
+    "noMatches": "No matches",
+    "previous": "Previous match",
+    "next": "Next match",
+    "close": "Close"
   },
   "loadingError": {
     "title": "Kiszolgáló betöltése sikertelen",

--- a/src/i18n/it-IT.i18n.json
+++ b/src/i18n/it-IT.i18n.json
@@ -86,7 +86,8 @@
     }
   },
   "menus": {
-    "simulateDisconnected": "Simula disconnessione"
+    "simulateDisconnected": "Simula disconnessione",
+    "findInPage": "&Find…"
   },
   "tray": {
     "presence": {
@@ -99,5 +100,13 @@
       "signIn": "Accedi a {{- workspace}}",
       "addWorkspace": "Aggiungi area di lavoro"
     }
+  },
+  "findInPage": {
+    "placeholder": "Find in page",
+    "matchCount": "{{current}} of {{total}}",
+    "noMatches": "No matches",
+    "previous": "Previous match",
+    "next": "Next match",
+    "close": "Close"
   }
 }

--- a/src/i18n/ja.i18n.json
+++ b/src/i18n/ja.i18n.json
@@ -153,6 +153,7 @@
     "documentation": "ドキュメント",
     "editMenu": "編集 (&E)",
     "fileMenu": "ファイル (&F)",
+    "findInPage": "&Find…",
     "forward": "進む(&F)",
     "helpMenu": "ヘルプ (&H)",
     "learnMore": "もっと詳しく知る",
@@ -178,6 +179,14 @@
     "zoomIn": "拡大",
     "zoomOut": "縮小",
     "simulateDisconnected": "切断をシミュレート"
+  },
+  "findInPage": {
+    "placeholder": "Find in page",
+    "matchCount": "{{current}} of {{total}}",
+    "noMatches": "No matches",
+    "previous": "Previous match",
+    "next": "Next match",
+    "close": "Close"
   },
   "loadingError": {
     "title": "サーバーの読み込みに失敗しました",

--- a/src/i18n/no.i18n.json
+++ b/src/i18n/no.i18n.json
@@ -366,6 +366,7 @@
     "settings": "Innstillinger",
     "editMenu": "Redigere",
     "fileMenu": "Fil",
+    "findInPage": "&Find…",
     "forward": "Framover",
     "helpMenu": "Hjelp",
     "hide": "Skjul {{- appName}}",
@@ -401,6 +402,14 @@
     "zoomIn": "Zoom inn",
     "zoomOut": "Zoom ut",
     "simulateDisconnected": "Simuler frakobling"
+  },
+  "findInPage": {
+    "placeholder": "Find in page",
+    "matchCount": "{{current}} of {{total}}",
+    "noMatches": "No matches",
+    "previous": "Previous match",
+    "next": "Next match",
+    "close": "Close"
   },
   "loadingError": {
     "title": "Serveren kunne ikke lastes inn",

--- a/src/i18n/pl.i18n.json
+++ b/src/i18n/pl.i18n.json
@@ -178,6 +178,7 @@
     "documentation": "Dokumentacja",
     "editMenu": "&Edycja",
     "fileMenu": "&Plik",
+    "findInPage": "&Find…",
     "forward": "&Do przodu",
     "helpMenu": "Po&moc",
     "hide": "Ukryj {{- appName}}",
@@ -207,6 +208,14 @@
     "zoomIn": "Przybliż",
     "zoomOut": "Oddal",
     "simulateDisconnected": "Symuluj rozłączenie"
+  },
+  "findInPage": {
+    "placeholder": "Find in page",
+    "matchCount": "{{current}} of {{total}}",
+    "noMatches": "No matches",
+    "previous": "Previous match",
+    "next": "Next match",
+    "close": "Close"
   },
   "loadingError": {
     "title": "Błąd ładowania serwera",

--- a/src/i18n/pt-BR.i18n.json
+++ b/src/i18n/pt-BR.i18n.json
@@ -330,6 +330,7 @@
     "settings": "Configurações",
     "editMenu": "&Editar",
     "fileMenu": "&Arquivo",
+    "findInPage": "&Find…",
     "forward": "&Avançar",
     "helpMenu": "Aj&uda",
     "hide": "Ocultar {{- appName}}",
@@ -361,6 +362,14 @@
     "zoomIn": "Aumentar zoom",
     "zoomOut": "Diminuir zoom",
     "simulateDisconnected": "Simular desconexão"
+  },
+  "findInPage": {
+    "placeholder": "Find in page",
+    "matchCount": "{{current}} of {{total}}",
+    "noMatches": "No matches",
+    "previous": "Previous match",
+    "next": "Next match",
+    "close": "Close"
   },
   "loadingError": {
     "title": "Servidor Falhou em Carregar",

--- a/src/i18n/ru.i18n.json
+++ b/src/i18n/ru.i18n.json
@@ -313,6 +313,7 @@
     "settings": "Настройки",
     "editMenu": "&Правка",
     "fileMenu": "&Файл",
+    "findInPage": "&Find…",
     "forward": "Вперед",
     "helpMenu": "&Справка",
     "hide": "Скрыть {{- appName}}",
@@ -343,6 +344,14 @@
     "zoomIn": "Увеличить",
     "zoomOut": "Уменьшить",
     "simulateDisconnected": "Симулировать отключение"
+  },
+  "findInPage": {
+    "placeholder": "Find in page",
+    "matchCount": "{{current}} of {{total}}",
+    "noMatches": "No matches",
+    "previous": "Previous match",
+    "next": "Next match",
+    "close": "Close"
   },
   "loadingError": {
     "title": "Не удалось загрузить сервер",

--- a/src/i18n/sv.i18n.json
+++ b/src/i18n/sv.i18n.json
@@ -344,6 +344,7 @@
     "settings": "Inställningar",
     "editMenu": "&Editera",
     "fileMenu": "&Fil",
+    "findInPage": "&Find…",
     "forward": "&Framåt",
     "helpMenu": "&Hjälp",
     "hide": "Göm {{- appName}}",
@@ -379,6 +380,14 @@
     "zoomIn": "Zooma in",
     "zoomOut": "Zooma ut",
     "simulateDisconnected": "Simulera frånkoppling"
+  },
+  "findInPage": {
+    "placeholder": "Find in page",
+    "matchCount": "{{current}} of {{total}}",
+    "noMatches": "No matches",
+    "previous": "Previous match",
+    "next": "Next match",
+    "close": "Close"
   },
   "loadingError": {
     "title": "Servern kunde inte laddas",

--- a/src/i18n/tr-TR.i18n.json
+++ b/src/i18n/tr-TR.i18n.json
@@ -166,6 +166,7 @@
     "documentation": "Dökümantasyon",
     "editMenu": "&Düzenle",
     "fileMenu": "&Dosya",
+    "findInPage": "&Find…",
     "forward": "&İleri",
     "helpMenu": "&Yardım",
     "learnMore": "Daha fazlasını öğren",
@@ -191,6 +192,14 @@
     "zoomIn": "Yakınlaştır",
     "zoomOut": "Uzaklaştır",
     "simulateDisconnected": "Bağlantı Kesilmesini Simüle Et"
+  },
+  "findInPage": {
+    "placeholder": "Find in page",
+    "matchCount": "{{current}} of {{total}}",
+    "noMatches": "No matches",
+    "previous": "Previous match",
+    "next": "Next match",
+    "close": "Close"
   },
   "loadingError": {
     "title": "Sunucu yüklenirken hata oluştu",

--- a/src/i18n/uk-UA.i18n.json
+++ b/src/i18n/uk-UA.i18n.json
@@ -147,6 +147,7 @@
     "documentation": "Документація",
     "editMenu": "&Редагувати",
     "fileMenu": "&Файл",
+    "findInPage": "&Find…",
     "forward": "Вперед",
     "helpMenu": "&Довідка",
     "hide": "Приховати {{- appName}}",
@@ -176,6 +177,14 @@
     "zoomIn": "Збільшити",
     "zoomOut": "Зменшити",
     "simulateDisconnected": "Симулювати відключення"
+  },
+  "findInPage": {
+    "placeholder": "Find in page",
+    "matchCount": "{{current}} of {{total}}",
+    "noMatches": "No matches",
+    "previous": "Previous match",
+    "next": "Next match",
+    "close": "Close"
   },
   "loadingError": {
     "title": "Не вдалося завантажити сервер",

--- a/src/i18n/zh-CN.i18n.json
+++ b/src/i18n/zh-CN.i18n.json
@@ -208,6 +208,7 @@
     "settings": "设置",
     "editMenu": "编辑 (&E)",
     "fileMenu": "文件 (&F)",
+    "findInPage": "&Find…",
     "forward": "下一步 (&F)",
     "helpMenu": "帮助 (&H)",
     "learnMore": "了解更多",
@@ -233,6 +234,14 @@
     "zoomIn": "放大",
     "zoomOut": "缩小",
     "simulateDisconnected": "模拟断开连接"
+  },
+  "findInPage": {
+    "placeholder": "Find in page",
+    "matchCount": "{{current}} of {{total}}",
+    "noMatches": "No matches",
+    "previous": "Previous match",
+    "next": "Next match",
+    "close": "Close"
   },
   "loadingError": {
     "title": "服务器载入失败",

--- a/src/i18n/zh-TW.i18n.json
+++ b/src/i18n/zh-TW.i18n.json
@@ -145,6 +145,7 @@
     "documentation": "文件",
     "editMenu": "編輯 (&E)",
     "fileMenu": "檔案 (&F)",
+    "findInPage": "&Find…",
     "forward": "下一步 (&F)",
     "helpMenu": "幫助 (&H)",
     "learnMore": "了解更多",
@@ -170,6 +171,14 @@
     "zoomIn": "放大",
     "zoomOut": "縮小",
     "simulateDisconnected": "模擬中斷連線"
+  },
+  "findInPage": {
+    "placeholder": "Find in page",
+    "matchCount": "{{current}} of {{total}}",
+    "noMatches": "No matches",
+    "previous": "Previous match",
+    "next": "Next match",
+    "close": "Close"
   },
   "loadingError": {
     "title": "伺服器載入失敗",

--- a/src/ui/actions.ts
+++ b/src/ui/actions.ts
@@ -19,6 +19,7 @@ export const LOADING_ERROR_VIEW_RELOAD_SERVER_CLICKED =
   'loading-error-view/reload-server-clicked';
 export const MENU_BAR_ADD_NEW_SERVER_CLICKED =
   'menu-bar/add-new-server-clicked';
+export const MENU_BAR_FIND_IN_PAGE_CLICKED = 'menu-bar/find-in-page-clicked';
 export const MENU_BAR_SELECT_SERVER_CLICKED = 'menu-bar/select-server-clicked';
 export const MENU_BAR_TOGGLE_IS_MENU_BAR_ENABLED_CLICKED =
   'menu-bar/toggle-is-menu-bar-enabled-clicked';
@@ -194,6 +195,7 @@ export type UiActionTypeToPayloadMap = {
   [CLEAR_CACHE_DIALOG_KEEP_LOGIN_DATA_CLICKED]: WebContents['id'];
   [LOADING_ERROR_VIEW_RELOAD_SERVER_CLICKED]: { url: Server['url'] };
   [MENU_BAR_ADD_NEW_SERVER_CLICKED]: void;
+  [MENU_BAR_FIND_IN_PAGE_CLICKED]: void;
   [MENU_BAR_SELECT_SERVER_CLICKED]: Server['url'];
   [MENU_BAR_TOGGLE_IS_MENU_BAR_ENABLED_CLICKED]: boolean;
   [MENU_BAR_TOGGLE_IS_SHOW_WINDOW_ON_UNREAD_CHANGED_ENABLED_CLICKED]: boolean;

--- a/src/ui/components/ServersView/FindInPageBar.spec.tsx
+++ b/src/ui/components/ServersView/FindInPageBar.spec.tsx
@@ -1,0 +1,172 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { FindInPageBar } from './FindInPageBar';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (key === 'findInPage.matchCount' && opts) {
+        return `${opts.current} of ${opts.total}`;
+      }
+      return key;
+    },
+  }),
+}));
+
+const noop = () => undefined;
+
+describe('FindInPageBar', () => {
+  it('renders the placeholder and match counter', () => {
+    render(
+      <FindInPageBar
+        query='hello'
+        onQueryChange={noop}
+        activeMatchOrdinal={1}
+        matches={3}
+        onNext={noop}
+        onPrevious={noop}
+        onClose={noop}
+      />
+    );
+
+    expect(
+      screen.getByPlaceholderText('findInPage.placeholder')
+    ).toBeInTheDocument();
+    expect(screen.getByText('1 of 3')).toBeInTheDocument();
+  });
+
+  it('shows no matches message when query is set but matches is zero', () => {
+    render(
+      <FindInPageBar
+        query='xyz'
+        onQueryChange={noop}
+        activeMatchOrdinal={0}
+        matches={0}
+        onNext={noop}
+        onPrevious={noop}
+        onClose={noop}
+      />
+    );
+
+    expect(screen.getByText('findInPage.noMatches')).toBeInTheDocument();
+  });
+
+  it('calls onQueryChange when typing', () => {
+    const onQueryChange = jest.fn();
+    render(
+      <FindInPageBar
+        query=''
+        onQueryChange={onQueryChange}
+        activeMatchOrdinal={0}
+        matches={0}
+        onNext={noop}
+        onPrevious={noop}
+        onClose={noop}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('findInPage.placeholder'), {
+      target: { value: 'test' },
+    });
+    expect(onQueryChange).toHaveBeenCalledWith('test');
+  });
+
+  it('calls onNext on Enter and onPrevious on Shift+Enter', () => {
+    const onNext = jest.fn();
+    const onPrevious = jest.fn();
+    render(
+      <FindInPageBar
+        query='hello'
+        onQueryChange={noop}
+        activeMatchOrdinal={1}
+        matches={2}
+        onNext={onNext}
+        onPrevious={onPrevious}
+        onClose={noop}
+      />
+    );
+
+    const input = screen.getByPlaceholderText('findInPage.placeholder');
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onNext).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: true });
+    expect(onPrevious).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose on Escape', () => {
+    const onClose = jest.fn();
+    render(
+      <FindInPageBar
+        query='hello'
+        onQueryChange={noop}
+        activeMatchOrdinal={1}
+        matches={2}
+        onNext={noop}
+        onPrevious={noop}
+        onClose={onClose}
+      />
+    );
+
+    fireEvent.keyDown(screen.getByPlaceholderText('findInPage.placeholder'), {
+      key: 'Escape',
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the same input DOM node across a query change', () => {
+    const { rerender } = render(
+      <FindInPageBar
+        query=''
+        onQueryChange={noop}
+        activeMatchOrdinal={0}
+        matches={0}
+        onNext={noop}
+        onPrevious={noop}
+        onClose={noop}
+      />
+    );
+
+    const inputBeforeTyping = screen.getByPlaceholderText(
+      'findInPage.placeholder'
+    );
+
+    rerender(
+      <FindInPageBar
+        query='a'
+        onQueryChange={noop}
+        activeMatchOrdinal={1}
+        matches={5}
+        onNext={noop}
+        onPrevious={noop}
+        onClose={noop}
+      />
+    );
+
+    const inputAfterTyping = screen.getByPlaceholderText(
+      'findInPage.placeholder'
+    );
+
+    expect(inputAfterTyping).toBe(inputBeforeTyping);
+    expect(screen.getByText('1 of 5')).toBeInTheDocument();
+  });
+
+  it('calls onClose when the close button is clicked', () => {
+    const onClose = jest.fn();
+    render(
+      <FindInPageBar
+        query='hello'
+        onQueryChange={noop}
+        activeMatchOrdinal={1}
+        matches={2}
+        onNext={noop}
+        onPrevious={noop}
+        onClose={onClose}
+      />
+    );
+
+    fireEvent.click(screen.getByTitle('findInPage.close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/ui/components/ServersView/FindInPageBar.tsx
+++ b/src/ui/components/ServersView/FindInPageBar.tsx
@@ -1,0 +1,110 @@
+import styled from '@emotion/styled';
+import { Box, TextInput, IconButton } from '@rocket.chat/fuselage';
+import type { ChangeEvent, KeyboardEvent, Ref } from 'react';
+import { useTranslation } from 'react-i18next';
+
+const Wrapper = styled(Box)`
+  position: absolute;
+  top: 8px;
+  right: 16px;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  border-radius: 4px;
+  background-color: var(--rcx-color-surface-light);
+  box-shadow: var(--rcx-color-shadow-elevation-1);
+`;
+
+type FindInPageBarProps = {
+  query: string;
+  onQueryChange: (query: string) => void;
+  activeMatchOrdinal: number;
+  matches: number;
+  onNext: () => void;
+  onPrevious: () => void;
+  onClose: () => void;
+  inputRef?: Ref<HTMLInputElement>;
+};
+
+export const FindInPageBar = ({
+  query,
+  onQueryChange,
+  activeMatchOrdinal,
+  matches,
+  onNext,
+  onPrevious,
+  onClose,
+  inputRef,
+}: FindInPageBarProps) => {
+  const { t } = useTranslation();
+
+  let counterText = '';
+  if (query.length > 0) {
+    counterText =
+      matches > 0
+        ? t('findInPage.matchCount', {
+            current: activeMatchOrdinal,
+            total: matches,
+          })
+        : t('findInPage.noMatches');
+  }
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>): void => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      if (event.shiftKey) {
+        onPrevious();
+        return;
+      }
+      onNext();
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      onClose();
+    }
+  };
+
+  return (
+    <Wrapper>
+      <TextInput
+        ref={inputRef}
+        value={query}
+        onChange={(event: ChangeEvent<HTMLInputElement>) =>
+          onQueryChange(event.target.value)
+        }
+        onKeyDown={handleKeyDown}
+        placeholder={t('findInPage.placeholder')}
+        addon={
+          <Box fontScale='c1' color='hint'>
+            {counterText}
+          </Box>
+        }
+      />
+      <IconButton
+        icon='chevron-up'
+        small
+        title={t('findInPage.previous')}
+        aria-label={t('findInPage.previous')}
+        onClick={onPrevious}
+      />
+      <IconButton
+        icon='chevron-down'
+        small
+        title={t('findInPage.next')}
+        aria-label={t('findInPage.next')}
+        onClick={onNext}
+      />
+      <IconButton
+        icon='cross'
+        small
+        title={t('findInPage.close')}
+        aria-label={t('findInPage.close')}
+        onClick={onClose}
+      />
+    </Wrapper>
+  );
+};

--- a/src/ui/components/ServersView/ServerPane.spec.tsx
+++ b/src/ui/components/ServersView/ServerPane.spec.tsx
@@ -1,10 +1,40 @@
 import '@testing-library/jest-dom';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { forwardRef } from 'react';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
 
-import { LOADING_ERROR_VIEW_RELOAD_SERVER_CLICKED } from '../../actions';
+import {
+  LOADING_ERROR_VIEW_RELOAD_SERVER_CLICKED,
+  MENU_BAR_FIND_IN_PAGE_CLICKED,
+} from '../../actions';
 import { ServerPane } from './ServerPane';
+
+const listeners: Array<(action: { type: string }) => void> = [];
+
+jest.mock('../../../store', () => ({
+  listen: (
+    type: string,
+    listener: (action: { type: string }) => void
+  ): (() => void) => {
+    const handler = (action: { type: string }): void => {
+      if (action.type === type) {
+        listener(action);
+      }
+    };
+    listeners.push(handler);
+    return () => {
+      const index = listeners.indexOf(handler);
+      if (index !== -1) listeners.splice(index, 1);
+    };
+  },
+}));
+
+const emit = (type: string): void => {
+  act(() => {
+    listeners.slice().forEach((listener) => listener({ type }));
+  });
+};
 
 jest.mock('electron', () => ({
   ipcRenderer: {
@@ -33,9 +63,33 @@ jest.mock('./UnsupportedServer', () => ({
   default: () => <div data-testid='unsupported' />,
 }));
 
+export const mockWebviewFns = {
+  findInPage: jest.fn(),
+  stopFindInPage: jest.fn(),
+  getWebContentsId: jest.fn(() => 1),
+  focus: jest.fn(),
+  blur: jest.fn(),
+  addEventListener: jest.fn(),
+  removeEventListener: jest.fn(),
+};
+
 jest.mock('./styles', () => ({
   DocumentViewerWrapper: ({ children }: any) => <div>{children}</div>,
-  StyledWebView: 'div',
+  StyledWebView: forwardRef((props: any, ref: any) => (
+    <div
+      ref={(node: any) => {
+        if (node) {
+          Object.assign(node, mockWebviewFns);
+        }
+        if (typeof ref === 'function') {
+          ref(node);
+        } else if (ref) {
+          ref.current = node;
+        }
+      }}
+      {...props}
+    />
+  )),
   Wrapper: ({ children, ...props }: any) => (
     <div data-testid='server-pane' {...props}>
       {children}
@@ -46,6 +100,11 @@ jest.mock('./styles', () => ({
 const makeStore = () => createStore((s = {}) => s as any);
 
 describe('ServerPane', () => {
+  beforeEach(() => {
+    listeners.length = 0;
+    Object.values(mockWebviewFns).forEach((fn) => fn.mockClear());
+  });
+
   it('renders selected server pane shell', () => {
     render(
       <Provider store={makeStore()}>
@@ -99,5 +158,118 @@ describe('ServerPane', () => {
       </Provider>
     );
     expect(screen.getByTestId('unsupported')).toBeInTheDocument();
+  });
+
+  it('does not render the find bar by default', () => {
+    render(
+      <Provider store={makeStore()}>
+        <ServerPane
+          lastPath={undefined}
+          serverUrl='https://open.rocket.chat'
+          isSelected
+          isFailed={false}
+          isSupported
+          title='Community'
+        />
+      </Provider>
+    );
+    expect(
+      screen.queryByPlaceholderText('findInPage.placeholder')
+    ).not.toBeInTheDocument();
+  });
+
+  it('opens the find bar for the selected pane when the menu action fires', () => {
+    render(
+      <Provider store={makeStore()}>
+        <ServerPane
+          lastPath={undefined}
+          serverUrl='https://open.rocket.chat'
+          isSelected
+          isFailed={false}
+          isSupported
+          title='Community'
+        />
+      </Provider>
+    );
+
+    emit(MENU_BAR_FIND_IN_PAGE_CLICKED);
+
+    const input = screen.getByPlaceholderText('findInPage.placeholder');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveFocus();
+  });
+
+  it('keeps focus on the find input when the window regains focus while the bar is open', () => {
+    render(
+      <Provider store={makeStore()}>
+        <ServerPane
+          lastPath={undefined}
+          serverUrl='https://open.rocket.chat'
+          isSelected
+          isFailed={false}
+          isSupported
+          title='Community'
+        />
+      </Provider>
+    );
+
+    emit(MENU_BAR_FIND_IN_PAGE_CLICKED);
+
+    const input = screen.getByPlaceholderText('findInPage.placeholder');
+    expect(input).toHaveFocus();
+
+    mockWebviewFns.focus.mockClear();
+    act(() => {
+      window.dispatchEvent(new Event('focus'));
+    });
+
+    expect(mockWebviewFns.focus).not.toHaveBeenCalled();
+    expect(input).toHaveFocus();
+  });
+
+  it('does not open the find bar for an unselected pane', () => {
+    render(
+      <Provider store={makeStore()}>
+        <ServerPane
+          lastPath={undefined}
+          serverUrl='https://open.rocket.chat'
+          isSelected={false}
+          isFailed={false}
+          isSupported
+          title='Community'
+        />
+      </Provider>
+    );
+
+    emit(MENU_BAR_FIND_IN_PAGE_CLICKED);
+
+    expect(
+      screen.queryByPlaceholderText('findInPage.placeholder')
+    ).not.toBeInTheDocument();
+  });
+
+  it('stops find in page on the webview when the bar is closed', () => {
+    render(
+      <Provider store={makeStore()}>
+        <ServerPane
+          lastPath={undefined}
+          serverUrl='https://open.rocket.chat'
+          isSelected
+          isFailed={false}
+          isSupported
+          title='Community'
+        />
+      </Provider>
+    );
+
+    emit(MENU_BAR_FIND_IN_PAGE_CLICKED);
+    fireEvent.click(screen.getByTitle('findInPage.close'));
+
+    expect(mockWebviewFns.stopFindInPage).toHaveBeenCalledWith(
+      'clearSelection'
+    );
+    expect(
+      screen.queryByPlaceholderText('findInPage.placeholder')
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/ui/components/ServersView/ServerPane.tsx
+++ b/src/ui/components/ServersView/ServerPane.tsx
@@ -1,16 +1,20 @@
+import type { FoundInPageEvent } from 'electron';
 import { ipcRenderer } from 'electron';
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import type { Dispatch } from 'redux';
 
+import { listen } from '../../../store';
 import type { RootAction } from '../../../store/actions';
 import {
   LOADING_ERROR_VIEW_RELOAD_SERVER_CLICKED,
+  MENU_BAR_FIND_IN_PAGE_CLICKED,
   WEBVIEW_ATTACHED,
   WEBVIEW_READY,
 } from '../../actions';
 import { getServerPanelId, getServerTabId } from '../utils/getServerDomId';
 import ErrorView from './ErrorView';
+import { FindInPageBar } from './FindInPageBar';
 import UnsupportedServer from './UnsupportedServer';
 import { StyledWebView, Wrapper } from './styles';
 
@@ -40,6 +44,15 @@ export const ServerPane = ({
 
   const webviewRef =
     useRef<ReturnType<(typeof document)['createElement']>>(null);
+  const findInputRef = useRef<HTMLInputElement>(null);
+
+  const [isFindBarOpen, setIsFindBarOpen] = useState(false);
+  const [findQuery, setFindQuery] = useState('');
+  const [findResult, setFindResult] = useState({
+    activeMatchOrdinal: 0,
+    matches: 0,
+  });
+  const [focusRequest, setFocusRequest] = useState(0);
 
   useEffect(() => {
     const webview = webviewRef.current;
@@ -48,7 +61,7 @@ export const ServerPane = ({
     }
 
     const handleWindowFocus = (): void => {
-      if (!isSelected || isFailed) {
+      if (!isSelected || isFailed || isFindBarOpen) {
         return;
       }
 
@@ -60,7 +73,7 @@ export const ServerPane = ({
     return () => {
       window.removeEventListener('focus', handleWindowFocus);
     };
-  }, [isFailed, isSelected, serverUrl]);
+  }, [isFailed, isSelected, isFindBarOpen, serverUrl]);
 
   useEffect(() => {
     const webview = webviewRef.current;
@@ -177,6 +190,142 @@ export const ServerPane = ({
     };
   }, [serverUrl]);
 
+  const closeFindBar = (): void => {
+    const webview = webviewRef.current;
+    try {
+      webview?.stopFindInPage('clearSelection');
+    } catch {
+      // webview may not be attached; nothing to clear
+    }
+    setIsFindBarOpen(false);
+    setFindQuery('');
+    setFindResult({ activeMatchOrdinal: 0, matches: 0 });
+    webview?.focus();
+  };
+
+  useEffect(() => {
+    const unsubscribe = listen(MENU_BAR_FIND_IN_PAGE_CLICKED, () => {
+      if (!isSelected || isFailed) {
+        return;
+      }
+
+      setIsFindBarOpen(true);
+      setFocusRequest((n) => n + 1);
+    });
+
+    return unsubscribe;
+  }, [isSelected, isFailed]);
+
+  useEffect(() => {
+    if (!isFindBarOpen) {
+      return;
+    }
+
+    const input = findInputRef.current;
+    input?.focus();
+    input?.select();
+
+    const rafId = requestAnimationFrame(() => {
+      if (document.activeElement !== input) {
+        input?.focus();
+        input?.select();
+      }
+    });
+
+    return () => {
+      cancelAnimationFrame(rafId);
+    };
+  }, [isFindBarOpen, focusRequest]);
+
+  useEffect(() => {
+    if (!isSelected && isFindBarOpen) {
+      closeFindBar();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSelected]);
+
+  useEffect(
+    () => () => {
+      const webview = webviewRef.current;
+      try {
+        webview?.stopFindInPage('clearSelection');
+      } catch {
+        // webview may not be attached; nothing to clear
+      }
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (!isFindBarOpen) {
+      return;
+    }
+
+    const webview = webviewRef.current;
+    if (!webview) {
+      return;
+    }
+
+    try {
+      if (findQuery.length > 0) {
+        webview.findInPage(findQuery, { findNext: true });
+      } else {
+        webview.stopFindInPage('clearSelection');
+        setFindResult({ activeMatchOrdinal: 0, matches: 0 });
+      }
+    } catch {
+      // webview may not be attached yet
+    }
+  }, [findQuery, isFindBarOpen]);
+
+  useEffect(() => {
+    if (!isFindBarOpen) {
+      return;
+    }
+
+    const webview = webviewRef.current;
+    if (!webview) {
+      return;
+    }
+
+    const handleFoundInPage = (event: FoundInPageEvent): void => {
+      setFindResult({
+        activeMatchOrdinal: event.result.activeMatchOrdinal,
+        matches: event.result.matches,
+      });
+    };
+
+    webview.addEventListener('found-in-page', handleFoundInPage);
+
+    return () => {
+      webview.removeEventListener('found-in-page', handleFoundInPage);
+    };
+  }, [isFindBarOpen]);
+
+  const handleFindNext = (): void => {
+    const webview = webviewRef.current;
+    if (!webview || findQuery.length === 0) {
+      return;
+    }
+    try {
+      webview.findInPage(findQuery, { forward: true, findNext: false });
+    } catch {
+      // webview may not be attached yet
+    }
+  };
+
+  const handleFindPrevious = (): void => {
+    const webview = webviewRef.current;
+    if (!webview || findQuery.length === 0) {
+      return;
+    }
+    try {
+      webview.findInPage(findQuery, { forward: false, findNext: false });
+    } catch {
+      // webview may not be attached yet
+    }
+  };
+
   return (
     <Wrapper
       isVisible={isSelected}
@@ -200,6 +349,18 @@ export const ServerPane = ({
         serverUrl={serverUrl}
       />
       <ErrorView isFailed={isFailed} onReload={handleReload} />
+      {isFindBarOpen && !isFailed && (
+        <FindInPageBar
+          query={findQuery}
+          onQueryChange={setFindQuery}
+          activeMatchOrdinal={findResult.activeMatchOrdinal}
+          matches={findResult.matches}
+          onNext={handleFindNext}
+          onPrevious={handleFindPrevious}
+          onClose={closeFindBar}
+          inputRef={findInputRef}
+        />
+      )}
     </Wrapper>
   );
 };

--- a/src/ui/main/menuBar.ts
+++ b/src/ui/main/menuBar.ts
@@ -21,6 +21,7 @@ import {
   APP_MENU_TRIGGERED,
   CLEAR_CACHE_TRIGGERED,
   MENU_BAR_ADD_NEW_SERVER_CLICKED,
+  MENU_BAR_FIND_IN_PAGE_CLICKED,
   MENU_BAR_SELECT_SERVER_CLICKED,
   MENU_BAR_SET_NAVIGATION_LAYOUT_CLICKED,
   MENU_BAR_TOGGLE_IS_MENU_BAR_ENABLED_CLICKED,
@@ -300,6 +301,21 @@ export const createEditMenu = createSelector(
         id: 'selectAll',
         label: t('menus.selectAll'),
         role: 'selectAll',
+      },
+      { type: 'separator' },
+      {
+        id: 'findInPage',
+        label: t('menus.findInPage'),
+        accelerator: 'CommandOrControl+F',
+        click: async () => {
+          const browserWindow = await getRootWindow();
+
+          if (!browserWindow.isVisible()) {
+            browserWindow.showInactive();
+          }
+          browserWindow.focus();
+          dispatch({ type: MENU_BAR_FIND_IN_PAGE_CLICKED });
+        },
       },
     ],
   })


### PR DESCRIPTION
## Summary

Makes Cmd+F / Ctrl+F work in the desktop app: a browser-style find bar searches the visible text of the active workspace.

- Add a "Find…" item with `CommandOrControl+F` to the Edit menu. Keystrokes inside the workspace webview never reach the host window, so the menu accelerator is what carries the shortcut.
- Add `FindInPageBar` (Fuselage text input, "n of m" counter, previous/next/close). Enter steps forward, Shift+Enter back, Escape closes and clears highlights.
- Wire `ServerPane` to the selected webview's `findInPage` / `stopFindInPage` / `found-in-page`; highlights are cleared on close, workspace switch and unmount, and focus returns to the webview.
- Keep keyboard focus on the find input: focus after the input mounts, skip the window-focus webview refocus while the bar is open, and always render the counter addon so Fuselage does not remount the input on the first keystroke.
- Add `menus.findInPage` and `findInPage.*` strings to English and the 16 other wired locales (English fallback text).

## Verification

- Running dev app: open via shortcut, typing updates the counter and highlights, Enter / Shift+Enter stepping, "No matches" state, re-trigger selects the query, Escape closes and refocuses the webview.
- `yarn test` on FindInPageBar, ServerPane and menuBar specs: 46 tests passed.
- `yarn lint` (eslint + tsc): clean.

## Manual checks for reviewers

- Ctrl+F on Windows/Linux with the menu bar hidden.
- Cmd+F while the cursor is in the chat composer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Find in Page functionality, accessible from the Edit menu with `Ctrl/Cmd+F`.
  * Added a search bar showing match counts, no-match feedback, and previous/next navigation.
  * Added keyboard shortcuts for navigating results and closing the search bar.
  * Added localized labels for the feature across supported languages.

* **Tests**
  * Added coverage for search behavior, navigation, focus handling, closing, and pane selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->