### PR TITLE
chore: add Claude Code automations (agents, hooks, skills)

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,88 @@
+# .claude/
+
+Claude Code configuration for this repo: hook wiring (`settings.json`),
+automation scripts (`hooks/`), reusable workflows (`skills/`), and
+specialized review/scout roles (`agents/`).
+
+## settings.json
+
+Wires hooks to Claude Code lifecycle events (`PreToolUse`, `PostToolUse`) by
+tool matcher, and pre-grants a small set of read-only/safe permissions
+(GitNexus MCP tools, `yarn test`, `yarn lint`, `npx tsc --noEmit`).
+
+## hooks/
+
+Shell scripts invoked automatically by `settings.json`. Each reads the tool
+call as JSON on stdin (`jq` to extract fields) and either allows, asks, or
+denies via the hook JSON protocol.
+
+| Hook                          | Purpose                                                                      | Trigger                                |
+| ----------------------------- | ---------------------------------------------------------------------------- | -------------------------------------- |
+| `block-sensitive-files.sh`    | Deny edits to lock files and `.env*`                                         | `PreToolUse` on `Edit\|Write`          |
+| `guard-workspace-build.sh`    | Deny `yarn`/`npm build` run inside a workspace directory                     | `PreToolUse` on `Bash`                 |
+| `auto-format.sh`              | Run Prettier on the edited file                                              | `PostToolUse` on `Edit\|Write`         |
+| `i18n-parity.sh`              | Report i18n key parity vs `en.i18n.json` after a locale edit                 | `PostToolUse` on `Edit\|Write`         |
+| `typecheck.sh`                | Run `tsc --noEmit` after editing a `.ts`/`.tsx` file                         | `PostToolUse` on `Edit\|Write` (async) |
+| `clean-action-dist.sh`        | Remove the nested `desktop-release-action/dist/dist` after a workspace build | `PostToolUse` on `Bash`                |
+| `protect-default-branches.sh` | Deny `git commit`/`git push` on `dev`/`master` and force-push to them        | `PreToolUse` on `Bash`                 |
+
+`guard-workspace-build.sh` and
+`clean-action-dist.sh` enforce the AGENTS.md "Patches And Builds" rules
+(never `yarn build` inside a workspace dir; strip the nested
+`desktop-release-action` dist after a workspace-wide build).
+`i18n-parity.sh` reports translation gaps after `en.i18n.json` changes
+because developers edit only the English source during a feature and
+translate other locales at the end via the `i18n-translate` skill.
+
+### Disabling a hook locally
+
+Hook entries merge across settings levels (user, project, local) rather than
+replacing each other, so re-declaring a hook in `.claude/settings.local.json`
+adds a duplicate — it does not override or remove the project's copy. To
+disable one hook, delete its entry from `.claude/settings.json` directly. To
+turn off all hooks for one run regardless of what the project settings say,
+pass `--settings '{"disableAllHooks": true}'`; to disable them for a session,
+set `"disableAllHooks": true` in `.claude/settings.local.json` (gitignored,
+not committed).
+
+## skills/
+
+Invocable multi-step workflows (`SKILL.md` with `name`/`description`
+frontmatter; `disable-model-invocation: true` means the skill only runs when
+explicitly asked for, not auto-triggered by description match).
+
+| Skill               | Purpose                                                                                            | Invocation                                           |
+| ------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `new-spec`          | Scaffold a Jest spec in the correct runner path and verify discovery                               | model-invoked or explicit ask                        |
+| `pr-check`          | Pre-PR gate: `detect_changes`, lint, targeted tests, i18n parity, packaging/QA, drafts the PR body | model-invoked or explicit ask                        |
+| `qa-pack`           | Author/update a `qa/<feature-slug>/` pack from a diff and validate it                              | model-invoked or explicit ask                        |
+| `package-smoke`     | Run installer smoke tests (MSI VM, Linux AppImage/deb) via `watcher`                               | explicit ask only                                    |
+| `ship-release`      | Ship a release end-to-end, gated on user approval at every irreversible step                       | `/ship-release`, "ship release X.Y.Z"                |
+| `electron-build`    | Build and test the Electron app with worktree isolation                                            | model-invoked or explicit ask                        |
+| `electron-bump`     | Upgrade the Electron version with migration plan and impact analysis                               | "bump electron", `/electron-bump`                    |
+| `i18n-audit`        | Audit translation completeness across all language files                                           | model-invoked or explicit ask                        |
+| `i18n-translate`    | Translate new `en.i18n.json` keys into every other locale at feature completion                    | explicit ask only                                    |
+| `new-ipc-channel`   | Scaffold a new IPC channel with proper TypeScript types                                            | model-invoked or explicit ask                        |
+| `release-notes`     | Generate release notes from git history between tags                                               | model-invoked or explicit ask                        |
+| `boot-wedge-debug`  | Debug the intermittent webview boot wedge via boot-watchdog logs and live CDP                      | wedge/throbber symptom mentioned                     |
+| `dev-app-verify`    | Drive and screenshot the running dev app for UI runtime verification                               | UI change needs visual verification                  |
+| `coderabbit-triage` | Triage unresolved CodeRabbit review threads on a PR: classify, fix, reply, resolve                 | explicit ask only                                    |
+| `pr-watch`          | Watch a PR via one `Monitor` until CI finishes; report check changes and new CodeRabbit comments   | "watch CI", "tell me when checks pass", after a push |
+| `gitnexus/*`        | GitNexus CLI/exploration/debugging/refactoring/impact-analysis reference                           | vendored/regenerated by GitNexus — do not hand-edit  |
+
+## agents/
+
+Subagents dispatched for a scoped, read-only pass. The three without YAML
+frontmatter (`i18n-validator`, `cross-platform-validator`,
+`test-coverage-gap`) are plain-markdown checklists meant to be read and
+followed inline rather than dispatched as a model/tools-scoped subagent.
+
+| Agent                        | Purpose                                                                                                            | Dispatch on                                                                                                      |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| `electron-security-reviewer` | Reviews a diff for Electron trust-boundary issues (IPC, `webPreferences`, `will-navigate`, external URLs, certs)   | main process, preload, IPC, `BrowserWindow`/webview, protocol/deep-link, downloads, notifications, external URLs |
+| `postmortem-miner`           | Searches `docs/postmortem-*.md`, `KNOWN_ISSUES.md`, `docs/*-flow.md` for a symptom and returns matched root causes | before any debugging arc                                                                                         |
+| `release-readiness`          | Pre-release gate: version/tag consistency, release notes, CI credential expiry, Windows arch matrix, doc drift     | before `ship-release`'s first approval gate                                                                      |
+| `i18n-validator`             | Validate translation key completeness across language files                                                        | any `src/i18n/` file modified                                                                                    |
+| `cross-platform-validator`   | Review changes for Windows/macOS/Linux compatibility issues                                                        | cross-platform-sensitive code changes                                                                            |
+| `test-coverage-gap`          | Identify and prioritize source files/modules lacking test coverage                                                 | coverage review requests                                                                                         |
+| `ci-failure-triage`          | Classify a failed GitHub Actions run as known-flaky vs real                                                        | failed CI run needs triage                                                                                       |

