### PR TITLE
CORE-2685 Show camera, microphone and screen-share indicators on workspace tabs

### DIFF
--- a/src/i18n/en.i18n.json
+++ b/src/i18n/en.i18n.json
@@ -601,7 +601,10 @@
       "audioPlaying": "Playing audio",
       "audioMuted": "Muted",
       "muteWorkspace": "Mute workspace",
-      "unmuteWorkspace": "Unmute workspace"
+      "unmuteWorkspace": "Unmute workspace",
+      "captureScreen": "Sharing screen",
+      "captureCamera": "Camera on",
+      "captureMicrophone": "Microphone on"
     }
   },
   "tabBar": {

--- a/src/i18n/hu.i18n.json
+++ b/src/i18n/hu.i18n.json
@@ -445,7 +445,10 @@
       "audioPlaying": "Playing audio",
       "audioMuted": "Muted",
       "muteWorkspace": "Mute workspace",
-      "unmuteWorkspace": "Unmute workspace"
+      "unmuteWorkspace": "Unmute workspace",
+      "captureScreen": "Sharing screen",
+      "captureCamera": "Camera on",
+      "captureMicrophone": "Microphone on"
     }
   },
   "tabBar": {

--- a/src/i18n/no.i18n.json
+++ b/src/i18n/no.i18n.json
@@ -458,7 +458,10 @@
       "audioPlaying": "Playing audio",
       "audioMuted": "Muted",
       "muteWorkspace": "Mute workspace",
-      "unmuteWorkspace": "Unmute workspace"
+      "unmuteWorkspace": "Unmute workspace",
+      "captureScreen": "Sharing screen",
+      "captureCamera": "Camera on",
+      "captureMicrophone": "Microphone on"
     }
   },
   "tabBar": {

--- a/src/i18n/pt-BR.i18n.json
+++ b/src/i18n/pt-BR.i18n.json
@@ -416,7 +416,10 @@
       "audioPlaying": "Playing audio",
       "audioMuted": "Muted",
       "muteWorkspace": "Mute workspace",
-      "unmuteWorkspace": "Unmute workspace"
+      "unmuteWorkspace": "Unmute workspace",
+      "captureScreen": "Sharing screen",
+      "captureCamera": "Camera on",
+      "captureMicrophone": "Microphone on"
     }
   },
   "tabBar": {

--- a/src/i18n/sv.i18n.json
+++ b/src/i18n/sv.i18n.json
@@ -436,7 +436,10 @@
       "audioPlaying": "Playing audio",
       "audioMuted": "Muted",
       "muteWorkspace": "Mute workspace",
-      "unmuteWorkspace": "Unmute workspace"
+      "unmuteWorkspace": "Unmute workspace",
+      "captureScreen": "Sharing screen",
+      "captureCamera": "Camera on",
+      "captureMicrophone": "Microphone on"
     }
   },
   "tabBar": {

--- a/src/ipc/channels.ts
+++ b/src/ipc/channels.ts
@@ -2,7 +2,7 @@ import type { AnyAction } from 'redux';
 
 import type { Download } from '../downloads/common';
 import type { OutlookEventsResponse } from '../outlookCalendar/type';
-import type { Server } from '../servers/common';
+import type { MediaCaptureState, Server } from '../servers/common';
 import type { TelephonyDiagnostics } from '../telephony/diagnostics';
 import type { SystemIdleState } from '../userPresence/common';
 
@@ -68,6 +68,7 @@ type ChannelToArgsMap = {
   'video-call-window/prewarm-capturer-cache': () => {
     success: boolean;
   };
+  'video-call-window/media-capture-changed': (state: MediaCaptureState) => void;
   'jitsi-desktop-capturer-get-sources': (
     args: [options: Electron.SourcesOptions, jitsiDomain: string]
   ) => Electron.DesktopCapturerSource[];

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -6,6 +6,7 @@ import { JitsiMeetElectron } from './jitsi/preload';
 import { listenToNotificationsRequests } from './notifications/preload';
 import { listenToScreenSharingRequests } from './screenSharing/preload';
 import { RocketChatDesktop } from './servers/preload/api';
+import { listenToMediaCaptureReports } from './servers/preload/mediaCapture';
 import { listenToNavigateToRouteRequests } from './servers/preload/navigateToRoute';
 import { listenToPresenceChangeRequests } from './servers/preload/presence';
 import { setServerUrl } from './servers/preload/urls';
@@ -60,6 +61,7 @@ const start = async (): Promise<void> => {
   window.removeEventListener('load', start);
 
   setServerUrl(serverUrl);
+  listenToMediaCaptureReports();
 
   await whenReady();
 

--- a/src/servers/common.ts
+++ b/src/servers/common.ts
@@ -3,6 +3,14 @@ import type { SupportedVersions } from './supportedVersions/types';
 
 export type UserPresence = 'online' | 'away' | 'busy' | 'offline';
 
+export type MediaCaptureState = {
+  camera: boolean;
+  microphone: boolean;
+  screen: boolean;
+};
+
+export type MediaCaptureSource = 'workspace' | 'videoCall';
+
 export type Server = {
   url: string;
   title?: string;
@@ -39,6 +47,7 @@ export type Server = {
   presenceSupported?: boolean;
   isAudible?: boolean;
   isAudioMuted?: boolean;
+  mediaCapture?: Partial<Record<MediaCaptureSource, MediaCaptureState>>;
 };
 
 export const enum ServerUrlResolutionStatus {

--- a/src/servers/main/preloadCoverage.main.spec.ts
+++ b/src/servers/main/preloadCoverage.main.spec.ts
@@ -89,7 +89,10 @@ jest.mock('electron', () => ({
   contextBridge: {
     exposeInMainWorld: (...args: any[]) => (exposeInMainWorld as any)(...args),
   },
-  webFrame: { setZoomFactor: jest.fn() },
+  webFrame: {
+    setZoomFactor: jest.fn(),
+    executeJavaScript: jest.fn(() => Promise.resolve()),
+  },
   clipboard: {
     writeText: jest.fn(),
     readText: jest.fn(() => 'clip'),

--- a/src/servers/preload/__tests__/mediaCapture.spec.ts
+++ b/src/servers/preload/__tests__/mediaCapture.spec.ts
@@ -1,0 +1,197 @@
+/** @jest-environment jsdom */
+import { installMediaCaptureHook } from '../mediaCapture';
+
+type FakeTrack = {
+  kind: 'audio' | 'video';
+  readyState: 'live' | 'ended';
+  addEventListener: jest.Mock;
+  stop: () => void;
+  _endedHandlers: Array<() => void>;
+};
+
+// Constructed via `new (window as any).MediaStreamTrack()` so `track.stop()`
+// resolves through the (possibly hook-patched) prototype method, matching how
+// a real MediaStreamTrack instance behaves.
+const createFakeTrack = (kind: 'audio' | 'video'): FakeTrack => {
+  const track = new (window as any).MediaStreamTrack() as FakeTrack;
+  track.kind = kind;
+  track.readyState = 'live';
+  track._endedHandlers = [];
+  track.addEventListener = jest.fn((event: string, handler: () => void) => {
+    if (event === 'ended') {
+      track._endedHandlers.push(handler);
+    }
+  });
+
+  return track;
+};
+
+const createFakeStream = (tracks: FakeTrack[]) => ({
+  getTracks: () => tracks,
+});
+
+describe('servers/preload/mediaCapture hook script', () => {
+  let reportMediaCapture: jest.Mock;
+  let getUserMediaMock: jest.Mock;
+  let getDisplayMediaMock: jest.Mock;
+
+  const installHook = (): void => {
+    installMediaCaptureHook();
+  };
+
+  beforeEach(() => {
+    reportMediaCapture = jest.fn();
+    getUserMediaMock = jest.fn();
+    getDisplayMediaMock = jest.fn();
+
+    delete (window as any).__rcDesktopMediaCaptureHooked;
+    (window as any).RocketChatDesktop = { reportMediaCapture };
+
+    Object.defineProperty(window.navigator, 'mediaDevices', {
+      configurable: true,
+      value: {
+        getUserMedia: getUserMediaMock,
+        getDisplayMedia: getDisplayMediaMock,
+      },
+    });
+
+    (window as any).MediaStreamTrack = function MediaStreamTrack(
+      this: FakeTrack
+    ) {
+      this.readyState = 'live';
+    };
+    (window as any).MediaStreamTrack.prototype.stop = function stop(
+      this: FakeTrack
+    ) {
+      this.readyState = 'ended';
+    };
+
+    installHook();
+  });
+
+  it('reports camera true after getUserMedia resolves a video track', async () => {
+    const videoTrack = createFakeTrack('video');
+    getUserMediaMock.mockResolvedValue(createFakeStream([videoTrack]));
+
+    await window.navigator.mediaDevices.getUserMedia({ video: true } as any);
+
+    expect(reportMediaCapture).toHaveBeenCalledTimes(1);
+    expect(reportMediaCapture).toHaveBeenCalledWith({
+      camera: true,
+      microphone: false,
+      screen: false,
+    });
+  });
+
+  it('reports microphone true after getUserMedia resolves an audio track', async () => {
+    const audioTrack = createFakeTrack('audio');
+    getUserMediaMock.mockResolvedValue(createFakeStream([audioTrack]));
+
+    await window.navigator.mediaDevices.getUserMedia({ audio: true } as any);
+
+    expect(reportMediaCapture).toHaveBeenCalledWith({
+      camera: false,
+      microphone: true,
+      screen: false,
+    });
+  });
+
+  it('reports screen true after getDisplayMedia resolves', async () => {
+    const screenTrack = createFakeTrack('video');
+    getDisplayMediaMock.mockResolvedValue(createFakeStream([screenTrack]));
+
+    await window.navigator.mediaDevices.getDisplayMedia({} as any);
+
+    expect(reportMediaCapture).toHaveBeenCalledWith({
+      camera: false,
+      microphone: false,
+      screen: true,
+    });
+  });
+
+  it('reports state false again after the track is stopped via track.stop()', async () => {
+    const videoTrack = createFakeTrack('video');
+    getUserMediaMock.mockResolvedValue(createFakeStream([videoTrack]));
+
+    await window.navigator.mediaDevices.getUserMedia({ video: true } as any);
+    reportMediaCapture.mockClear();
+
+    videoTrack.stop();
+
+    expect(reportMediaCapture).toHaveBeenCalledTimes(1);
+    expect(reportMediaCapture).toHaveBeenCalledWith({
+      camera: false,
+      microphone: false,
+      screen: false,
+    });
+  });
+
+  it('reports state false again after the track fires "ended"', async () => {
+    const videoTrack = createFakeTrack('video');
+    getUserMediaMock.mockResolvedValue(createFakeStream([videoTrack]));
+
+    await window.navigator.mediaDevices.getUserMedia({ video: true } as any);
+    reportMediaCapture.mockClear();
+
+    videoTrack.readyState = 'ended';
+    videoTrack._endedHandlers.forEach((handler) => handler());
+
+    expect(reportMediaCapture).toHaveBeenCalledTimes(1);
+    expect(reportMediaCapture).toHaveBeenCalledWith({
+      camera: false,
+      microphone: false,
+      screen: false,
+    });
+  });
+
+  it('does not report duplicate identical state', async () => {
+    const videoTrack = createFakeTrack('video');
+    const audioTrack = createFakeTrack('audio');
+    getUserMediaMock.mockResolvedValue(
+      createFakeStream([videoTrack, audioTrack])
+    );
+
+    await window.navigator.mediaDevices.getUserMedia({
+      video: true,
+      audio: true,
+    } as any);
+    expect(reportMediaCapture).toHaveBeenCalledTimes(1);
+
+    // A second getUserMedia call that adds no new distinct state must not
+    // trigger a second report.
+    const secondVideoTrack = createFakeTrack('video');
+    getUserMediaMock.mockResolvedValue(createFakeStream([secondVideoTrack]));
+    await window.navigator.mediaDevices.getUserMedia({ video: true } as any);
+
+    expect(reportMediaCapture).toHaveBeenCalledTimes(1);
+  });
+
+  it('also reports through window.videoCallWindow.reportMediaCapture when present', async () => {
+    const videoCallReport = jest.fn();
+    (window as any).videoCallWindow = { reportMediaCapture: videoCallReport };
+
+    const videoTrack = createFakeTrack('video');
+    getUserMediaMock.mockResolvedValue(createFakeStream([videoTrack]));
+
+    await window.navigator.mediaDevices.getUserMedia({ video: true } as any);
+
+    expect(videoCallReport).toHaveBeenCalledWith({
+      camera: true,
+      microphone: false,
+      screen: false,
+    });
+  });
+
+  it('does not install the hook twice', async () => {
+    installHook();
+
+    const videoTrack = createFakeTrack('video');
+    getUserMediaMock.mockResolvedValue(createFakeStream([videoTrack]));
+
+    // getUserMedia should still be wrapped exactly once: calling it resolves
+    // without throwing and reports exactly once.
+    await window.navigator.mediaDevices.getUserMedia({ video: true } as any);
+
+    expect(reportMediaCapture).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/servers/preload/api.ts
+++ b/src/servers/preload/api.ts
@@ -14,9 +14,11 @@ import {
   clearOutlookCredentials,
   setUserToken,
 } from '../../outlookCalendar/preload';
+import { dispatch } from '../../store';
 import { onTelephonyCallRequested } from '../../telephony/preload';
+import { WEBVIEW_MEDIA_CAPTURE_CHANGED } from '../../ui/actions';
 import { setUserPresenceDetection } from '../../userPresence/preload';
-import type { Server } from '../common';
+import type { MediaCaptureState, Server } from '../common';
 import { setBadge } from './badge';
 import { writeTextToClipboard } from './clipboard';
 import {
@@ -41,13 +43,31 @@ import {
 } from './sidebar';
 import { setUserThemeAppearance } from './themeAppearance';
 import { setTitle } from './title';
-import { setUrlResolver } from './urls';
+import { getServerUrl, setUrlResolver } from './urls';
 import { setUserLoggedIn } from './userLoggedIn';
 import { setUserRoles } from './userRoles';
 import { setVersion } from './version';
 
 type ServerInfo = {
   version: string;
+};
+
+const isMediaCaptureState = (value: unknown): value is MediaCaptureState =>
+  typeof value === 'object' &&
+  value !== null &&
+  typeof (value as MediaCaptureState).camera === 'boolean' &&
+  typeof (value as MediaCaptureState).microphone === 'boolean' &&
+  typeof (value as MediaCaptureState).screen === 'boolean';
+
+const reportMediaCapture = (state: MediaCaptureState): void => {
+  if (!isMediaCaptureState(state)) {
+    return;
+  }
+
+  dispatch({
+    type: WEBVIEW_MEDIA_CAPTURE_CHANGED,
+    payload: { url: getServerUrl(), source: 'workspace', state },
+  });
 };
 
 export let serverInfo: ServerInfo;
@@ -78,6 +98,7 @@ type ExtendedIRocketChatDesktop = IRocketChatDesktop & {
       statusText?: string
     ) => void
   ) => void;
+  reportMediaCapture: (state: MediaCaptureState) => void;
 };
 
 declare global {
@@ -110,6 +131,7 @@ export const RocketChatDesktop: Window['RocketChatDesktop'] = {
   setUserRoles,
   setUserPresence,
   onPresenceChangeRequested,
+  reportMediaCapture,
   setUserThemeAppearance,
   createNotification,
   destroyNotification,

--- a/src/servers/preload/mediaCapture.ts
+++ b/src/servers/preload/mediaCapture.ts
@@ -1,0 +1,174 @@
+import { webFrame } from 'electron';
+
+type TrackKind = 'camera' | 'microphone' | 'screen';
+
+type MediaCaptureState = {
+  camera: boolean;
+  microphone: boolean;
+  screen: boolean;
+};
+
+/**
+ * Runs inside the page's main world (injected via `webFrame.executeJavaScript`
+ * — see below) OR called directly in unit tests against a fake `window` /
+ * `navigator`. Electron gives us no active-capture event, so the only
+ * reliable signal is patching `getUserMedia`/`getDisplayMedia` and tracking
+ * the returned MediaStreamTracks' lifecycle ourselves.
+ *
+ * Reused verbatim by the video-call window's preload — that is why it reports
+ * through BOTH `window.RocketChatDesktop?.reportMediaCapture` (workspace
+ * webview bridge) and `window.videoCallWindow?.reportMediaCapture` (video
+ * call window bridge); whichever bridge exists in that page picks it up.
+ *
+ * Has no closed-over references outside the global `window`, since its
+ * `.toString()` is executed verbatim in the page's main world by
+ * `webFrame.executeJavaScript` (see `MEDIA_CAPTURE_HOOK_SCRIPT` below) — that
+ * verbatim re-execution is what makes this dependency-free function safe to
+ * ship as a string.
+ */
+export function installMediaCaptureHook(): void {
+  const win = window as any;
+
+  if (win.__rcDesktopMediaCaptureHooked) {
+    return;
+  }
+  win.__rcDesktopMediaCaptureHooked = true;
+
+  const tracks = new Set<{ track: any; kind: TrackKind }>();
+  let lastReported: MediaCaptureState | null = null;
+
+  const computeState = (): MediaCaptureState => {
+    let camera = false;
+    let microphone = false;
+    let screen = false;
+    tracks.forEach((entry) => {
+      if (entry.track.readyState !== 'live') {
+        return;
+      }
+      if (entry.kind === 'screen') {
+        screen = true;
+      } else if (entry.kind === 'camera') {
+        camera = true;
+      } else if (entry.kind === 'microphone') {
+        microphone = true;
+      }
+    });
+    return { camera, microphone, screen };
+  };
+
+  const report = (): void => {
+    const state = computeState();
+    if (
+      lastReported &&
+      lastReported.camera === state.camera &&
+      lastReported.microphone === state.microphone &&
+      lastReported.screen === state.screen
+    ) {
+      return;
+    }
+    lastReported = state;
+    if (typeof win.RocketChatDesktop?.reportMediaCapture === 'function') {
+      win.RocketChatDesktop.reportMediaCapture(state);
+    }
+    if (typeof win.videoCallWindow?.reportMediaCapture === 'function') {
+      win.videoCallWindow.reportMediaCapture(state);
+    }
+  };
+
+  const untrack = (mediaStreamTrack: any): void => {
+    let removed = false;
+    tracks.forEach((entry) => {
+      if (entry.track === mediaStreamTrack) {
+        tracks.delete(entry);
+        removed = true;
+      }
+    });
+    if (removed) {
+      report();
+    }
+  };
+
+  const trackKindFor = (
+    kindLabelFor: 'userMedia' | 'screen',
+    mediaStreamTrack: any
+  ): TrackKind => {
+    if (kindLabelFor === 'screen') {
+      return 'screen';
+    }
+    return mediaStreamTrack.kind === 'video' ? 'camera' : 'microphone';
+  };
+
+  const track = (mediaStream: any, kindLabelFor: 'userMedia' | 'screen') => {
+    mediaStream.getTracks().forEach((mediaStreamTrack: any) => {
+      const kind = trackKindFor(kindLabelFor, mediaStreamTrack);
+      tracks.add({ track: mediaStreamTrack, kind });
+      mediaStreamTrack.addEventListener('ended', () => {
+        untrack(mediaStreamTrack);
+      });
+    });
+    report();
+  };
+
+  if (typeof win.MediaStreamTrack?.prototype?.stop === 'function') {
+    const originalStop = win.MediaStreamTrack.prototype.stop;
+    win.MediaStreamTrack.prototype.stop = function (this: any, ...args: any[]) {
+      const result = originalStop.apply(this, args);
+      untrack(this);
+      return result;
+    };
+  }
+
+  const mediaDevices = win.navigator?.mediaDevices;
+
+  if (typeof mediaDevices?.getUserMedia === 'function') {
+    const originalGetUserMedia = mediaDevices.getUserMedia;
+    mediaDevices.getUserMedia = function (this: any, ...args: any[]) {
+      return originalGetUserMedia.apply(this, args).then((stream: any) => {
+        track(stream, 'userMedia');
+        return stream;
+      });
+    };
+  }
+
+  if (typeof mediaDevices?.getDisplayMedia === 'function') {
+    const originalGetDisplayMedia = mediaDevices.getDisplayMedia;
+    mediaDevices.getDisplayMedia = function (this: any, ...args: any[]) {
+      return originalGetDisplayMedia.apply(this, args).then((stream: any) => {
+        track(stream, 'screen');
+        return stream;
+      });
+    };
+  }
+}
+
+/**
+ * Self-contained IIFE string (`installMediaCaptureHook`'s source, wrapped in
+ * an immediately-invoked call) injected into the page's main world via
+ * `webFrame.executeJavaScript`. The function body has no free variables other
+ * than the global `window`, so its `.toString()` re-executes correctly in
+ * that separate JS context.
+ */
+export const MEDIA_CAPTURE_HOOK_SCRIPT = `(${installMediaCaptureHook.toString()})();`;
+
+let injected = false;
+
+/**
+ * Injects the media-capture hook script into the workspace webview's page (its
+ * main world) so we can observe getUserMedia/getDisplayMedia calls from the
+ * preload's isolated context, where the page's `navigator` can't be patched
+ * directly. Must run in preload, before the page's own scripts call into
+ * `navigator.mediaDevices` — preload always runs first.
+ */
+export const listenToMediaCaptureReports = (): void => {
+  if (injected) {
+    return;
+  }
+  injected = true;
+
+  webFrame.executeJavaScript(MEDIA_CAPTURE_HOOK_SCRIPT).catch((error) => {
+    console.error(
+      '[Rocket.Chat Desktop] Failed to inject media capture hook:',
+      error
+    );
+  });
+};

--- a/src/servers/reducers.ts
+++ b/src/servers/reducers.ts
@@ -21,6 +21,7 @@ import {
   WEBVIEW_FAVICON_CHANGED,
   WEBVIEW_AUDIO_STATE_CHANGED,
   WEBVIEW_AUDIO_MUTED_CHANGED,
+  WEBVIEW_MEDIA_CAPTURE_CHANGED,
   WEBVIEW_DID_START_LOADING,
   WEBVIEW_DID_FAIL_LOAD,
   WEBVIEW_READY,
@@ -66,6 +67,7 @@ type ServersActionTypes =
   | ActionOf<typeof WEBVIEW_FAVICON_CHANGED>
   | ActionOf<typeof WEBVIEW_AUDIO_STATE_CHANGED>
   | ActionOf<typeof WEBVIEW_AUDIO_MUTED_CHANGED>
+  | ActionOf<typeof WEBVIEW_MEDIA_CAPTURE_CHANGED>
   | ActionOf<typeof APP_SETTINGS_LOADED>
   | ActionOf<typeof WEBVIEW_DID_START_LOADING>
   | ActionOf<typeof WEBVIEW_DID_FAIL_LOAD>
@@ -272,6 +274,22 @@ export const servers: Reducer<Server[], ServersActionTypes> = (
       return update(state, { url, isAudioMuted });
     }
 
+    case WEBVIEW_MEDIA_CAPTURE_CHANGED: {
+      const { url, source, state: captureState } = action.payload;
+      const index = state.findIndex((server) => server.url === url);
+      if (index === -1) {
+        return state;
+      }
+      const server = state[index];
+      const nextMediaCapture = { ...server.mediaCapture };
+      if (captureState === null) {
+        delete nextMediaCapture[source];
+      } else {
+        nextMediaCapture[source] = captureState;
+      }
+      return update(state, { url, mediaCapture: nextMediaCapture });
+    }
+
     case WEBVIEW_DID_NAVIGATE: {
       const { url, pageUrl } = action.payload;
       if (pageUrl?.includes(url)) {
@@ -300,6 +318,9 @@ export const servers: Reducer<Server[], ServersActionTypes> = (
       return servers.map((server: Server) => ({
         ...server,
         url: ensureUrlFormat(server.url),
+        isAudible: false,
+        isAudioMuted: false,
+        mediaCapture: undefined,
       }));
     }
 
@@ -312,6 +333,7 @@ export const servers: Reducer<Server[], ServersActionTypes> = (
         documentViewerFormat: '',
         isAudible: false,
         isAudioMuted: false,
+        mediaCapture: undefined,
       }));
     }
 

--- a/src/servers/reducers/__tests__/servers.spec.ts
+++ b/src/servers/reducers/__tests__/servers.spec.ts
@@ -15,6 +15,7 @@ import {
   WEBVIEW_FAVICON_CHANGED,
   WEBVIEW_AUDIO_STATE_CHANGED,
   WEBVIEW_AUDIO_MUTED_CHANGED,
+  WEBVIEW_MEDIA_CAPTURE_CHANGED,
   WEBVIEW_DID_START_LOADING,
   WEBVIEW_DID_FAIL_LOAD,
   WEBVIEW_READY,
@@ -364,6 +365,79 @@ describe('servers reducer', () => {
     });
   });
 
+  describe('WEBVIEW_MEDIA_CAPTURE_CHANGED', () => {
+    it('should set the media capture state for a source', () => {
+      const newState = servers([existing], {
+        type: WEBVIEW_MEDIA_CAPTURE_CHANGED,
+        payload: {
+          url,
+          source: 'workspace',
+          state: { camera: true, microphone: false, screen: false },
+        },
+      } as any);
+
+      expect(newState[0].mediaCapture).toEqual({
+        workspace: { camera: true, microphone: false, screen: false },
+      });
+    });
+
+    it('should merge a second source alongside an existing one', () => {
+      const withWorkspace: Server = {
+        ...existing,
+        mediaCapture: {
+          workspace: { camera: true, microphone: false, screen: false },
+        },
+      };
+
+      const newState = servers([withWorkspace], {
+        type: WEBVIEW_MEDIA_CAPTURE_CHANGED,
+        payload: {
+          url,
+          source: 'videoCall',
+          state: { camera: false, microphone: true, screen: false },
+        },
+      } as any);
+
+      expect(newState[0].mediaCapture).toEqual({
+        workspace: { camera: true, microphone: false, screen: false },
+        videoCall: { camera: false, microphone: true, screen: false },
+      });
+    });
+
+    it('should clear a source when state is null', () => {
+      const withBoth: Server = {
+        ...existing,
+        mediaCapture: {
+          workspace: { camera: true, microphone: false, screen: false },
+          videoCall: { camera: false, microphone: true, screen: false },
+        },
+      };
+
+      const newState = servers([withBoth], {
+        type: WEBVIEW_MEDIA_CAPTURE_CHANGED,
+        payload: { url, source: 'workspace', state: null },
+      } as any);
+
+      expect(newState[0].mediaCapture).toEqual({
+        videoCall: { camera: false, microphone: true, screen: false },
+      });
+    });
+
+    it('should not modify state for an unknown url', () => {
+      const state = [existing];
+      const newState = servers(state, {
+        type: WEBVIEW_MEDIA_CAPTURE_CHANGED,
+        payload: {
+          url: 'https://unknown.rocket.chat/',
+          source: 'workspace',
+          state: { camera: true, microphone: false, screen: false },
+        },
+      } as any);
+
+      expect(newState).toBe(state);
+    });
+  });
+
   describe('WEBVIEW_DID_NAVIGATE', () => {
     it('should set lastPath when pageUrl includes the server url', () => {
       const newState = servers([existing], {
@@ -447,6 +521,28 @@ describe('servers reducer', () => {
 
       expect(newState[0].url).toBe('https://open.rocket.chat/');
     });
+
+    it('should reset audio state flags and mediaCapture for a persisted server', () => {
+      const newState = servers([], {
+        type: SERVERS_LOADED,
+        payload: {
+          servers: [
+            {
+              url: 'https://open.rocket.chat',
+              isAudible: true,
+              isAudioMuted: true,
+              mediaCapture: {
+                workspace: { camera: true, microphone: false, screen: false },
+              },
+            },
+          ],
+        },
+      } as any);
+
+      expect(newState[0].isAudible).toBe(false);
+      expect(newState[0].isAudioMuted).toBe(false);
+      expect(newState[0].mediaCapture).toBeUndefined();
+    });
   });
 
   describe('APP_SETTINGS_LOADED', () => {
@@ -477,6 +573,24 @@ describe('servers reducer', () => {
 
       expect(newState[0].isAudible).toBe(false);
       expect(newState[0].isAudioMuted).toBe(false);
+    });
+
+    it('should reset mediaCapture', () => {
+      const newState = servers([], {
+        type: APP_SETTINGS_LOADED,
+        payload: {
+          servers: [
+            {
+              url: 'https://open.rocket.chat',
+              mediaCapture: {
+                workspace: { camera: true, microphone: false, screen: false },
+              },
+            },
+          ],
+        },
+      } as any);
+
+      expect(newState[0].mediaCapture).toBeUndefined();
     });
 
     it('should fall back to current state when servers missing', () => {

--- a/src/ui/actions.ts
+++ b/src/ui/actions.ts
@@ -1,6 +1,10 @@
 import type { WebContents } from 'electron';
 
-import type { Server } from '../servers/common';
+import type {
+  MediaCaptureSource,
+  MediaCaptureState,
+  Server,
+} from '../servers/common';
 import type { NavigationLayout, RootWindowIcon, WindowState } from './common';
 
 export const ABOUT_DIALOG_DISMISSED = 'about-dialog/dismissed';
@@ -61,6 +65,7 @@ export const WEBVIEW_DID_START_LOADING = 'webview/did-start-loading';
 export const WEBVIEW_FAVICON_CHANGED = 'webview/favicon-changed';
 export const WEBVIEW_AUDIO_STATE_CHANGED = 'webview/audio-state-changed';
 export const WEBVIEW_AUDIO_MUTED_CHANGED = 'webview/audio-muted-changed';
+export const WEBVIEW_MEDIA_CAPTURE_CHANGED = 'webview/media-capture-changed';
 export const WEBVIEW_FOCUS_REQUESTED = 'webview/focus-requested';
 export const WEBVIEW_MESSAGE_BOX_BLURRED = 'webview/message-box-blurred';
 export const WEBVIEW_MESSAGE_BOX_FOCUSED = 'webview/message-box-focused';
@@ -239,6 +244,11 @@ export type UiActionTypeToPayloadMap = {
   [WEBVIEW_AUDIO_MUTED_CHANGED]: {
     url: Server['url'];
     isAudioMuted: boolean;
+  };
+  [WEBVIEW_MEDIA_CAPTURE_CHANGED]: {
+    url: Server['url'];
+    source: MediaCaptureSource;
+    state: MediaCaptureState | null;
   };
   [WEBVIEW_FOCUS_REQUESTED]: { url: string; view: 'server' | 'downloads' };
   [WEBVIEW_MESSAGE_BOX_BLURRED]: void;

--- a/src/ui/components/TabBar/WorkspaceTab.spec.tsx
+++ b/src/ui/components/TabBar/WorkspaceTab.spec.tsx
@@ -96,3 +96,99 @@ describe('WorkspaceTab audio indicator', () => {
     });
   });
 });
+
+describe('WorkspaceTab media capture indicator', () => {
+  beforeEach(() => {
+    mockDispatch.mockClear();
+  });
+
+  it('renders nothing when no source reports any active capture', () => {
+    render(
+      <WorkspaceTab
+        {...baseProps}
+        orientation='horizontal'
+        mediaCapture={{
+          workspace: { camera: false, microphone: false, screen: false },
+        }}
+      />
+    );
+
+    expect(screen.queryByLabelText(/sidebar.tooltips.capture/)).toBeNull();
+    // No capture icon rendered (mic/video/desktop) alongside the tab.
+    expect(document.querySelector('[data-capture]')).not.toBeInTheDocument();
+  });
+
+  it('shows the indicator when screen sharing is active', () => {
+    render(
+      <WorkspaceTab
+        {...baseProps}
+        orientation='horizontal'
+        mediaCapture={{
+          workspace: { camera: false, microphone: false, screen: true },
+        }}
+      />
+    );
+
+    expect(document.querySelector('[data-capture]')).toBeInTheDocument();
+  });
+
+  it('shows the indicator when only the microphone is active', () => {
+    render(
+      <WorkspaceTab
+        {...baseProps}
+        orientation='horizontal'
+        mediaCapture={{
+          workspace: { camera: false, microphone: true, screen: false },
+        }}
+      />
+    );
+
+    expect(document.querySelector('[data-capture]')).toBeInTheDocument();
+  });
+
+  it('merges capture state across the workspace and videoCall sources (OR)', () => {
+    render(
+      <WorkspaceTab
+        {...baseProps}
+        orientation='horizontal'
+        mediaCapture={{
+          workspace: { camera: false, microphone: false, screen: false },
+          videoCall: { camera: true, microphone: false, screen: false },
+        }}
+      />
+    );
+
+    expect(document.querySelector('[data-capture]')).toBeInTheDocument();
+  });
+
+  it('does not render the capture indicator in the vertical sidebar layout', () => {
+    render(
+      <WorkspaceTab
+        {...baseProps}
+        orientation='vertical'
+        mediaCapture={{
+          workspace: { camera: false, microphone: true, screen: false },
+        }}
+      />
+    );
+
+    expect(document.querySelector('[data-capture]')).not.toBeInTheDocument();
+  });
+
+  it('includes the capture label in the tab tooltip/aria-label', () => {
+    render(
+      <WorkspaceTab
+        {...baseProps}
+        orientation='horizontal'
+        mediaCapture={{
+          workspace: { camera: false, microphone: true, screen: false },
+        }}
+      />
+    );
+
+    const tab = screen.getByRole('tab');
+    expect(tab.getAttribute('aria-label')).toContain(
+      'sidebar.tooltips.captureMicrophone'
+    );
+  });
+});

--- a/src/ui/components/TabBar/WorkspaceTab.tsx
+++ b/src/ui/components/TabBar/WorkspaceTab.tsx
@@ -9,6 +9,7 @@ import type {
 import { useContext, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import type { Server } from '../../../servers/common';
 import { dispatch } from '../../../store';
 import {
   SERVER_CONTEXT_MENU_TRIGGERED,
@@ -22,6 +23,7 @@ import { getServerPanelId, getServerTabId } from '../utils/getServerDomId';
 import { getServerInitials } from '../utils/getServerInitials';
 import {
   BadgeWrapper,
+  CaptureIndicator,
   Divider,
   Favicon,
   Initials,
@@ -68,6 +70,7 @@ type WorkspaceTabProps = {
   userLoggedIn?: boolean;
   isAudible?: boolean;
   isAudioMuted?: boolean;
+  mediaCapture?: Server['mediaCapture'];
   compact: boolean;
   orientation?: TabOrientation;
   shortcutNumber: string | null;
@@ -88,6 +91,7 @@ const WorkspaceTab = ({
   userLoggedIn,
   isAudible,
   isAudioMuted,
+  mediaCapture,
   compact,
   orientation = 'horizontal',
   shortcutNumber,
@@ -142,11 +146,39 @@ const WorkspaceTab = ({
 
   const audioSuffix = getAudioSuffix();
 
+  // OR each boolean across every reporting source (workspace webview + video
+  // call window) — either one actively capturing is enough to show the state.
+  const activeCapture = {
+    camera: Object.values(mediaCapture ?? {}).some((state) => state.camera),
+    microphone: Object.values(mediaCapture ?? {}).some(
+      (state) => state.microphone
+    ),
+    screen: Object.values(mediaCapture ?? {}).some((state) => state.screen),
+  };
+
+  // A single 'rec' glyph covers all three capture states — it no longer
+  // distinguishes which device is active (the tooltip suffix below still
+  // does, via the three i18n labels).
+  const anyCapture =
+    activeCapture.screen || activeCapture.camera || activeCapture.microphone;
+
+  const getCaptureSuffix = (): string => {
+    const labels = [
+      activeCapture.screen && t('sidebar.tooltips.captureScreen'),
+      activeCapture.camera && t('sidebar.tooltips.captureCamera'),
+      activeCapture.microphone && t('sidebar.tooltips.captureMicrophone'),
+    ].filter((label): label is string => Boolean(label));
+
+    return labels.length > 0 ? ` — ${labels.join(', ')}` : '';
+  };
+
+  const captureSuffix = getCaptureSuffix();
+
   const serverAddress = url.replace(/\/+$/, '');
   const tooltipName = removeServerAddress(title, serverAddress);
   const tooltipPrimaryLine = `${
     tooltipName || serverAddress
-  }${unreadSuffix}${audioSuffix}${shortcutSuffix}`;
+  }${unreadSuffix}${audioSuffix}${captureSuffix}${shortcutSuffix}`;
   // Show the name on the first line and the address on a second line. When the
   // title is only the address, the primary line already is it, so skip line two.
   const tooltipLines = tooltipName
@@ -250,6 +282,17 @@ const WorkspaceTab = ({
     </SpeakerButton>
   ) : null;
 
+  // Horizontal tab-strip only, same rule as the speaker indicator above. No
+  // click action: this is a read-only status glyph, so it carries no
+  // role='button', no handlers, and is aria-hidden — the capture state is
+  // exposed to assistive tech via the tab's own tooltip/aria-label suffix.
+  const showCapture = !isVertical && anyCapture;
+  const captureElement = showCapture ? (
+    <CaptureIndicator aria-hidden='true' data-capture='rec'>
+      <Icon name='rec' size='x16' />
+    </CaptureIndicator>
+  ) : null;
+
   return (
     <>
       <Tab
@@ -297,6 +340,7 @@ const WorkspaceTab = ({
         ) : (
           <>
             {badgeElement}
+            {captureElement}
             {speakerElement}
           </>
         )}

--- a/src/ui/components/TabBar/index.tsx
+++ b/src/ui/components/TabBar/index.tsx
@@ -154,6 +154,7 @@ export const TabBar = ({
               userLoggedIn={server.userLoggedIn}
               isAudible={server.isAudible}
               isAudioMuted={server.isAudioMuted}
+              mediaCapture={server.mediaCapture}
               compact={compact}
               orientation={orientation}
               shortcutNumber={shortcutNumber}

--- a/src/ui/components/TabBar/styles.tsx
+++ b/src/ui/components/TabBar/styles.tsx
@@ -435,22 +435,15 @@ export const BadgeWrapper = styled.div`
 `;
 
 /* Same 16px footprint as TabBadge/Badge (min-width/min-height: 1rem), reusing
-   Fuselage Badge variant token chains verbatim (compiled fuselage.css) so the
-   speaker indicator reads as a sibling of the mention/unread badges rather
-   than a new visual language. Unmuted uses the ghost chain (same as the
-   plain audible state); muted swaps to the danger chain so the Fuselage
-   `volume-off` icon reads as an actively-muted control, not just another
-   badge color. Horizontal tab-strip only — rendered as a plain sibling of
-   the badge, not inside BadgeWrapper, so no pointer-events override is
-   needed here. `$muted` is a transient prop (emotion convention:
-   `$`-prefixed props are consumed by the styled component and never
-   forwarded to the DOM span). `line-height: 0` keeps the Fuselage Icon's
-   own line-height from nudging it off-centre inside the flex-centred
-   circle. */
-/* The mute control keeps the neutral ghost badge in both states — the
-   Fuselage `volume` / `volume-off` glyph alone signals muted vs. unmuted.
-   Red is reserved for the capture (rec) indicator, matching Chrome, which
-   colors only camera/mic/screen capture and leaves audio controls neutral. */
+   the Fuselage ghost badge token chain so the speaker reads as a sibling of
+   the mention/unread badges. The mute control keeps this neutral ghost badge
+   in both states — the Fuselage `volume` / `volume-off` glyph alone signals
+   muted vs. unmuted. Red is reserved for the capture (rec) indicator, matching
+   Chrome, which colors only camera/mic/screen capture and leaves audio
+   controls neutral. Horizontal tab-strip only — rendered as a plain sibling of
+   the badge, not inside BadgeWrapper, so no pointer-events override is needed.
+   `line-height: 0` keeps the Fuselage Icon's own line-height from nudging it
+   off-centre inside the flex-centred circle. */
 export const SpeakerButton = styled.span`
   flex-shrink: 0;
   display: flex;
@@ -477,6 +470,35 @@ export const SpeakerButton = styled.span`
     outline: 1px solid currentColor;
     outline-offset: 1px;
   }
+`;
+
+/* Camera/microphone/screen-share indicator, sibling of SpeakerButton: a single
+   red `rec` glyph on transparent — no filled disc behind it — matching
+   Chrome's tab alert color, which keeps audio-only grey but flags
+   camera/mic/desktop capture in red. Non-interactive (no click action per the
+   spec — the info lives in the tab's tooltip/aria-label only, hence no
+   cursor/pointer handlers and `aria-hidden` on the element itself). Sized to
+   the same ~16px footprint as the badge/speaker so it lines up with them.
+   Horizontal tab-strip only, same rule as the speaker indicator. */
+/* The capture (rec) glyph uses the pure Fuselage red palette token
+   (`red-500` = #EC0D2A), the same bright recording red the Rocket.Chat
+   composer's audio-message `<Icon name='rec' color='red' />` renders. The
+   `color='danger'` prop and the danger badge chain both resolve to a duller,
+   pinker red (font-danger red600 / a tinted badge background), which read as
+   a different red beside the composer's marker. Setting `color` here and
+   letting the icon inherit currentColor keeps the tab marker on the exact
+   recording red. */
+export const CaptureIndicator = styled.span`
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  min-width: 16px;
+  min-height: 16px;
+  line-height: 0;
+  color: var(--rcx-color-red-500, #ec0d2a);
 `;
 
 export const WindowControlsGroup = styled.div`

--- a/src/ui/main/serverView/index.ts
+++ b/src/ui/main/serverView/index.ts
@@ -46,6 +46,7 @@ import {
   WEBVIEW_FORCE_RELOAD_WITH_CACHE_CLEAR,
   WEBVIEW_AUDIO_STATE_CHANGED,
   WEBVIEW_AUDIO_MUTED_CHANGED,
+  WEBVIEW_MEDIA_CAPTURE_CHANGED,
 } from '../../actions';
 import { handleMediaPermissionRequest } from '../mediaPermissions';
 import { getRootWindow } from '../rootWindow';
@@ -308,6 +309,11 @@ const initializeServerWebContentsAfterAttach = (
     dispatch({
       type: WEBVIEW_AUDIO_STATE_CHANGED,
       payload: { url: serverUrl, isAudible: false },
+    });
+
+    dispatch({
+      type: WEBVIEW_MEDIA_CAPTURE_CHANGED,
+      payload: { url: serverUrl, source: 'workspace', state: null },
     });
 
     const canPurge = select(

--- a/src/videoCallWindow/ipc.ts
+++ b/src/videoCallWindow/ipc.ts
@@ -29,8 +29,12 @@ import {
   resolveStandaloneOriginWindow,
   setupServerViewDisplayMedia,
 } from '../screenSharing/serverViewScreenSharing';
-import { select, dispatchLocal } from '../store';
-import { VIDEO_CALL_WINDOW_STATE_CHANGED } from '../ui/actions';
+import type { MediaCaptureState } from '../servers/common';
+import { select, dispatch, dispatchLocal } from '../store';
+import {
+  VIDEO_CALL_WINDOW_STATE_CHANGED,
+  WEBVIEW_MEDIA_CAPTURE_CHANGED,
+} from '../ui/actions';
 import { debounce } from '../ui/main/debounce';
 import { handleMediaPermissionRequest } from '../ui/main/mediaPermissions';
 import { isInsideSomeScreen, getRootWindow } from '../ui/main/rootWindow';
@@ -160,6 +164,21 @@ const restoreServerViewHandler = async (
   }
 };
 
+// Clears the 'videoCall' media capture source for the call's originating
+// server so the tab indicator drops the moment the call window closes,
+// instead of lingering on whatever capture state was last reported. No-op for
+// isolated/fallback sessions (no server url to key the state on). Safe to call
+// from every teardown path — the same idempotency reasoning as
+// `restoreServerViewHandler` applies (last-writer-wins reducer merge).
+const clearVideoCallMediaCapture = (call: ActiveCall | null): void => {
+  if (!call?.isSharedSession) return;
+  const serverUrl = call.partition.replace(/^persist:/, '');
+  dispatch({
+    type: WEBVIEW_MEDIA_CAPTURE_CHANGED,
+    payload: { url: serverUrl, source: 'videoCall', state: null },
+  });
+};
+
 const cleanupVideoCallWindow = () => {
   const capturedCall = activeCall;
   if (
@@ -211,6 +230,7 @@ const cleanupVideoCallWindow = () => {
       // Restore the server-view display-media handler that this call's unified
       // handler took over (no-op on isolated/fallback sessions).
       void restoreServerViewHandler(capturedCall);
+      clearVideoCallMediaCapture(capturedCall);
 
       // Tear down screen sharing (active + queued) before removing window
       // listeners — silent cleanup() would orphan a popout-parented picker
@@ -797,6 +817,7 @@ const openVideoCallWindow = async (
       // display-media handler. Restore the plain server-view handler so
       // main-app screen sharing keeps working (no-op on isolated sessions).
       void restoreServerViewHandler(capturedCall);
+      clearVideoCallMediaCapture(capturedCall);
 
       // Clear credentials and provider on close
       videoCallCredentials = null;
@@ -981,6 +1002,7 @@ const openVideoCallWindow = async (
     // never fires — restore the server-view handler here too (idempotent).
     webContents.on('render-process-gone', () => {
       void restoreServerViewHandler(capturedCall);
+      clearVideoCallMediaCapture(capturedCall);
     });
 
     // Set the pending URL after window is created to prevent race condition with cleanup
@@ -1109,6 +1131,35 @@ export const startVideoCallWindowHandler = (): void => {
       win.close();
     }
   });
+
+  // Reported by the media capture hook script injected into the call
+  // window's page (see src/videoCallWindow/preload/index.ts). Attributes the
+  // state to the call's originating server via `activeCall`'s partition —
+  // the call window itself has no server url of its own.
+  ipcMain.on(
+    'video-call-window/media-capture-changed',
+    (_event, state: MediaCaptureState) => {
+      if (
+        typeof state !== 'object' ||
+        state === null ||
+        typeof state.camera !== 'boolean' ||
+        typeof state.microphone !== 'boolean' ||
+        typeof state.screen !== 'boolean'
+      ) {
+        return;
+      }
+
+      if (!activeCall?.isSharedSession) {
+        return;
+      }
+
+      const serverUrl = activeCall.partition.replace(/^persist:/, '');
+      dispatch({
+        type: WEBVIEW_MEDIA_CAPTURE_CHANGED,
+        payload: { url: serverUrl, source: 'videoCall', state },
+      });
+    }
+  );
 
   handle('video-call-window/screen-recording-is-permission-granted', async () =>
     checkScreenRecordingPermission()

--- a/src/videoCallWindow/main/ipc.main.spec.ts
+++ b/src/videoCallWindow/main/ipc.main.spec.ts
@@ -118,9 +118,11 @@ const select = jest.fn((..._a: any[]) => ({
   isAutoOpenEnabled: false,
 }));
 const dispatchLocal = jest.fn((..._a: any[]) => undefined);
+const dispatch = jest.fn((..._a: any[]) => undefined);
 jest.mock('../../store', () => ({
   select: (...a: any[]) => select(...a),
   dispatchLocal: (...a: any[]) => dispatchLocal(...a),
+  dispatch: (...a: any[]) => dispatch(...a),
 }));
 
 // --- remaining leaf imports of ipc.ts: keep them inert ---
@@ -848,6 +850,104 @@ describe('videoCallWindow/ipc — PR #3359 hardening', () => {
         listener({ sender: { hostWebContents: null } })
       ).not.toThrow();
     });
+  });
+
+  // -------------------------------------------------------------------------
+  // media-capture-changed: 'video-call-window/media-capture-changed' (ipcMain.on)
+  // -------------------------------------------------------------------------
+  describe('media-capture-changed', () => {
+    const getMediaCaptureHandler = async () => {
+      await loadModule();
+      const electron = (await import('electron')) as any;
+      const call = electron.ipcMain.on.mock.calls.find(
+        ([channel]: [string]) =>
+          channel === 'video-call-window/media-capture-changed'
+      );
+      if (!call)
+        throw new Error('media-capture-changed listener not registered');
+      return call[1] as (event: unknown, state: unknown) => void;
+    };
+
+    it('dispatches WEBVIEW_MEDIA_CAPTURE_CHANGED for the shared session server', async () => {
+      getServerUrlByWebContentsId.mockReturnValue('https://chat.example');
+      const { openWindow } = await loadModule();
+      await open(openWindow, makeCallerWc(1));
+
+      const electron = (await import('electron')) as any;
+      const call = electron.ipcMain.on.mock.calls.find(
+        ([channel]: [string]) =>
+          channel === 'video-call-window/media-capture-changed'
+      );
+      const listener = call[1] as (event: unknown, state: unknown) => void;
+
+      listener({}, { camera: true, microphone: false, screen: false });
+
+      expect(dispatch).toHaveBeenCalledWith({
+        type: 'webview/media-capture-changed',
+        payload: {
+          url: 'https://chat.example',
+          source: 'videoCall',
+          state: { camera: true, microphone: false, screen: false },
+        },
+      });
+    });
+
+    it('does nothing when there is no active shared-session call', async () => {
+      const listener = await getMediaCaptureHandler();
+
+      listener({}, { camera: true, microphone: false, screen: false });
+
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it('does nothing for a malformed payload', async () => {
+      getServerUrlByWebContentsId.mockReturnValue('https://chat.example');
+      const { openWindow } = await loadModule();
+      await open(openWindow, makeCallerWc(1));
+      const electron = (await import('electron')) as any;
+      const call = electron.ipcMain.on.mock.calls.find(
+        ([channel]: [string]) =>
+          channel === 'video-call-window/media-capture-changed'
+      );
+      const listener = call[1] as (event: unknown, state: unknown) => void;
+
+      listener({}, { camera: 'yes' });
+
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // teardown: the 'closed' event clears the videoCall media capture source for
+  // a shared session, so the tab indicator drops when the call window closes.
+  // -------------------------------------------------------------------------
+  it("clears the 'videoCall' media capture source on window close (shared session)", async () => {
+    getServerUrlByWebContentsId.mockReturnValue('https://chat.example');
+    const { openWindow } = await loadModule();
+    await open(openWindow, makeCallerWc(1));
+
+    fire(createdWindows[0].listeners, 'closed');
+
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'webview/media-capture-changed',
+      payload: {
+        url: 'https://chat.example',
+        source: 'videoCall',
+        state: null,
+      },
+    });
+  });
+
+  it('does not dispatch a clear on close for a fallback (non-shared) session', async () => {
+    getServerUrlByWebContentsId.mockReturnValue(undefined);
+    const { openWindow } = await loadModule();
+    await open(openWindow, makeCallerWc(1));
+
+    fire(createdWindows[0].listeners, 'closed');
+
+    expect(dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'webview/media-capture-changed' })
+    );
   });
 
   // -------------------------------------------------------------------------

--- a/src/videoCallWindow/preload/index.ts
+++ b/src/videoCallWindow/preload/index.ts
@@ -1,5 +1,19 @@
-import { contextBridge, ipcRenderer } from 'electron';
+import { contextBridge, ipcRenderer, webFrame } from 'electron';
+
+import type { MediaCaptureState } from '../../servers/common';
+import { MEDIA_CAPTURE_HOOK_SCRIPT } from '../../servers/preload/mediaCapture';
 import './jitsiBridge';
+
+// Same hook used by the workspace webview preload — the video call window's
+// host page has no contextIsolation, so this could patch `navigator`
+// directly, but injecting via executeJavaScript keeps the same code path (and
+// therefore the same tested behavior) for both surfaces.
+webFrame.executeJavaScript(MEDIA_CAPTURE_HOOK_SCRIPT).catch((error) => {
+  console.error(
+    '[Rocket.Chat Desktop] Failed to inject media capture hook in video call window:',
+    error
+  );
+});
 
 // Accept only in-app relative routes ("/..."), rejecting absolute URLs,
 // protocol-relative URLs ("//host") and the backslash variant ("/\\host") so
@@ -50,5 +64,9 @@ contextBridge.exposeInMainWorld('videoCallWindow', {
     serverUrl: string;
   } | null> => {
     return ipcRenderer.invoke('video-call-window/get-credentials');
+  },
+  // Reported by the injected media capture hook script above.
+  reportMediaCapture: (state: MediaCaptureState) => {
+    ipcRenderer.send('video-call-window/media-capture-changed', state);
   },
 });


### PR DESCRIPTION
Follow-up to CORE-2614. Shows when a workspace is capturing camera, microphone or screen, the way Chrome marks a tab that is recording, and reserves red for capture.

Stacked on #3491 (feat/tab-audio-indicator) — review or merge that first. This PR's base will retarget to `dev` once #3491 lands.

## What it does

- Injects a self-contained hook into the page's main world (Electron emits no active-capture event) that wraps `getUserMedia` / `getDisplayMedia`, tracks live tracks (patching `MediaStreamTrack.stop` plus the `ended` event), and reports a deduped `{ camera, microphone, screen }` state.
- Two sources per workspace: the webview page (via the desktop bridge) and the separate video-call window (via IPC, attributed through the `persist:<serverUrl>` partition and cleared on every teardown path).
- The horizontal tab strip shows a single red `rec` glyph while any device is capturing, using Fuselage `red-500` (#EC0D2A), the same recording marker the web composer uses. The tooltip names the active devices.
- Per-source state on the server record, ORed in the tab, reset on both startup rehydration paths and on webview destroy.

## Also here

- Fixes a pre-existing gap: `SERVERS_LOADED` did not reset the transient `isAudible` / `isAudioMuted` / `mediaCapture` fields, so a stale muted speaker or capture badge could show after restart. Both rehydration paths now reset them; a cold boot comes up clean.

## Verification

- `npx tsc --noEmit`, `yarn lint`: 0 errors
- 118 tests across the servers reducer, preload hook, serverView listeners, video-call IPC and TabBar suites
- `yarn build` passes; the injected hook is present and self-contained in both preload bundles
- Verified in the running dev app: a real `getUserMedia` grant shows the red rec glyph and clears on track stop; bridge and IPC paths both drive it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual indicators to workspace tabs when screen sharing, camera, or microphone capture is active.
  * Capture status now combines activity from workspace and video call sessions.
  * Added accessible tooltip and screen-reader labels describing active capture types.
  * Added localized tooltip text for supported languages.

* **Bug Fixes**
  * Capture indicators are cleared when a workspace or video call session ends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->