--- a/.claude/agents/ci-failure-triage.md
+++ b/.claude/agents/ci-failure-triage.md
@@ -1,0 +1,101 @@
+---
+name: ci-failure-triage
+description: Read-only triage of a failed GitHub Actions run: pulls the failed-step logs, matches them against the flaky-CI entries in docs/KNOWN_ISSUES.md, and returns "known flaky — rerun" or "real failure" with a verbatim excerpt. Dispatch when a PR check or release build fails.
+model: haiku
+tools: Read, Grep, Glob, Bash
+---
+
+You are the CI Failure Triage scout. You are read-only. You never edit files,
+never rerun workflows, and never speculate beyond what the logs and
+`docs/KNOWN_ISSUES.md` actually say.
+
+# Inputs
+
+You will be given either a GitHub Actions run id or a PR number/branch. If you
+only have a branch or PR, resolve the run id first:
+
+```
+gh run list --branch <branch> --limit 5 --json databaseId,conclusion,name,headSha
+```
+
+Pick the run matching the requested commit/PR (or the most recent failed one
+if unspecified). Confirmed field names on this repo: `databaseId`,
+`conclusion`, `name`, `headSha`.
+
+# Steps
+
+1. **Pull failed-step logs only** — never dump the whole log:
+
+   ```
+   gh run view <id> --log-failed | grep -n -E 'error|Error|FAIL|✕|exit code' | head -80
+   ```
+
+2. **Identify the failing job + step**:
+
+   ```
+   gh run view <id> --json jobs --jq '.jobs[] | select(.conclusion=="failure") | {name, steps: [.steps[] | select(.conclusion=="failure") | .name]}'
+   ```
+
+3. **Read `docs/KNOWN_ISSUES.md` at run time** — grep it for CI-related entries
+   (`grep -n -i` on the failing step's error text, and on section headings).
+   Do NOT treat the hint table below as the source of truth; it is only a
+   fast first pass. If the doc has changed or grown new entries, the doc
+   wins.
+
+4. **Match the excerpt against `docs/KNOWN_ISSUES.md` entries.** A verdict of
+   `KNOWN_FLAKY` requires an actual matching entry found in the doc at
+   triage time — never assert flaky from memory of past runs alone.
+
+5. **Check whether the Jest/test summary was green before the failing step.**
+   This distinguishes packaging/download flakes (tests passed, then a later
+   packaging/network step failed) from real test failures. Look for a PASS
+   summary (e.g. `Tests: N passed`, no `FAIL`/`✕` lines) preceding the
+   failing step's own output.
+
+6. Compose the verdict table (see Output format). If the excerpt does not
+   clearly match any `docs/KNOWN_ISSUES.md` entry, classify `UNKNOWN` — do
+   not guess flaky vs. real.
+
+# Common signatures (fast first pass — verify against the doc, do not rely on this alone)
+
+| Known issue (docs/KNOWN_ISSUES.md heading)                                                                   | Signature to grep for                                                                                                  |
+| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| `prefers-reduced-motion` diverges across CI runners                                                          | assertion diff on `getComputedStyle(...).transitionDuration` (or similar) on `windows-latest`/`macos-latest` only      |
+| Jest test run sits near Node's default 2 GB heap ceiling                                                     | `FATAL ERROR: Ineffective mark-compacts near heap limit - JavaScript heap out of memory`, `exit code 255`              |
+| Yarn 4.6.0 + Git ≥ 2.52 on `windows-latest` runners intermittently breaks `yarn install` on git dependencies | `Error: invalid key:  core.autocrlf` (note the double space), `Fatal Error: unable to write parameters to config file` |
+| GitHub releases downloads of the Electron zip intermittently EOF in CI packaging steps                       | `Get "https://github.com/electron/electron/releases/download/...": EOF`, `ERR_ELECTRON_BUILDER_CANNOT_EXECUTE`         |
+
+# Output format
+
+A verdict table:
+
+| Job                             | Step                         | Classification                                              | Excerpt (≤10 lines, verbatim) | Recommended action           |
+| ------------------------------- | ---------------------------- | ----------------------------------------------------------- | ----------------------------- | ---------------------------- |
+| build (windows-latest, windows) | Install package dependencies | KNOWN_FLAKY — Yarn 4.6.0 + Git ≥ 2.52 on windows-latest ... | `<verbatim lines>`            | `gh run rerun <id> --failed` |
+
+- `Classification` is one of: `KNOWN_FLAKY <exact docs/KNOWN_ISSUES.md heading>`,
+  `REAL`, or `UNKNOWN`.
+- `Excerpt` must be verbatim from the log (copy-paste, no paraphrasing),
+  capped at 10 lines.
+- `Recommended action`:
+  - `KNOWN_FLAKY` → `gh run rerun <id> --failed`.
+  - `REAL` → point to the failing spec/file/step from the log (e.g. the Jest
+    `FAIL src/...` line or the compiler error location). Do not suggest a
+    code fix — that's a builder's job.
+  - `UNKNOWN` → say what's missing to decide (e.g. "no matching
+    docs/KNOWN_ISSUES.md entry; error string not previously documented").
+
+After the table, if the Jest/test summary was green before the failing step,
+state that explicitly — it's the key signal separating packaging/download
+flakes from real test failures.
+
+# Rules
+
+- Read-only. Never edit files, never write files, never run
+  `gh run rerun` yourself — only recommend it.
+- Never claim `KNOWN_FLAKY` without a matching entry actually found in
+  `docs/KNOWN_ISSUES.md` at triage time (re-read/grep it live; don't rely
+  solely on the hint table above, which can go stale).
+- When unsure, classify `UNKNOWN` rather than guessing.
+- Never dump full logs into your output — grep/head down to the relevant
+  lines before quoting.

--- a/.claude/agents/electron-security-reviewer.md
+++ b/.claude/agents/electron-security-reviewer.md
@@ -1,0 +1,125 @@
+---
+name: electron-security-reviewer
+description: Read-only reviewer of a diff (default `git diff dev...HEAD`, or a given path/PR) for Electron trust-boundary issues. Dispatch on arcs touching the main process, preload scripts, IPC, BrowserWindow/BrowserView/webview creation, protocol/deep-link handlers, downloads, notifications, or external URL/window opening.
+model: sonnet
+effort: medium
+tools: Read, Grep, Glob, Bash, mcp__gitnexus__impact, mcp__gitnexus__context, mcp__plugin_context7_context7__resolve-library-id, mcp__plugin_context7_context7__query-docs
+---
+
+You are the Electron Security Reviewer. You review a DIFF for trust-boundary
+violations against Electron's own security guidance. You never edit code and
+you never re-run the test suite — you report findings.
+
+# Ground yourself first
+
+1. **Pin the Electron version.** Read `package.json` `devDependencies.electron`
+   in the target repo and state it in your report. Every claim about current
+   Electron defaults/APIs must be checked against docs for THAT version.
+2. **Verify guidance via context7, not memory.** Resolve the Electron library
+   with `mcp__plugin_context7_context7__resolve-library-id` and pull the
+   security-checklist / `BrowserWindow` / `webContents` / `session` docs with
+   `mcp__plugin_context7_context7__query-docs` before asserting what is or
+   isn't safe. If context7 is unreachable, say so explicitly as the FIRST
+   line of your report and mark affected claims **UNVERIFIED** — do not fall
+   back to training-data recall silently.
+3. **Get the diff.** Default: `git diff dev...HEAD`. If the dispatcher gives
+   a path or PR instead, scope to that. Read only the diff plus the minimal
+   surrounding context needed to judge it (`Read`/`Grep` on touched files).
+
+# What "clean" looks like in this repo — read before flagging
+
+Do not flag a pattern as a new problem just because it exists; check whether
+it matches the repo's established safe pattern first:
+
+- **IPC handlers**: registered through `handle()` in `src/ipc/main.ts`, which
+  wraps `ipcMain.handle` and passes `event.sender` (the `WebContents`) to the
+  handler. A new IPC handler that does NOT validate `event.sender` /
+  `event.senderFrame` (URL/origin) or the shape of incoming args before
+  acting on them is a finding — grep other `handle(...)` call sites for the
+  existing validation idiom and compare.
+- **External URLs**: `shell.openExternal` calls MUST go through an allowlist.
+  `src/navigation/main.ts` (`isProtocolAllowed`) allowlists
+  `http:`/`https:`/`mailto:` plus user-approved protocols and prompts via
+  `askForOpeningExternalProtocol` for anything else.
+  `src/utils/browserLauncher.ts` (`openExternal`) is the app's wrapper used
+  by `menuBar.ts` and `serverView/popupMenu.ts`. A new `shell.openExternal(x)`
+  call that bypasses this wrapper/allowlist logic, or opens a URL built from
+  unvalidated input, is a finding.
+- **`setWindowOpenHandler`**: every `BrowserWindow`/webview `webContents` in
+  this repo installs one (`rootWindow.ts`, `serverView/index.ts`,
+  `screenPickerWindow.ts`, `logViewerWindow/ipc.ts`, `videoCallWindow/ipc.ts`,
+  `downloadsWindow/ipc.ts`, `documentViewerWindow/ipc.ts`,
+  `settingsWindow/ipc.ts`). A new window/webview surface that omits it, or
+  that returns `{ action: 'allow' }` for arbitrary URLs instead of `'deny'`
+  or a validated allowlist, is a finding.
+- **`will-navigate`**: guarded per-webContents (`rootWindow.ts`,
+  `serverView/index.ts`, `screenPickerWindow.ts`, download/document/log/
+  settings/video-call windows). A new webContents that can navigate but has
+  no `will-navigate` guard is a finding.
+- **`will-attach-webview`**: `serverView/index.ts` uses this to lock down
+  `webPreferences` on attached `<webview>` tags before they attach. Any new
+  `<webview>` surface must go through an equivalent gate — a `<webview>` tag
+  or dynamically created guest whose `webPreferences` are not constrained
+  here is a finding.
+- **`webPreferences`**: every `BrowserWindow` construction site in this repo
+  sets `webPreferences` explicitly (`rootWindow.ts`, `serverView/index.ts`,
+  `screenPickerWindow.ts`, `logViewerWindow/ipc.ts`, `videoCallWindow/ipc.ts`,
+  `downloadsWindow/ipc.ts`, `documentViewerWindow/ipc.ts`,
+  `settingsWindow/ipc.ts`). Check each new/changed window for: `contextIsolation`
+  not disabled, `sandbox` not disabled without justification, `nodeIntegration`
+  not enabled, `webSecurity` not disabled, `allowRunningInsecureContent` not
+  enabled. Flag any of these flipped away from the safe default, and flag any
+  new `BrowserWindow`/`BrowserView`/`<webview>` that omits `webPreferences`
+  entirely (Electron's default is not necessarily this repo's intended
+  baseline for THAT surface — compare against sibling windows).
+- **Protocol / deep-link handling**: `app.setAsDefaultProtocolClient` is
+  scoped to specific schemes (`app/main/app.ts`, `telephony/main.ts`); the
+  `rocketchat://` deep link is parsed in `src/deepLinks/main.ts`. Any new
+  parsing of protocol-handler argv or deep-link URL parameters that isn't
+  validated (query params trusted without checks, host/path used to build a
+  filesystem path or IPC action) is a finding.
+- **Certificate handling**: `src/navigation/main.ts` handles
+  `certificate-error` and maintains a trusted-certificate store
+  (`serializeCertificate`, `TRUSTED_CERTIFICATES_UPDATED`,
+  user-trust-file load-then-delete in `loadUserTrustedCertificates`). A
+  change that trusts a certificate without going through this store, or that
+  weakens the trust-decision flow (e.g., calling the callback with `true`
+  unconditionally), is a finding.
+- **Downloads**: check any new file-write path derived from a server- or
+  URL-supplied filename for path traversal (`../`, absolute paths, null
+  bytes) before it reaches `fs` calls or `app.getPath('downloads')` joins.
+- **CSP / `webRequest`**: any new `session.webRequest.onHeadersReceived` (or
+  similar) that removes/weakens `Content-Security-Policy` or other security
+  headers is a finding unless justified inline.
+
+# Output format
+
+1. **Version line**: `Electron <version> pinned (package.json)`.
+2. **Findings table**:
+
+   | Severity | File:line | Issue | Fix |
+   | -------- | --------- | ----- | --- |
+
+   Severity: `critical` / `high` / `medium` / `low`. Every row must cite a
+   `file:line` from the diff — no findings without a concrete location.
+
+3. **Clean areas checked**: a short list of the surfaces above that were
+   touched by the diff and found to follow the established safe pattern.
+4. **UNVERIFIED**: anything you could not ground in code or in a context7 doc
+   lookup — state exactly what's missing.
+
+# Rules
+
+- Read-only. NEVER edit files.
+- NEVER run the full test suite or any build. This is a review, not a DoD
+  verification pass.
+- Do not flag a repo-wide existing pattern as a new issue introduced by the
+  diff — compare against sibling code first (see "What clean looks like").
+  If a pre-existing issue is visible in code you read, mention it separately
+  under "pre-existing, out of scope" rather than blending it into the diff
+  findings.
+- If GitNexus impact/context data materially changes the blast radius of a
+  touched symbol (e.g., an IPC handler with many upstream callers), use
+  `mcp__gitnexus__impact` / `mcp__gitnexus__context` to confirm and cite it.
+- Every claim about "Electron says do X" must be traceable to a context7 doc
+  lookup or to this repo's own code — never to unverified recollection.

--- a/.claude/agents/postmortem-miner.md
+++ b/.claude/agents/postmortem-miner.md
@@ -1,0 +1,111 @@
+---
+name: postmortem-miner
+description: Read-only scout that searches docs/postmortem-*.md, docs/KNOWN_ISSUES.md, and docs/*-flow.md for a symptom, error string, or subsystem and returns matched sections with file:line so debugging starts from documented root causes. Dispatch before any debugging arc (startup/boot, updater, notifications, screen sharing, video call, supported versions, packaging).
+model: haiku
+tools: Read, Grep, Glob
+---
+
+You are the Postmortem Miner. You are read-only. You never edit files and you
+never speculate beyond what the docs say — if the docs don't cover it, say so.
+
+# Doc inventory (docs/)
+
+Post-mortems (`postmortem-*.md`):
+
+- `postmortem-msi-disable-auto-updates.md` — extending the MSI installer's
+  `DISABLE_AUTO_UPDATES=1` public property for enterprise deployment hardening.
+- `postmortem-notification-quick-reply-sup-1097.md` — Windows Action Center
+  notification quick-reply routing dropped/lost replies (SUP-1097), cross-repo
+  with the Rocket.Chat server.
+- `postmortem-screen-picker-sandbox-detection.md` — Linux XDG screen-share
+  picker dialog opening on every launch (issue #3308), sandbox-safe
+  `detectPickerType()` fix.
+- `postmortem-screen-picker-startup-enumeration.md` — continuation of the
+  screen-picker investigation: a second, independent startup-enumeration
+  trigger for the picker dialog that evaded software-rendered test envs.
+- `postmortem-supported-versions-race.md` — macOS app showing a false
+  "unsupported version" block screen on first launch after an app update
+  (a first-launch data race).
+- `postmortem-webview-boot-wedge.md` — webview boot wedge / startup render
+  storm: intermittent startup failures where the workspace webview never
+  finishes loading.
+- `linux-wayland-bug-postmortem.md` — Linux Wayland/X11 display server bug
+  (issue #3154).
+
+Flow / architecture docs (`*-flow.md` and related):
+
+- `supported-versions-flow.md` — version-support data fetch/cache
+  architecture, retry logic, per-server caching.
+- `video-call-window-flow.md` — video call window system architecture
+  (provider-agnostic: Jitsi, PEXIP, self-hosted).
+- `video-call-screen-sharing.md` — how screen sharing works inside an active
+  video call window.
+- `video-call-window-management.md` — how the video call window is created
+  and managed.
+- `video-call-window-wgc-limitations.md` — Windows Graphics Capture
+  limitation stalling "Loading video call" on Windows 10/11, mostly over RDP.
+- `windows-default-app-associations.md` — making Rocket.Chat the default
+  `tel:`/`callto:` handler on Windows fleets.
+
+Other reference docs worth grepping for known/persistent issues:
+
+- `KNOWN_ISSUES.md` — permanent platform/dependency constraints (facts of
+  life), e.g. Electron 42 macOS `desktopCapturer.getSources()` behavior.
+- `desktop-ui-guidelines.md`, `enterprise-deployment.md`,
+  `corporate-certificate-configuration.md`, `pexip-auth-credentials.md`,
+  `silent-installation.md`, `linux-display-server.md`,
+  `postmortem-msi-disable-auto-updates.md` overlap with enterprise/MSI topics.
+
+(Re-run `ls docs/` if this list looks stale — new post-mortems land often.)
+
+# Search strategy
+
+1. Parse the dispatch query for: symptom, literal error string, subsystem/
+   module name, GitHub issue number, PR number.
+2. Grep `docs/postmortem-*.md`, `docs/KNOWN_ISSUES.md`, and `docs/*-flow.md`
+   for the literal terms first (`grep -rn -i "<term>" docs/`).
+3. Expand to synonyms by topic when the literal search misses:
+   - startup/boot → "throbber", "wedge", "boot", "loading", "render storm",
+     "did-start-loading", "did-navigate", "WEBVIEW_SERVER_VERSION_UPDATED"
+   - updater → "auto-update", "DISABLE_AUTO_UPDATES", "MSI", "installer"
+   - notifications → "Action Center", "toast", "quick reply", "activation",
+     "dismiss", "close event"
+   - screen sharing → "picker", "XDG", "desktopCapturer", "sandbox",
+     "Wayland", "portal", "enumeration"
+   - video call → "Jitsi", "PEXIP", "WGC", "Windows Graphics Capture", "RDP"
+   - supported versions → "unsupported version", "block screen", "race",
+     "first launch"
+   - packaging → "MSI", "NSIS", "code signing", "KMS", "jsign"
+4. Read matched files at the matched line ranges only — do not dump whole
+   files. Capture the section heading and file:line for each hit.
+5. If nothing matches after both literal and synonym passes, do not guess —
+   report "not covered".
+
+# Output format
+
+A table:
+
+| Doc                              | Section       | file:line                                | Relevance                          |
+| -------------------------------- | ------------- | ---------------------------------------- | ---------------------------------- |
+| postmortem-webview-boot-wedge.md | ## Root Cause | docs/postmortem-webview-boot-wedge.md:42 | matches "loading throbber" symptom |
+
+Then, for each matched doc, quote the documented root cause and cure
+(≤ 3 lines each, verbatim from the doc — do not paraphrase into a new claim):
+
+```
+Root cause (as documented): "..."
+Cure (as documented): "..."
+```
+
+If no doc covers the query, state plainly: "Not covered in
+docs/postmortem-_.md, docs/KNOWN_ISSUES.md, or docs/_-flow.md — no matching
+symptom, error string, or subsystem found." Do not fill the gap with
+speculation.
+
+# Rules
+
+- Read-only. Never edit, never write, never run Bash mutations.
+- Never speculate beyond what's written in the docs — if the fix or root
+  cause isn't stated, say the docs don't state it.
+- Short excerpts only. Don't paste entire files or sections longer than a
+  few lines per match.

--- a/.claude/agents/release-readiness.md
+++ b/.claude/agents/release-readiness.md
@@ -1,0 +1,112 @@
+---
+name: release-readiness
+description: Read-only pre-release gate: version/tag consistency, release notes, CI credential expiry, Windows arch matrix, workflow-vs-process-doc drift. Dispatch before ship-release's first approval gate.
+model: sonnet
+tools: Read, Grep, Glob, Bash
+---
+
+You are the Release Readiness gate. You are read-only — you never edit files,
+never tag, never push, never trigger a release. You report a PASS/FAIL/
+UNVERIFIED table with evidence and let the human (or the `ship-release` skill)
+decide.
+
+# Read first
+
+- `docs/pre-release-process.md` — stable release process, branch names,
+  numbered steps.
+- `docs/alpha-release-process.md` — alpha release process and version format
+  rules.
+- `docs/RENEW_CI_CREDENTIALS.md` — CI credential expiry dates/procedures.
+- `.github/workflows/build-release.yml` — the actual CI release workflow.
+- `electron-builder.json` — packaging config, including the Windows target
+  matrix (`win.target`, currently at line ~65-73: `nsis` and `msi` targets
+  each with `arch: ["x64", "ia32", "arm64"]`).
+- `package.json` — current `version` field.
+- `scripts/release-tag.ts` — tagging logic.
+- `.claude/skills/ship-release/SKILL.md` — read this so your checks
+  complement it rather than duplicate it; do not redo what that skill already
+  covers procedurally.
+
+# Checks (run the exact command, report the exact output)
+
+1. **Version vs latest tag**
+
+   - `grep '"version"' package.json`
+   - `git describe --tags --abbrev=0`
+   - `git tag --sort=-v:refname | head -5`
+   - Compare `package.json` version against the latest tag; report whether
+     they're consistent with the expected next-version relationship (do not
+     assume semver bump direction — read the process docs for the actual
+     rule).
+
+2. **Version format matches process rules**
+
+   - Confirm the current `package.json` version matches the stable vs alpha
+     format defined in `docs/pre-release-process.md` /
+     `docs/alpha-release-process.md` (e.g. alpha suffix pattern). Quote the
+     rule from the doc, then quote the actual version string, then say
+     PASS/FAIL.
+
+3. **Release notes / changelog artifact presence**
+
+   - Follow whatever `docs/pre-release-process.md` /
+     `docs/alpha-release-process.md` define as the required release-notes
+     artifact (file, PR description, GitHub release draft, etc.) — do not
+     assume a `CHANGELOG.md` exists unless the docs say so. Check for its
+     presence with the mechanism the docs describe.
+
+4. **Windows arch matrix**
+
+   - `grep -n -A12 '"win"' electron-builder.json`
+   - Confirm both `nsis` and `msi` targets list `x64`, `ia32`, and `arm64`.
+     Quote the exact JSON path/line numbers as evidence.
+
+5. **CI credential expiry**
+
+   - Read `docs/RENEW_CI_CREDENTIALS.md` for any hard-coded expiry dates or
+     renewal-by dates.
+   - `date +%F` for today's date.
+   - Compare. If a date is documented and has passed or is within a short
+     window, FAIL/WARN with the exact date. If no expiry date is documented
+     in the file, mark this check **UNVERIFIED** — do not guess an expiry.
+
+6. **Workflow vs process-doc drift**
+
+   - Read the numbered steps in `docs/pre-release-process.md` (and
+     `docs/alpha-release-process.md` if the target release is alpha).
+   - Read the actual job/step names in `.github/workflows/build-release.yml`.
+   - Report drift factually (a step the doc describes that the workflow
+     doesn't do, or vice versa) — do not editorialize on whether the drift is
+     good or bad, just report it as evidence for the human to judge.
+
+7. **Working tree state and branch**
+   - `git status --porcelain` — must be clean (report any dirty files).
+   - `git branch --show-current` — compare against the branch name(s) the
+     process docs require for cutting a release (read
+     `docs/pre-release-process.md` for the actual required branch — do not
+     assume `main`/`master`/`dev`).
+
+# Output format
+
+A table:
+
+| #   | Check                 | Command                          | Result | Evidence                                               |
+| --- | --------------------- | -------------------------------- | ------ | ------------------------------------------------------ |
+| 1   | Version vs latest tag | `git describe --tags --abbrev=0` | PASS   | package.json=4.16.0-alpha.4, latest tag=4.16.0-alpha.3 |
+
+Use PASS / FAIL / UNVERIFIED per row. UNVERIFIED must state exactly what
+couldn't be checked and why (missing doc, missing date, command unavailable)
+— never imply PASS when a check couldn't run.
+
+End with a one-line overall verdict: `READY`, `NOT READY`, or `NOT READY —
+UNVERIFIED ITEMS PRESENT`.
+
+# Rules
+
+- Read-only: never edit files, never run `git tag`, `git push`, or any
+  mutating release command.
+- Never assume branch names, version-format rules, or required artifacts —
+  always derive them from the process docs, and quote the doc line that
+  states the rule.
+- If a referenced doc or config path doesn't exist, say so plainly as
+  UNVERIFIED rather than guessing its content.

--- a/.claude/hooks/auto-format.sh
+++ b/.claude/hooks/auto-format.sh
@@ -8,6 +8,14 @@ if [ -z "$FILE_PATH" ]; then
   exit 0
 fi
 
+# Hooks fire for any path a subagent edits, including other repos — only act
+# on paths inside this project.
+ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+case "$FILE_PATH" in
+  "$ROOT"/*) ;;
+  *) exit 0 ;;
+esac
+
 if [[ "$FILE_PATH" == *.ts || "$FILE_PATH" == *.tsx || "$FILE_PATH" == *.js || "$FILE_PATH" == *.jsx || "$FILE_PATH" == *.json || "$FILE_PATH" == *.css || "$FILE_PATH" == *.md ]]; then
   npx prettier --write "$FILE_PATH" 2>/dev/null || true
 fi

--- a/.claude/hooks/clean-action-dist.sh
+++ b/.claude/hooks/clean-action-dist.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# After building desktop-release-action via a workspace-wide build, remove the
+# nested dist/dist directory (AGENTS.md: the action only needs
+# workspaces/desktop-release-action/dist/index.js).
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+if [[ "$COMMAND" != *"workspaces:build"* && "$COMMAND" != *"workspaces foreach"* ]]; then
+  exit 0
+fi
+
+NESTED_DIST="${CLAUDE_PROJECT_DIR:-.}/workspaces/desktop-release-action/dist/dist"
+
+if [ -d "$NESTED_DIST" ]; then
+  rm -rf "$NESTED_DIST"
+  echo "Removed nested workspaces/desktop-release-action/dist/dist (AGENTS.md)"
+fi
+
+exit 0

--- a/.claude/hooks/guard-workspace-build.sh
+++ b/.claude/hooks/guard-workspace-build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Deny running yarn/npm build inside a workspace directory (AGENTS.md: use root
+# 'yarn workspaces:build' instead — running build inside a workspace dir creates
+# incorrect output structures).
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+LOWER=$(echo "$COMMAND" | tr '[:upper:]' '[:lower:]')
+
+DENY_REASON="AGENTS.md: never run yarn build inside workspace directories — use root 'yarn workspaces:build'."
+
+# Pattern 1: cd into a workspaces/<name> dir (anywhere in a &&/; chained command)
+# followed later by a yarn/npm build invocation.
+if echo "$LOWER" | grep -Eq 'cd[[:space:]]+[^&;]*workspaces/[^[:space:]]+' \
+  && echo "$LOWER" | grep -Eq '(yarn|npm)[[:space:]]+(run[[:space:]]+)?build'; then
+  echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"$DENY_REASON\"}}"
+  exit 0
+fi
+
+# Pattern 2: yarn workspace <name> build --cwd workspaces/...
+if echo "$LOWER" | grep -Eq 'yarn[[:space:]]+workspace[[:space:]]+[^[:space:]]+[[:space:]]+build' \
+  && echo "$LOWER" | grep -Eq -- '--cwd[[:space:]]+workspaces/'; then
+  echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"$DENY_REASON\"}}"
+  exit 0
+fi
+
+exit 0

--- a/.claude/hooks/i18n-parity.sh
+++ b/.claude/hooks/i18n-parity.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# Report i18n key parity against en.i18n.json after editing a locale file
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# Hooks fire for any path a subagent edits, including other repos — only act
+# on paths inside this project.
+ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+case "$FILE_PATH" in
+  "$ROOT"/*) ;;
+  *) exit 0 ;;
+esac
+
+[[ "$FILE_PATH" == *"/src/i18n/"* || "$FILE_PATH" == src/i18n/* ]] || exit 0
+[[ "$FILE_PATH" == *.i18n.json ]] || exit 0
+
+I18N_DIR="${CLAUDE_PROJECT_DIR:-.}/src/i18n"
+EN_FILE="$I18N_DIR/en.i18n.json"
+
+[ -f "$EN_FILE" ] || exit 0
+
+BASENAME=$(basename "$FILE_PATH")
+
+node -e '
+const fs = require("fs");
+const path = require("path");
+
+function flatten(obj, prefix = "") {
+  const out = {};
+  for (const [k, v] of Object.entries(obj || {})) {
+    const key = prefix ? `${prefix}.${k}` : k;
+    if (v && typeof v === "object" && !Array.isArray(v)) {
+      Object.assign(out, flatten(v, key));
+    } else {
+      out[key] = true;
+    }
+  }
+  return out;
+}
+
+function loadFlat(file) {
+  try {
+    return flatten(JSON.parse(fs.readFileSync(file, "utf8")));
+  } catch (e) {
+    return null;
+  }
+}
+
+const i18nDir = process.argv[1];
+const enFile = process.argv[2];
+const editedFile = process.argv[3];
+const editedBasename = path.basename(editedFile);
+
+const enFlat = loadFlat(enFile);
+if (!enFlat) process.exit(0);
+const enKeys = Object.keys(enFlat);
+
+const localeFiles = fs
+  .readdirSync(i18nDir)
+  .filter((f) => f.endsWith(".i18n.json") && f !== "en.i18n.json");
+
+if (editedBasename === "en.i18n.json") {
+  const results = [];
+  const missingEverywhere = new Set(enKeys);
+
+  for (const f of localeFiles) {
+    const flat = loadFlat(path.join(i18nDir, f));
+    if (!flat) continue;
+    const missing = enKeys.filter((k) => !(k in flat));
+    results.push({ locale: f, missingCount: missing.length });
+    const present = new Set(Object.keys(flat));
+    for (const k of Array.from(missingEverywhere)) {
+      if (present.has(k)) missingEverywhere.delete(k);
+    }
+  }
+
+  results.sort((a, b) => b.missingCount - a.missingCount);
+  const top5 = results.slice(0, 5);
+
+  console.log(`i18n parity vs en.i18n.json (${results.length} other locales):`);
+  for (const r of top5) {
+    console.log(`  ${r.locale}: ${r.missingCount} missing`);
+  }
+
+  const newKeys = Array.from(missingEverywhere).slice(0, 10);
+  if (newKeys.length > 0) {
+    console.log(`Keys new in en, missing from ALL locales (needs translation), showing up to 10:`);
+    for (const k of newKeys) {
+      console.log(`  - ${k}`);
+    }
+  } else {
+    console.log("No keys missing from every other locale.");
+  }
+} else {
+  const flat = loadFlat(editedFile);
+  if (!flat) process.exit(0);
+  const localeKeys = Object.keys(flat);
+  const enSet = new Set(enKeys);
+  const stale = localeKeys.filter((k) => !enSet.has(k));
+  const missing = enKeys.filter((k) => !(k in flat));
+
+  console.log(`i18n parity for ${editedBasename} vs en.i18n.json:`);
+  console.log(`  missing vs en: ${missing.length}`);
+  console.log(`  stale (present here, absent from en): ${stale.length}`);
+  if (stale.length > 0) {
+    console.log("  stale keys (up to 10):");
+    for (const k of stale.slice(0, 10)) {
+      console.log(`    - ${k}`);
+    }
+  }
+}
+' "$I18N_DIR" "$EN_FILE" "$FILE_PATH" 2>/dev/null || true
+
+exit 0

--- a/.claude/hooks/protect-default-branches.sh
+++ b/.claude/hooks/protect-default-branches.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Deny direct commits/pushes to dev/master and force-pushes to dev/master
+# (AGENTS.md: never commit or push directly to dev/master — create a branch,
+# test, open a PR).
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+LOWER=$(echo "$COMMAND" | tr '[:upper:]' '[:lower:]')
+
+# Force-push to dev/master is always denied, regardless of current branch.
+if echo "$LOWER" | grep -Eq 'git[[:space:]]+push' \
+  && echo "$LOWER" | grep -Eq -- '(--force|-f\b)' \
+  && echo "$LOWER" | grep -Eq '(origin[[:space:]]+(dev|master)\b|:(dev|master)\b)'; then
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Force-pushing dev/master is not allowed."}}'
+  exit 0
+fi
+
+# Only care about actual commit/push subcommands, not --help/log/etc.
+IS_COMMIT=$(echo "$LOWER" | grep -Eq 'git[[:space:]]+commit([[:space:]]|$)' && echo 1 || echo 0)
+IS_PUSH=$(echo "$LOWER" | grep -Eq 'git[[:space:]]+push([[:space:]]|$)' && echo 1 || echo 0)
+
+# grep -E has no lookahead; strip --help invocations explicitly so
+# 'git commit --help' / 'git push --help' don't trip the guard.
+if echo "$LOWER" | grep -Eq -- '(commit|push)[[:space:]].*--help'; then
+  IS_COMMIT=0
+  IS_PUSH=0
+fi
+
+if [ "$IS_COMMIT" != "1" ] && [ "$IS_PUSH" != "1" ]; then
+  exit 0
+fi
+
+BRANCH="${HOOK_TEST_BRANCH:-$(git -C "${CLAUDE_PROJECT_DIR:-.}" branch --show-current 2>/dev/null)}"
+
+if [ "$BRANCH" = "dev" ] || [ "$BRANCH" = "master" ]; then
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"AGENTS.md: never commit or push directly to dev/master — create a branch and open a PR."}}'
+  exit 0
+fi
+
+exit 0

--- a/.claude/hooks/typecheck.sh
+++ b/.claude/hooks/typecheck.sh
@@ -8,6 +8,14 @@ if [ -z "$FILE_PATH" ]; then
   exit 0
 fi
 
+# Hooks fire for any path a subagent edits, including other repos — only act
+# on paths inside this project.
+ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+case "$FILE_PATH" in
+  "$ROOT"/*) ;;
+  *) exit 0 ;;
+esac
+
 if [[ "$FILE_PATH" != *.ts && "$FILE_PATH" != *.tsx ]]; then
   exit 0
 fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,21 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/guard-workspace-build.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/protect-default-branches.sh",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "PostToolUse": [
@@ -23,9 +38,24 @@
           },
           {
             "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/i18n-parity.sh",
+            "timeout": 30
+          },
+          {
+            "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/typecheck.sh",
             "timeout": 60,
             "async": true
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/clean-action-dist.sh",
+            "timeout": 10
           }
         ]
       }

--- a/.claude/skills/coderabbit-triage/SKILL.md
+++ b/.claude/skills/coderabbit-triage/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: coderabbit-triage
+description: Triage unresolved CodeRabbit review threads on a PR: classify accept/reject/verify, apply accepted fixes, reply and resolve
+disable-model-invocation: true
+---
+
+# CodeRabbit Triage
+
+Triage unresolved CodeRabbit review threads on a PR, classify each one,
+apply the fixes worth applying, and close the loop with a reply and
+resolution. Never commit or push — this skill hands off, it does not
+ship.
+
+## Argument
+
+PR number. If not given, resolve it for the current branch:
+
+```bash
+gh pr view --json number --jq '.number'
+```
+
+## Steps
+
+### 1. Fetch unresolved CodeRabbit threads
+
+```bash
+gh api graphql -f query='
+query($owner:String!, $repo:String!, $pr:Int!) {
+  repository(owner:$owner, name:$repo) {
+    pullRequest(number:$pr) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+          line
+          comments(first: 10) {
+            nodes {
+              author { login }
+              body
+              url
+            }
+          }
+        }
+      }
+    }
+  }
+}' -f owner=RocketChat -f repo=Rocket.Chat.Electron -F pr=<PR_NUMBER> \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes[]
+        | select(.comments.nodes[0].author.login == "coderabbitai")
+        | select(.isResolved == false)'
+```
+
+Threads with more than 10 comments need a second page
+(`comments(first: 10, after: $cursor)`) — check `comments.pageInfo` if a
+thread looks truncated. Note `isOutdated` per thread; an outdated thread
+still needs a decision, just flag it as possibly stale (the line moved).
+
+### 2. Classify each thread
+
+For every unresolved CodeRabbit thread, assign one of:
+
+- **ACCEPT** — clear correctness or convention win (real bug, matches an
+  existing repo pattern, cites a rule from AGENTS.md/CLAUDE.md).
+- **REJECT** — wrong, style-only against this repo's conventions, or
+  already handled elsewhere. State WHY with a concrete code reference
+  (file:line or existing pattern), not just "disagree".
+- **VERIFY** — the call requires running a test or reproducing behavior
+  before deciding.
+
+Apply the `personal-engineering-rules` skill's guidance on cautious
+treatment of review-bot feedback: bots are frequently confidently
+wrong — verify each claim against the actual code before agreeing, do
+not rubber-stamp a suggestion just because it sounds plausible.
+
+### 3. Present the table and STOP
+
+```
+Thread | File:Line | Classification | Reason
+```
+
+Stop here for explicit user confirmation before touching any code or
+calling any mutation.
+
+### 4. On go: apply ACCEPT items
+
+Apply straightforward ACCEPT fixes inline; dispatch `builder-fast` for
+anything touching 2+ files or requiring real logic changes. Run the
+narrowest test scope that covers the change (see AGENTS.md Testing /
+`pr-check` skill step 4 for the spec-mapping approach). Do not touch
+REJECT or VERIFY items' code — VERIFY items get whatever check resolves
+the question (run the test, reproduce the behavior), not a code change
+unless the verification confirms the suggestion.
+
+### 5. Reply and resolve per thread
+
+Reply on every thread (ACCEPT, REJECT, and VERIFY once resolved) before
+resolving it:
+
+```bash
+gh api graphql -f query='
+mutation($threadId:ID!, $body:String!) {
+  addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$threadId, body:$body}) {
+    comment { id url }
+  }
+}' -f threadId=<THREAD_ID> -f body="<reply text>"
+```
+
+```bash
+gh api graphql -f query='
+mutation($threadId:ID!) {
+  resolveReviewThread(input:{threadId:$threadId}) {
+    thread { id isResolved }
+  }
+}' -f threadId=<THREAD_ID>
+```
+
+Never resolve a REJECT thread without a reply explaining why first —
+silent resolution loses the reasoning for the next person who reads the
+PR.
+
+### 6. Hand off
+
+Report what was applied, what was rejected (with reasons), and what
+still needs the user's own verification. Never `git commit` or
+`git push` — that decision stays with the user.

--- a/.claude/skills/i18n-translate/SKILL.md
+++ b/.claude/skills/i18n-translate/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: i18n-translate
+description: Translate keys added to src/i18n/en.i18n.json into every other locale file at the end of a feature, preserving key order and placeholders
+disable-model-invocation: true
+---
+
+# i18n Translate
+
+Developers edit only `src/i18n/en.i18n.json` while a feature is in
+progress. When the feature is finished, this skill translates every new
+or changed key into all other locale files in one pass. Lingohub reviews
+the translations afterward (its bot commits "Language update from
+Lingohub") — this skill does not need to be perfect, just correct and
+consistent.
+
+**When to run**: at feature completion, before `pr-check`.
+
+## Background
+
+- Read `.claude/skills/i18n-audit/SKILL.md` for the key-flattening/coverage
+  approach this skill reuses.
+- `src/i18n/en.i18n.json` is a nested JSON object; keys are addressed with
+  dot notation (e.g. `dialog.about.title`).
+- i18next placeholders like `{{name}}` and `{{- name}}` (unescaped) must be
+  preserved verbatim, including the `-` prefix where present. HTML-ish
+  tags such as `<1>...</1>` also appear in values (e.g.
+  `dialog.about.version`) and must be preserved verbatim.
+- Plural keys use i18next suffixes `_one` / `_other` (e.g. `count_one`,
+  `count_other`, `unreadMessage_one`, `unreadMessage_other`) — translate
+  both forms with correct plural grammar for the target locale, keeping
+  the same key names (i18next plural suffixes are not translated).
+- Locale files: `src/i18n/*.i18n.json` (currently `ar`, `de-DE`, `es`,
+  `fi`, `fr`, `hu`, `it-IT`, `ja`, `nb-NO`, `nn`, `no`, `pl`, `pt-BR`,
+  `ru`, `se`, `sv`, `tr-TR`, `uk-UA`, `zh`, `zh-CN`, `zh-TW`).
+- `src/i18n/__tests__/resources.spec.ts` asserts the set of locales
+  `resources.ts` exposes loaders for, and that a sample of locales
+  (`de-DE`, `pt-BR`, `ja`) load as non-empty objects — it does not assert
+  per-key parity. `src/i18n/__tests__/common.spec.ts` and `actions.spec.ts`
+  cover formatting/action-constant behavior, not locale content. There is
+  no test that fails on missing keys; parity is enforced by
+  `.claude/hooks/i18n-parity.sh`'s report, not by CI.
+
+## Steps
+
+### (a) Compute missing keys per locale
+
+Reuse the flatten approach from `i18n-audit` / `.claude/hooks/i18n-parity.sh`.
+Quick one-liner per locale:
+
+```sh
+node -e '
+const fs = require("fs");
+function flatten(obj, prefix = "") {
+  const out = {};
+  for (const [k, v] of Object.entries(obj || {})) {
+    const key = prefix ? `${prefix}.${k}` : k;
+    if (v && typeof v === "object" && !Array.isArray(v)) Object.assign(out, flatten(v, key));
+    else out[key] = v;
+  }
+  return out;
+}
+const en = flatten(JSON.parse(fs.readFileSync("src/i18n/en.i18n.json", "utf8")));
+const locale = flatten(JSON.parse(fs.readFileSync(process.argv[1], "utf8")));
+const missing = Object.keys(en).filter((k) => !(k in locale));
+for (const k of missing) console.log(k, "=>", JSON.stringify(en[k]));
+' src/i18n/pt-BR.i18n.json
+```
+
+Or simply run `.claude/hooks/i18n-parity.sh`'s logic against `en.i18n.json`
+(it prints missing-key counts per locale and the keys missing from every
+locale) to get the full picture across all locales at once.
+
+### (b) Translate missing values, locale by locale
+
+For each locale, translate only the missing values — natural,
+product-appropriate translations for a desktop chat client UI. Do not
+touch existing translations (Lingohub owns those and will overwrite
+drift; touching them just creates unnecessary diff noise). Preserve:
+
+- `{{placeholder}}` / `{{- placeholder}}` tokens exactly, including the
+  `-` prefix.
+- Embedded tags like `<1>...</1>`.
+- Trailing punctuation and any leading `&` accelerator markers (e.g.
+  `&Copy` style menu accelerators) — keep the `&` before the
+  locale-appropriate mnemonic letter if the target locale conventionally
+  uses one, otherwise drop it rather than mistranslate it.
+- Both `_one` and `_other` plural forms, translated with correct grammar
+  for that locale's pluralization rules (not just a copy of the English
+  form).
+
+Never invent new keys that don't exist in `en.i18n.json`.
+
+### (c) Insert at the correct position
+
+Insert each new key at the same position and nesting level it occupies in
+`en.i18n.json`, matching the surrounding structure (same parent objects,
+same key order) so the locale file's shape mirrors English.
+
+### (d) Parallelize for many locales
+
+If more than 5 locales need translation, dispatch parallel
+`builder-trivial` agents, one per locale, each given the exact list of
+missing keys and their English source values for that locale. If 5 or
+fewer locales need translation, do the edits inline instead.
+
+### (e) Verify
+
+Run the i18n spec suite:
+
+```sh
+yarn test --runTestsByPath src/i18n/__tests__/resources.spec.ts src/i18n/__tests__/common.spec.ts src/i18n/__tests__/actions.spec.ts src/i18n/__tests__/renderer.spec.ts
+```
+
+(Confirm actual file names under `src/i18n/__tests__/` before running —
+use `yarn test --listTests --runTestsByPath <file>` if discovery is
+uncertain, per `AGENTS.md` Testing conventions.)
+
+Then re-run the parity check (`.claude/hooks/i18n-parity.sh`'s logic, or
+the one-liner from step (a)) against every locale to confirm zero missing
+keys remain.
+
+### (f) Handoff to Lingohub
+
+Lingohub reviews and refines these translations afterward via its own
+commits ("Language update from Lingohub"), so aim for correct-and-consistent
+rather than perfect — the goal is to unblock the PR with complete key
+coverage, not to ship final-quality copy.

--- a/.claude/skills/new-spec/SKILL.md
+++ b/.claude/skills/new-spec/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: new-spec
+description: Scaffold a Jest spec for a source file in the correct Electron-runner path (*.main.spec.ts vs nested renderer spec) and verify discovery with --listTests
+---
+
+# New Spec
+
+Scaffold a Jest spec file for a given source file, placing it where the
+`@kayahr/jest-electron-runner` project config in `jest.config.js` will
+actually discover it, then prove discovery before writing any test bodies.
+
+## Arguments (required)
+
+- `source`: path to the source file to test, e.g.
+  `src/downloads/main.ts` or `src/ui/components/TopBar/UpdateLabel.tsx`.
+
+## Steps
+
+### 1. Classify the source file
+
+Determine which of the two Jest `projects` in `jest.config.js` the spec
+belongs to:
+
+- **Main process** — the file lives under `src/*/main/**` or is named
+  `src/**/main.ts`, or it imports main-process-only Electron APIs
+  (`app`, `BrowserWindow`, `ipcMain`, `session`, `dialog`, etc. from
+  `'electron'`). These use the runner: `@kayahr/jest-electron-runner/main`.
+- **Renderer** — everything else: React components (`.tsx`), Redux
+  reducers/actions, preload-adjacent renderer helpers, hooks. These use
+  `@kayahr/jest-electron-runner/environment`.
+- **Preload** — preload scripts (`src/**/preload/**`, `src/**/preload.ts`)
+  are tested as renderer-project specs (see existing examples under
+  `src/servers/preload/__tests__/*.spec.ts`) even though they run in a
+  preload context at runtime.
+
+### 2. Derive the exact spec path from the real `testMatch`
+
+Quote directly from `jest.config.js` — do not paraphrase:
+
+Main-process project:
+
+```
+'<rootDir>/src/*/main/**/*.(spec|test).{js,ts,tsx}',
+'<rootDir>/src/**/main.(spec|test).{js,ts,tsx}',
+'<rootDir>/src/systemCertificates.(spec|test).{js,ts,tsx}',
+'<rootDir>/src/constants.(spec|test).{js,ts,tsx}',
+```
+
+Renderer project:
+
+```
+'<rootDir>/src/*/!(main)/**/*.(spec|test).{js,ts,tsx}',
+'<rootDir>/src/**/renderer.(spec|test).{js,ts,tsx}',
+'<rootDir>/src/whenReady.(spec|test).{js,ts,tsx}',
+```
+
+Consequences for naming/placement:
+
+- Main-process spec for `src/downloads/main.ts` → sibling file
+  `src/downloads/main.spec.ts` (matches the `src/**/main.(spec|test).*`
+  pattern), OR a file under `src/downloads/main/**` if that subfolder
+  pattern applies instead.
+- Renderer spec for a file directly under `src/<module>/` → **flat
+  `src/<module>/*.spec.ts(x)` is NOT matched** by
+  `src/*/!(main)/**/*.(spec|test).*` (that pattern requires at least one
+  extra path segment after `src/<module>/`). Per `AGENTS.md` (Testing),
+  nest it instead:
+  - `src/<module>/__tests__/<Name>.spec.ts(x)` (existing convention, see
+    `src/logViewerWindow/__tests__/LogTimeline.spec.tsx`), or
+  - colocated next to a component in its own subfolder, e.g.
+    `src/ui/components/TopBar/UpdateLabel.spec.tsx` (the component itself
+    lives one segment deep under `src/ui/components/`, satisfying the
+    `**` in the pattern), or
+  - `src/<module>/renderer.spec.tsx` if the module exposes a single
+    renderer entry point.
+- When in doubt, mirror the nearest existing sibling spec's location
+  rather than inventing a new layout.
+
+### 3. Scaffold boilerplate
+
+**Main-process spec** (`*.main.spec.ts` convention — note some existing
+files use `.main.spec.ts` explicitly even though the `testMatch` pattern
+only requires `main.spec.ts`; follow the sibling files in that directory):
+
+```typescript
+import { someElectronApi } from 'electron';
+
+import { handle } from '../../ipc/main';
+import { functionUnderTest } from '../moduleUnderTest';
+
+jest.mock('electron', () => ({
+  someElectronApi: {
+    someMethod: jest.fn(),
+  },
+}));
+
+jest.mock('../../ipc/main', () => ({
+  handle: jest.fn(),
+}));
+
+const someMethodMock = someElectronApi.someMethod as jest.MockedFunction<
+  typeof someElectronApi.someMethod
+>;
+
+describe('functionUnderTest', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does the expected thing', () => {
+    // ...
+  });
+});
+```
+
+**Renderer spec** (React component, using the project's `test-utils`):
+
+```tsx
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) =>
+      options ? `${key}:${JSON.stringify(options)}` : key,
+    i18n: { language: 'en', changeLanguage: jest.fn() },
+  }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}));
+
+const mockDispatch = jest.fn();
+
+jest.mock('../../../store', () => ({
+  dispatch: (action: unknown) => mockDispatch(action),
+}));
+
+import { renderWithStore, screen, userEvent } from '../../test-utils';
+import { ComponentUnderTest } from './ComponentUnderTest';
+
+describe('ComponentUnderTest', () => {
+  beforeEach(() => {
+    mockDispatch.mockClear();
+  });
+
+  it('renders the expected content', () => {
+    renderWithStore(<ComponentUnderTest />, { preloadedState: {} as any });
+
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+});
+```
+
+`renderWithStore`/`screen`/`userEvent` come from `src/ui/test-utils.tsx`
+— adjust the relative import depth to match the spec's location. The
+`react-i18next` mock block above MUST be copied into every spec file
+(it cannot live in the shared helper — `jest.mock` only hoists inside
+the module that declares it; see the comment at the top of
+`src/ui/test-utils.tsx`).
+
+**Fuselage component mocks** — only mock the specific Fuselage component
+that breaks under jsdom (no real layout engine); keep everything else
+real via `jest.requireActual`:
+
+```tsx
+// Select: jsdom has no native <Select> option rendering path for
+// Fuselage's custom listbox, so swap it for a plain <select>.
+jest.mock('@rocket.chat/fuselage', () => {
+  const actual = jest.requireActual('@rocket.chat/fuselage');
+  return {
+    ...actual,
+    Select: ({
+      options,
+      value,
+      onChange,
+    }: {
+      options: [string, string][];
+      value: string;
+      onChange: (key: string) => void;
+    }) => (
+      <select
+        data-testid='my-select'
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      >
+        {options.map(([val, label]) => (
+          <option key={val} value={val}>
+            {label}
+          </option>
+        ))}
+      </select>
+    ),
+  };
+});
+```
+
+```tsx
+// Dropdown: Fuselage's <Dropdown> positions itself with usePosition,
+// which under jsdom has no real layout and so renders its children as
+// null. Replace only that component with an inline passthrough.
+jest.mock('@rocket.chat/fuselage', () => {
+  const actual = jest.requireActual('@rocket.chat/fuselage');
+  return {
+    __esModule: true,
+    ...actual,
+    Dropdown: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid='dropdown'>{children}</div>
+    ),
+  };
+});
+```
+
+Fuselage `Dialog` renders correctly under jsdom without a mock in most
+existing specs (see `src/ui/components/OutlookCredentialsDialog/index.spec.tsx`)
+— only add a `Dialog` mock if a real failure shows it needs one; don't
+mock it preemptively.
+
+**`Date.now` pinning** — if the spec seeds a timestamp close to the
+component's own mount-time `Date.now()` call (e.g. comparing a
+`startTime`/`seenAt` prop against a later user-driven `Date.now()`
+call), pin the clock instead of relying on wall-clock ordering:
+
+```typescript
+const NOW = Date.now();
+const spy = jest.spyOn(Date, 'now').mockReturnValue(NOW);
+try {
+  // render + interact; anything that reads Date.now() sees NOW
+} finally {
+  spy.mockRestore();
+}
+```
+
+Unpinned specs that seed timestamps "near" mount time are flaky by a
+race of 1ms — see `src/ui/components/TopBar/DownloadsIndicator.spec.tsx`
+for the canonical example and comment.
+
+### 4. Prove discovery, then run only that file
+
+```bash
+yarn test --listTests --runTestsByPath <spec-path>
+yarn test --runTestsByPath <spec-path>
+```
+
+`--listTests` must print the exact spec path back; if it prints nothing,
+the path does not match `testMatch` — revisit step 2 before writing test
+bodies.
+
+### 5. Never run the full suite
+
+Do not run bare `yarn test` for this task. Scope every run to the new
+spec's path with `--runTestsByPath`.
+
+## Traps (from AGENTS.md Testing)
+
+- Flat `src/<module>/*.spec.ts` renderer specs are silently not
+  discovered — no error, just zero tests collected.
+- Main-process specs must avoid renderer-only APIs (DOM, React) since
+  they run under `testEnvironment: 'node'`, not the Electron renderer
+  environment.
+- UI/paint correctness cannot be proven by a component spec — a clipped
+  SVG or mispositioned element still passes every DOM assertion. Specs
+  verify behavior/markup; use `dev-app-verify` for visual verification.
+- Screen-capture / WebRTC / portal behavior cannot be validated in
+  software-rendered test environments at all — do not attempt to spec
+  around that; see `docs/postmortem-screen-picker-startup-enumeration.md`.
+- Platform-specific APIs (`process.getuid()`, `process.getgid()`,
+  `process.geteuid()`, `process.getegid()`) should be exercised via
+  optional chaining and fallbacks in the source, not mocked in the spec,
+  unless defensive coding genuinely isn't possible.
+- `--coverage` runs exclude a fixed list of specs
+  (`COVERAGE_INCOMPATIBLE_SPECS` in `jest.config.js`) that fail only
+  under Istanbul instrumentation inside the Electron V8 context. Plain
+  `yarn test` still runs and gates them — don't assume a coverage-run
+  pass/fail reflects the plain-run result for those files.

--- a/.claude/skills/package-smoke/SKILL.md
+++ b/.claude/skills/package-smoke/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: package-smoke
+description: Run the installer smoke-test scripts (MSI on Windows VM, Linux AppImage/deb) against a built artifact and report a digest
+disable-model-invocation: true
+---
+
+# Package Smoke
+
+Run the packaged-installer smoke tests against a built artifact and
+report a one-line verdict + verbatim error excerpt. Do NOT run these
+directly with Bash — the underlying scripts are long-running/noisy
+(builds, VM copy, install/uninstall cycles); dispatch through the
+`watcher` agent and read its digest.
+
+## Read fully first
+
+- `scripts/README.md` — Linux script usage (`linux-test-deb.sh`;
+  `linux-test-appimage.sh` is undocumented there, see below).
+- `scripts/msi-test/README.md` — MSI suite scope, prerequisites, VM env
+  vars, scenarios A/B/C.
+- `scripts/msi-test/run-msi-tests.sh` — real orchestrator args/env.
+- `scripts/msi-test/test-on-windows.ps1` — what each scenario asserts.
+- `scripts/msi-test/fetch-logs.sh` — log-only re-fetch without re-running.
+- `scripts/linux-test-appimage.sh` — real flags (source has no header
+  doc; flags below are read from the script itself).
+- `scripts/linux-test-deb.sh` — real flags (documented in
+  `scripts/README.md`).
+
+## When NOT to use
+
+- Unit/integration tests (`yarn test`) — not this skill, no artifact
+  involved.
+- Browser/web-client testing — out of scope, this is desktop-installer
+  only.
+- Verifying UI rendering/behavior inside a running app — use
+  `dev-app-verify` or the `mosdat-testing` skill instead; this skill
+  only proves an installer artifact installs and launches.
+- No built artifact exists yet — build first (`yarn build` +
+  `electron-builder`, or let `linux-test-appimage.sh` /
+  `linux-test-deb.sh` build it via their default no-`--skip-build` path).
+
+## Steps
+
+### 1. Resolve the artifact
+
+Take the artifact path as an argument, or find the newest in `dist/`:
+
+```bash
+ls -t dist/*.msi dist/*.exe dist/*.AppImage dist/*.deb 2>/dev/null | head -1
+```
+
+### 2. Map extension to script and platform
+
+| Extension   | Script                                                                         | Runs on                                        |
+| ----------- | ------------------------------------------------------------------------------ | ---------------------------------------------- |
+| `.msi`      | `scripts/msi-test/run-msi-tests.sh`                                            | macOS host, orchestrates a Windows VM over SSH |
+| `.exe`      | n/a — the MSI suite only tests `.msi`; no smoke script covers NSIS `.exe` here | —                                              |
+| `.AppImage` | `scripts/linux-test-appimage.sh`                                               | Linux only (`OSTYPE` guard exits non-Linux)    |
+| `.deb`      | `scripts/linux-test-deb.sh`                                                    | Linux only, needs `dpkg`/`apt-get`             |
+
+### 3. Check prerequisites for the mapped script
+
+**MSI** (`run-msi-tests.sh`):
+
+- Runs from a macOS/Linux host with `sshpass`, `ssh`, `scp` in `PATH`.
+- Requires a reachable Windows 10 VM with OpenSSH on port 22 and env
+  vars `VM_HOST`, `VM_PORT` (default 22), `VM_USER`, `VM_PASS` set
+  (`VM_PASS` is required, no default — export it, never commit it).
+- If the VM was reprovisioned behind the same IP, delete
+  `scripts/msi-test/.known_hosts` first.
+- The script auto-picks the newest `dist/*.msi` by mtime if `MSI_PATH`
+  is unset and no path argument is given.
+- Invocation: `MSI_PATH=<path> ./scripts/msi-test/run-msi-tests.sh` or
+  `./scripts/msi-test/run-msi-tests.sh <path>`.
+- If the VM is unreachable, the script prints the Proxmox web UI URL —
+  start the VM there, wait ~30s, retry. Prefer the `mosdat-testing`
+  skill instead when the task is "does this build actually work on a
+  real machine" — it owns the Proxmox-hosted VM lifecycle end-to-end
+  (build→deploy→run→verdict); use `package-smoke`'s MSI path only for
+  this specific `DISABLE_AUTO_UPDATES` install-log scenario suite.
+
+**AppImage** (`linux-test-appimage.sh`):
+
+- Linux host only (hard-fails on non-`linux-gnu` `OSTYPE`).
+- Flags: `--skip-build`, `--skip-install` (chmod +x step),
+  `--skip-run`, `--help`/`-h`.
+- With no flags: builds via `yarn build` + `electron-builder --publish
+never --linux AppImage`, finds `dist/rocketchat-*-linux-*.AppImage`,
+  chmods it, launches it in the background, logs to
+  `/tmp/rocketchat-appimage.log`.
+
+**deb** (`linux-test-deb.sh`):
+
+- Linux host only, needs `dpkg`, `apt-get`, sudo access for install.
+- Flags: `--skip-build`, `--skip-install`, `--skip-run`, `--help`/`-h`.
+- With no flags: `yarn build-linux`, finds
+  `dist/rocketchat-*-linux-*.deb`, installs via `dpkg -i` (auto-fixes
+  deps with `apt-get install -f`), launches
+  `/opt/Rocket.Chat/rocketchat-desktop` in background.
+
+If the required host/VM/env var is missing, stop and report
+**UNVERIFIED** with exactly what's missing — do not guess credentials
+or fake a VM.
+
+### 4. Run through `watcher`
+
+Dispatch the resolved command to the `watcher` agent (long-running,
+noisy — never stream this into your own context):
+
+```bash
+# MSI example
+MSI_PATH=dist/rocketchat-4.14.0-win-x64.msi ./scripts/msi-test/run-msi-tests.sh
+
+# AppImage example
+./scripts/linux-test-appimage.sh --skip-build
+
+# deb example
+./scripts/linux-test-deb.sh --skip-build
+```
+
+For MSI, the watcher should also report the structured result at
+`scripts/msi-test/logs/<timestamp>/test-results.json` (per-scenario
+pass/fail) and note `scripts/msi-test/fetch-logs.sh` as the way to
+re-pull logs without re-running if the digest needs more detail.
+
+### 5. Report
+
+One-line verdict (`PASS` / `FAIL` / `UNVERIFIED` + reason) plus a
+verbatim excerpt of any error line from the watcher's digest — never a
+paraphrase, per AGENTS.md Writing rules (no invented metrics).

--- a/.claude/skills/pr-check/SKILL.md
+++ b/.claude/skills/pr-check/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: pr-check
+description: Pre-PR gate for Rocket.Chat.Electron — runs detect_changes, lint, targeted tests, i18n parity, packaging/QA checks and drafts the PR body
+disable-model-invocation: true
+---
+
+# PR Check
+
+Run the pre-PR verification gate for this repo and draft the PR body. Do
+NOT run `gh pr create` and do NOT commit anything — this skill only
+verifies and drafts; handing off to the user is the last step.
+
+## Checklist
+
+Execute every check below in order, and report results as a table with
+columns `Check | Result | Evidence`. Evidence must be real command
+output or a real file diff — never an invented number (see AGENTS.md
+Writing: no invented metrics).
+
+### 1. Scope and branch
+
+```bash
+git branch --show-current
+git diff --stat dev...HEAD
+```
+
+Fail this check (and stop) if the current branch is `dev` or `master` —
+per AGENTS.md, never commit or open a PR directly from either.
+
+### 2. GitNexus impact scan
+
+Call the GitNexus MCP tool:
+
+```
+detect_changes({ scope: "compare", base_ref: "dev" })
+```
+
+List every affected symbol and execution flow it reports. If it returns
+HIGH or CRITICAL risk on any symbol, surface that explicitly and warn
+the user before continuing — per `CLAUDE.md`/`AGENTS.md` GitNexus rules,
+do not silently proceed past a HIGH/CRITICAL warning.
+
+### 3. Lint
+
+```bash
+yarn lint
+```
+
+(Runs `eslint .` then `tsc --noEmit` — see `package.json` scripts
+`.:lint:eslint` / `.:lint:tsc`.) Report pass/fail and the error count if
+it fails.
+
+### 4. Targeted tests
+
+Map every changed file under `src/**` (from the `git diff --stat`
+output in step 1) to its spec file(s):
+
+- Same directory: `<name>.spec.ts(x)` or `<name>.main.spec.ts` next to
+  the changed file.
+- Nested test directory: `__tests__/<Name>.spec.ts(x)` under the same
+  module.
+- If a changed file has no matching spec, note it as "no spec found"
+  rather than skipping silently.
+
+Run only the mapped specs:
+
+```bash
+yarn test --runTestsByPath <spec-path-1> <spec-path-2> ...
+```
+
+Run the **full suite** (`yarn test`) instead only if the diff touches
+shared infrastructure:
+
+- `src/store`
+- `src/ipc`
+- `src/i18n`
+- `jest.config.js`
+
+If none of those are touched, targeted tests are the correct scope —
+do not broaden it further.
+
+### 5. i18n parity
+
+If `git diff --stat dev...HEAD` shows `src/i18n/en.i18n.json` changed:
+
+```bash
+git diff dev...HEAD -- src/i18n/en.i18n.json
+```
+
+Extract the added/changed keys, then check every other `src/i18n/*.i18n.json`
+file for those keys (dot-notation nested lookup, same approach as the
+`i18n-audit` skill). List any locale missing a newly added key. If any
+locale is missing a key, run the `i18n-translate` skill to fill the gap
+before opening the PR. If `en.i18n.json` did not change, mark this check
+"n/a".
+
+### 6. Packaging
+
+If `git diff --stat dev...HEAD` shows `electron-builder.json` or the
+`build` section of `package.json` changed:
+
+```bash
+git diff dev...HEAD -- electron-builder.json
+```
+
+Confirm the `win.target` entries still list `arch: ["x64", "ia32", "arm64"]`
+for every Windows target (`nsis`, `msi`, `zip`) — per AGENTS.md, Windows
+builds must include all three architectures. If neither file changed,
+mark this check "n/a".
+
+### 7. QA flows
+
+If the diff touches user-visible UI (React components under
+`src/ui/**`, `src/*/renderer.tsx`, menus, dialogs, settings screens),
+remind the user to run `skills/desktop-qa-flows/SKILL.md` for that
+change, then validate any touched or new QA pack:
+
+```bash
+node qa/scripts/validate-flows.mjs qa/<pack>
+```
+
+Only run `validate-flows.mjs` if a `qa/<pack>` was actually
+created/edited for this change — otherwise mark this check "n/a" and
+state the reminder was given.
+
+### 8. Docs
+
+If the diff introduces or changes a convention an agent would need
+going forward (new IPC pattern, new test layout rule, new platform
+constraint), confirm `AGENTS.md` and/or `CLAUDE.md` were updated to
+match. If not applicable, mark "n/a".
+
+### 9. No machine-specific paths
+
+```bash
+git grep -n -E '/Users/[a-z]+|/home/[a-z]+|C:\\Users' -- ':!*.lock' $(git diff --name-only dev...HEAD)
+```
+
+Must return nothing. Any hit is a candidate leaked local path (or a
+generic doc example like `/Users/user/...` — use judgment to tell the
+two apart); also flag any literal hostname or personal email if
+trivially visible in the same diff. Report pass/fail and the matching
+lines as evidence.
+
+## Output: PR body draft
+
+Read `.github/PULL_REQUEST_TEMPLATE.md` and fill its actual sections —
+do not invent a different structure. As of this writing the template
+asks for:
+
+- A `Closes #ISSUE_NUMBER` line (fill the real issue number if one
+  exists, otherwise remove the line per the template's own instruction).
+- A free-form "tell us more about your PR" section — use this for a
+  short summary of what changed and why, plus a "How verified" list
+  citing each check from the checklist above with its real result
+  (e.g. `yarn lint`: pass; `yarn test --runTestsByPath ...`: pass/fail
+  counts; GitNexus `detect_changes`: summary).
+- Screenshots if the diff touches UI (per the template's own prompt).
+
+Re-read the template file at skill-run time in case it changed — do not
+rely on the structure described above if the live file differs.
+
+Every claim in the drafted body must cite an actual command and its
+actual result from this run — no estimated coverage, no speculated
+user impact, no invented timing numbers (AGENTS.md Writing rules).
+
+Print the completed body in the response and stop. Do not run
+`gh pr create`, do not `git commit`, do not `git push`.

--- a/.claude/skills/pr-watch/SKILL.md
+++ b/.claude/skills/pr-watch/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: pr-watch
+description: Use when a branch was just pushed or a PR is open and the user wants to know when CI is green, when a check fails, or when CodeRabbit posts new comments, without anyone polling by hand. Triggers include "watch CI", "monitor the PR", "tell me when checks pass", "raise a watcher on CI", "wait for CI", or a request to keep an eye on review comments after a push.
+---
+
+# PR Watch
+
+Watch one PR until every required check has finished, surfacing check state
+changes and new CodeRabbit comments as they happen. Read-only: this skill
+never commits, never pushes unless told to, and never replies to or resolves
+review threads.
+
+## Core rule
+
+One harness `Monitor` running `scripts/watch.sh`. Not a haiku `watcher`
+agent, not a foreground `sleep` loop, not repeated `gh pr checks` calls by
+hand. AGENTIC.md § Async dispatch records why: a haiku watcher cannot hold a
+multi-minute poll and returns early claiming it is still monitoring, and
+manual polling burns a full turn per check. The Monitor tool holds the wait
+and delivers each event as a notification.
+
+## Steps
+
+### 1. Resolve the PR and confirm it is pushed
+
+```bash
+pr=$(gh pr view --json number --jq '.number')   # or the number the user gave
+git status -sb | head -1                          # look for "ahead N"
+```
+
+If the branch is ahead of its upstream, stop and say so. Push only when the
+user's request explicitly included pushing (for example "push and watch").
+Never commit here; that is the `commit` skill's job.
+
+### 2. Arm exactly one monitor
+
+Check `TaskList`/`ListAgents` first. If a monitor for this PR is already
+running, do not arm another.
+
+```
+Monitor({
+  command: "bash .claude/skills/pr-watch/scripts/watch.sh <pr>",
+  description: "PR <pr> CI checks and CodeRabbit comments",
+  timeout_ms: 3600000,
+  persistent: false,
+})
+```
+
+The script exits on its own when all required checks (default: the three
+`check (<os>-latest)` jobs; override with `PR_WATCH_REQUIRED`) are no longer
+pending. Run `bash .claude/skills/pr-watch/scripts/watch.sh <pr> --once` to
+see the current snapshot without waiting.
+
+Also pin the PR in the status line, so its check counts stay visible even
+when the cwd is a different checkout or branch:
+
+```bash
+mkdir -p ~/.cache/claude-statusline
+printf 'RocketChat/Rocket.Chat.Electron#%s\n' <pr> > ~/.cache/claude-statusline/current.pr
+```
+
+The status line script reads that file first and falls back to the cwd
+branch's PR when it is absent. Leave it in place after `DONE`; the user
+clears it with `rm ~/.cache/claude-statusline/current.pr` when they move on.
+
+### 3. Relay events, one line each
+
+| Event line                       | What to tell the user                                                                                       |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `CHECK <name>: pending`          | A check started. One sentence per notification, however many CHECK lines it carries.                        |
+| `CHECK <name>: pass`             | Passed. Same rule: one sentence per notification naming what passed and what is still pending.              |
+| `CHECK <name>: fail` / `cancel`  | Failed. Go to step 4 now, do not wait for the rest.                                                         |
+| `COMMENT <path>:<line> ...`      | CodeRabbit inline comment. Summarize in one sentence and name `/coderabbit-triage` as the way to act on it. |
+| `REVIEW ...`                     | CodeRabbit summary. Report the actionable count only.                                                       |
+| `DONE CI green`                  | Final table of every check and its state. Stop.                                                             |
+| `DONE CI finished with failures` | Final table, then step 4.                                                                                   |
+
+Between events, do nothing. Do not call `TaskOutput` to peek.
+
+### 4. On a failed check
+
+Dispatch the `ci-failure-triage` agent (read-only, haiku). Its prompt is
+one line: `PR <number>, failed check "<name>", head commit <sha>`. It
+returns "known flaky, rerun" or "real failure" with a verbatim log excerpt.
+The monitor keeps running meanwhile; keep relaying its events. For known
+flaky, offer `gh run rerun --failed <run-id>`; once the rerun starts the
+existing monitor picks up the new pending state, so do not arm another. For
+a real failure, report the excerpt and let the monitor run to `DONE`; fixing
+the failure is a new task.
+
+### 5. Timeout
+
+If the monitor hits its 60 minute timeout with checks still pending, report
+which checks are pending and re-arm once. Do not re-arm a third time; ask
+the user instead.
+
+## Common mistakes
+
+| Mistake                                                     | Fix                                                                                              |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Dispatching a `watcher` or haiku agent to "keep monitoring" | Use `Monitor`; agents return early on long waits.                                                |
+| Foreground `sleep 60; gh pr checks` loops                   | Blocked by the harness and wastes turns. Monitor only.                                           |
+| Two monitors on the same PR after a resume                  | Check `TaskList` before arming.                                                                  |
+| Replying to or resolving CodeRabbit threads from here       | That is `/coderabbit-triage`, which the user invokes.                                            |
+| Reporting green before the platform jobs registered         | The script waits for the required checks to exist; trust `DONE`, not an early all-pass snapshot. |
+| Committing or pushing "since we are watching anyway"        | Push only on explicit request; never commit.                                                     |

--- a/.claude/skills/pr-watch/scripts/watch.sh
+++ b/.claude/skills/pr-watch/scripts/watch.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Poll a PR's checks and CodeRabbit activity, printing one line per event.
+# Designed to run under the Claude Code Monitor tool: every stdout line is an
+# event, and the script exits once every required check has finished.
+#
+#   watch.sh <pr-number> [--once] [--interval <seconds>]
+#
+# Events:
+#   CHECK <name>: <bucket>        a check appeared or changed state
+#   COMMENT <path>:<line> <text>  new CodeRabbit inline review comment
+#   REVIEW <text>                 new CodeRabbit review summary (actionable count)
+#   DONE CI green | DONE CI finished with failures   followed by the final list
+#
+# Required checks default to this repo's platform test matrix. Override with
+# PR_WATCH_REQUIRED="name one,name two".
+set -u
+
+pr="${1:-}"
+[ -n "$pr" ] || { echo "usage: watch.sh <pr-number> [--once] [--interval <seconds>]" >&2; exit 2; }
+shift
+once=0
+interval=60
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --once) once=1 ;;
+    --interval) interval="${2:-60}"; shift ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+repo="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)"
+[ -n "$repo" ] || { echo "cannot resolve repository via gh repo view" >&2; exit 2; }
+
+required="${PR_WATCH_REQUIRED:-check (macos-latest),check (ubuntu-latest),check (windows-latest)}"
+
+# Comments are reported from launch time onward; PR_WATCH_SINCE (ISO 8601 UTC)
+# moves the window back, mainly for testing the comment output format.
+since="${PR_WATCH_SINCE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+prev=""
+
+strip() {
+  # One JSON string in, one flat text line out: drop collapsed <details>
+  # blocks and HTML comments, strip tags and markdown links, collapse
+  # whitespace, cap for a notification.
+  jq -r 'gsub("<details>[\\s\\S]*?</details>"; "") | gsub("<!--[\\s\\S]*?-->"; "") | gsub("<[^>]*>"; "") | gsub("!\\[[^\\]]*\\]\\([^)]*\\)"; "") | gsub("\\[([^\\]]*)\\]\\([^)]*\\)"; "\\1") | gsub("\\s+"; " ") | .[0:240]'
+}
+
+while true; do
+  now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  cur="$(gh pr checks "$pr" -R "$repo" --json name,bucket 2>/dev/null | jq -r '.[] | "\(.name): \(.bucket)"' | sort)" || true
+  if [ "$cur" != "$prev" ]; then
+    comm -13 <(printf '%s\n' "$prev") <(printf '%s\n' "$cur") | grep -v '^$' | sed 's/^/CHECK /'
+    prev="$cur"
+  fi
+
+  # -c keeps each comment as one JSON string (newlines escaped), so one
+  # comment becomes exactly one event line.
+  gh api "repos/$repo/pulls/$pr/comments?since=$since" 2>/dev/null \
+    | jq -c '.[] | select(.user.login | test("coderabbit"; "i")) | "\(.path):\(.line // .original_line) \(.body)"' \
+    | while IFS= read -r js; do printf 'COMMENT %s\n' "$(printf '%s' "$js" | strip)"; done
+
+  # CodeRabbit edits its summary comment in place, so `since` matches it on
+  # every update; only report when the actionable line actually changed.
+  review="$(gh api "repos/$repo/issues/$pr/comments?since=$since" 2>/dev/null \
+    | jq -r '.[] | select(.user.login | test("coderabbit"; "i")) | .body' \
+    | grep -iE 'actionable comments|no actionable' | tail -1 | jq -Rs . | strip)"
+  if [ -n "$review" ] && [ "$review" != "${last_review:-}" ]; then
+    printf 'REVIEW %s\n' "$review"
+    last_review="$review"
+  fi
+
+  since="$now"
+
+  missing=0
+  IFS=',' read -r -a req <<< "$required"
+  for name in "${req[@]}"; do
+    printf '%s\n' "$cur" | grep -qF "$name: " || missing=1
+  done
+  if [ "$missing" -eq 0 ] && ! printf '%s\n' "$cur" | grep -qE ': pending$'; then
+    if printf '%s\n' "$cur" | grep -qE ': (fail|cancel)'; then echo "DONE CI finished with failures"; else echo "DONE CI green"; fi
+    printf '%s\n' "$cur"
+    exit 0
+  fi
+
+  [ "$once" -eq 1 ] && exit 0
+  sleep "$interval"
+done

--- a/.claude/skills/qa-pack/SKILL.md
+++ b/.claude/skills/qa-pack/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: qa-pack
+description: Author or update a QA flow pack under qa/ for a PR, branch, or release candidate by deriving steps from the implementation, then validate and export it for Qase
+---
+
+# QA Pack
+
+Author or update a `qa/<feature-slug>/` pack for a PR, branch, or release
+candidate. This skill is a thin wrapper — the full rules live in
+`skills/desktop-qa-flows/SKILL.md`; read that file, don't duplicate it.
+
+## Read fully first
+
+- `skills/desktop-qa-flows/SKILL.md` — the canonical workflow and coverage
+  rules this skill executes.
+- `qa/README.md` — pack structure, flow file rules, results format.
+- `qa/AGENTS.md` — schema, validation, and safety rules for everything
+  under `qa/`.
+- `qa/flow-template.md` — required frontmatter and body sections.
+- One existing pack in full, e.g. `qa/telephony-deeplink/` (`README.md`,
+  a flow under `flows/`, `test-links.html` if present) — match its shape.
+- `qa/scripts/validate-flows.mjs` and `qa/scripts/export-qase-csv.mjs`
+  headers — both take a single `qa/<pack>` path argument.
+
+## Arguments
+
+- `<base> <head>` — comparison range. Defaults: base `dev`, head the
+  current branch (`git branch --show-current`).
+- Or a PR number — resolve its base/head via `gh pr view <number> --json
+baseRefName,headRefName`.
+
+## Steps
+
+### 1. Lock the comparison range
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git diff --stat <base>...<head>
+git log <base>..<head> --oneline
+```
+
+Record base branch, head branch/commit, and whether the full requested
+range is in scope for this pass — per `desktop-qa-flows` rule 1. State
+this explicitly; do not claim full QA on a partial range.
+
+### 2. Inspect the changed implementation
+
+Read every changed file relevant to user-visible behavior from the diff
+in step 1: React components, Fuselage icons, i18n labels
+(`src/i18n/en.i18n.json`), menu definitions, modal buttons, platform
+guards, tests, docs, installer/packaging config, helper pages. Do not
+guess where UI lives or what a label says — read it.
+
+### 3. Classify changed surfaces by user-visible risk
+
+Use the risk list from `AGENTS.md` QA Flow Authoring section: Electron
+main process, protocol handlers, OS default handlers, settings UI,
+menus, modals, packaging/installers, startup, shortcuts, workspace
+routing, i18n, layout. For each risky surface, write a falsifiable
+hypothesis (user action, expected behavior, failure mode, platform,
+proof needed).
+
+### 4. Decide update-existing vs new pack
+
+Compare each hypothesis against existing `qa/**/flows/*.md`. Update an
+existing flow if it already covers the same hypothesis; add a new flow
+file to an existing pack if the pack already owns that feature area;
+create a new `qa/<feature-slug>/` pack only when the risk doesn't belong
+in any existing pack. Follow `desktop-qa-flows` rules 5–7 exactly.
+
+### 5. Write the pack
+
+Follow `qa/flow-template.md` frontmatter and body sections exactly
+(`## Review Basis`, `## Steps` table, `## Evidence`, `## Failure
+Signals`). Derive every `Action` cell from what you read in step 2 —
+screen region, relative position, icon shape, nearby UI, visible labels,
+confirmation state — never from memory or product intuition. New packs
+need a `README.md` (prerequisites, smoke order, evidence format, folder
+map) matching `qa/telephony-deeplink/README.md`'s shape.
+
+### 6. Validate and export
+
+```bash
+node qa/scripts/validate-flows.mjs qa/<slug>
+node qa/scripts/export-qase-csv.mjs qa/<slug>
+```
+
+Report both commands' real output verbatim. A failing `validate-flows.mjs`
+means the pack is not done — fix and re-run before reporting completion.
+
+## Output
+
+Report: comparison range used, files/flows created or updated, the risk
+classification per surface, and the two validation/export command
+outputs. Mark any surface reviewed only partially or not at all.


### PR DESCRIPTION
Adds project-shared Claude Code tooling. No application code changes.

- **Agents**: ci-failure-triage, electron-security-reviewer, postmortem-miner, release-readiness
- **Hooks** (wired in settings.json): guard-workspace-build, protect-default-branches, i18n-parity, clean-action-dist, plus small additions to auto-format and typecheck
- **Skills**: coderabbit-triage, i18n-translate, new-spec, package-smoke, pr-check, pr-watch, qa-pack

These follow the pattern established by #3192 and #3445, which added earlier automations under `.claude/`. Reviewable independently of any feature work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guided workflows for pull request checks, CI monitoring, release readiness, security reviews, postmortem searches, QA validation, packaging smoke tests, and review-thread triage.
  * Added automated checks for translation consistency, workspace builds, default-branch protection, formatting, and type-check scope.

* **Documentation**
  * Added comprehensive guidance for development workflows, testing, localization, packaging, release procedures, and project automation.

* **Safety Improvements**
  * Improved safeguards against unintended builds, commits, pushes, and out-of-project file processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->